### PR TITLE
Remove unsupported PDF doc type

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,9 +14,7 @@ build:
 sphinx:
   configuration: docs/conf.py
 
-# Optionally build your docs in additional formats such as PDF
 formats:
-  - pdf
   - epub
 
 # Specify the Python requirements file


### PR DESCRIPTION
Read-the-docs build failed because PDF isn't supported for multi-page docs: https://app.readthedocs.org/projects/giql/builds/30649494/