### PR TITLE
Pin sqlglot <30 to fix broken parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
     { name = "Conrad Bzura", email = "conradbzura@gmail.com" },
 ]
 dependencies = [
-    "sqlglot>=20.0.0",
+    "sqlglot>=20.0.0,<30",
 ]
 description = "Genomic Interval Query Language - SQL dialect for genomic range queries"
 dynamic = ["version"]
@@ -84,6 +84,6 @@ pytest = ">=7.0.0"
 pytest-cov = ">=4.0.0"
 duckdb = ">=1.4.0"
 pandas = ">=2.0.0"
-sqlglot = ">=20.0.0"
+sqlglot = ">=20.0.0,<30"
 pip = "*"
 hypothesis = ">=6.148.2,<7"


### PR DESCRIPTION
## Summary
- Pins sqlglot dependency to `>=20.0.0,<30` in both project and pixi dependencies
- sqlglot 30.x introduced breaking changes to the expression class hierarchy (`Expr` vs `Expression` split) and `Parser.expression()` API that cause GIQL's custom spatial operator parsing to fail

## Test plan
- [x] Verify `giql` installs with sqlglot <30
- [x] Run existing test suite against sqlglot 29.x