### PR TITLE
Upgrade to sqlglot >=30 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
     { name = "Conrad Bzura", email = "conradbzura@gmail.com" },
 ]
 dependencies = [
-    "sqlglot>=20.0.0",
+    "sqlglot>=30.0.0",
 ]
 description = "Genomic Interval Query Language - SQL dialect for genomic range queries"
 dynamic = ["version"]
@@ -84,6 +84,6 @@ pytest = ">=7.0.0"
 pytest-cov = ">=4.0.0"
 duckdb = ">=1.4.0"
 pandas = ">=2.0.0"
-sqlglot = ">=20.0.0"
+sqlglot = ">=30.0.0"
 pip = "*"
 hypothesis = ">=6.148.2,<7"

--- a/src/giql/dialect.py
+++ b/src/giql/dialect.py
@@ -118,13 +118,14 @@ class GIQLDialect(Dialect):
                 self._match_r_paren()
 
                 return self.expression(
-                    SpatialSetPredicate,
-                    this=left,
-                    operator=operator,
-                    quantifier=quantifier,
-                    ranges=ranges,
+                    SpatialSetPredicate(
+                        this=left,
+                        operator=operator,
+                        quantifier=quantifier,
+                        ranges=ranges,
+                    )
                 )
             else:
                 # Simple spatial predicate
                 right = self._parse_term()
-                return self.expression(expr_class, this=left, expression=right)
+                return self.expression(expr_class(this=left, expression=right))

--- a/src/giql/expressions.py
+++ b/src/giql/expressions.py
@@ -24,7 +24,7 @@ class GenomicRange(exp.Expression):
     }
 
 
-class SpatialPredicate(exp.Binary):
+class SpatialPredicate(exp.Expression, exp.Binary):
     """Base class for spatial predicates."""
 
     pass
@@ -88,7 +88,7 @@ def _split_named_and_positional(args):
     return kwargs, positional_args
 
 
-class GIQLCluster(exp.Func):
+class GIQLCluster(exp.Expression, exp.Func):
     """CLUSTER window function for assigning cluster IDs to overlapping intervals.
 
     Implicitly partitions by chromosome and orders by start position.
@@ -116,7 +116,7 @@ class GIQLCluster(exp.Func):
         return cls(**kwargs)
 
 
-class GIQLMerge(exp.Func):
+class GIQLMerge(exp.Expression, exp.Func):
     """MERGE aggregate function for combining overlapping intervals.
 
     Merges overlapping or bookended intervals into single intervals.
@@ -144,7 +144,7 @@ class GIQLMerge(exp.Func):
         return cls(**kwargs)
 
 
-class GIQLDistance(exp.Func):
+class GIQLDistance(exp.Expression, exp.Func):
     """DISTANCE function for calculating genomic distances between intervals.
 
     Generates SQL CASE expression that computes distance between two genomic
@@ -175,7 +175,7 @@ class GIQLDistance(exp.Func):
         return cls(**kwargs)
 
 
-class GIQLNearest(exp.Func):
+class GIQLNearest(exp.Expression, exp.Func):
     """NEAREST function for finding k-nearest genomic features.
 
     Generates SQL for k-nearest neighbor queries using LATERAL joins


### PR DESCRIPTION
## Summary
- Adapts GIQL's custom expression classes to sqlglot 30.x's new class hierarchy (`Expr` vs `Expression` split)
- Updates `Parser.expression()` calls in the dialect to pass pre-constructed instances (new API)
- Pins sqlglot `>=30.0.0`

### Details
sqlglot 30.x made `Expr` a base trait where `_set_parent` raises `NotImplementedError`. Concrete classes must inherit from both `Expression` (which implements `_set_parent`, `__init__`, etc.) and their trait class (`Binary`, `Func`). This mirrors how sqlglot's own classes are defined (e.g., `class Add(Expression, Binary)`).

Affected classes: `SpatialPredicate`, `GIQLCluster`, `GIQLMerge`, `GIQLDistance`, `GIQLNearest`.

## Test plan
- [x] All 151 existing tests pass against sqlglot 30.0.3