### PR TITLE
Integrate knowledge graph context into SDLC skills with local understand-chat skill — Closes #81

### DIFF
--- a/llms/README.md
+++ b/llms/README.md
@@ -22,6 +22,7 @@ llms/
 │   ├── implement.md     ← /implement — implement a planned PR or issue
 │   ├── test.md          ← /test — generate test specifications
 │   ├── commit.md        ← /commit — stage and commit changes atomically
+│   ├── understand-chat.md ← /understand-chat — query the knowledge graph
 │   └── audit.md         ← /audit — post-skill compliance checker
 ├── test-guides/
 │   └── python.md        ← Python testing conventions
@@ -39,6 +40,8 @@ The typical development flow follows this sequence:
 4. **`/test`** — Generate test specifications covering public APIs of new or changed modules.
 5. **`/commit`** — Stage and commit changes in disciplined, atomic commits grouped by logical kind.
 6. **`/pr` (update)** — Update the draft PR description and mark it ready for review.
+
+Each pipeline skill optionally gathers **knowledge graph context** when `.understand-anything/knowledge-graph.json` is present. The graph provides architectural metadata — component relationships, layer assignments, and dependency structures — that enriches issue scoping, implementation planning, test coverage decisions, commit grouping, and PR descriptions. When no graph exists, the step is skipped silently and the skill continues as before. The standalone `/understand-chat` skill provides interactive graph querying outside the pipeline.
 
 **`/audit`** is a cross-cutting quality gate. It can be invoked after any skill (`/audit commit`, `/audit implement`, etc.) to spawn a fresh subagent that independently checks whether the skill's requirements were met.
 
@@ -124,6 +127,7 @@ sequenceDiagram
 | [implement.md](skills/implement.md) | `/implement <number>` | Resolve a PR or issue number to a draft PR, check out the branch, and enter plan mode to design and execute the implementation. |
 | [test.md](skills/test.md) | `/test` | Generate comprehensive Given-When-Then test specifications for source modules, targeting 100% coverage of public APIs. |
 | [commit.md](skills/commit.md) | `/commit` | Analyse the working tree diff, group changes by logical kind, and create disciplined atomic commits with conventional-commit messages. |
+| [understand-chat.md](skills/understand-chat.md) | `/understand-chat <query>` | Query the project knowledge graph to understand codebase architecture, components, and relationships. Standalone utility, not part of the SDLC pipeline. |
 | [audit.md](skills/audit.md) | `/audit <skill>` | Spawn an independent subagent to evaluate whether a skill's MUST/SHALL requirements were met, using binary checklist decomposition. |
 
 ### Test guides

--- a/llms/skills/commit.md
+++ b/llms/skills/commit.md
@@ -28,10 +28,11 @@ This skill is part of the development workflow pipeline: `/issue` → `/implemen
 1. Verify git state
 2. Create a staging branch
 3. Analyze the full diff
-4. Plan the commits
-5. Stage and commit sequentially
-6. Review and present
-7. Prompt the user to move onto the PR step
+4. Gather knowledge graph context
+5. Plan the commits
+6. Stage and commit sequentially
+7. Review and present
+8. Prompt the user to move onto the PR step
 
 ### 1. Verify git state
 
@@ -74,7 +75,24 @@ The diff MUST be read carefully. For each changed file, note:
 
 A commit plan MUST be built before touching anything. The goal is a sequence of commits where each one represents exactly one logical change.
 
-### 4. Plan the commits
+### 4. Gather knowledge graph context
+
+Check whether a knowledge graph is available:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+- **If the graph exists** — query it for architectural context relevant to the changed files:
+  1. Read the `"project"` section (first ~25 lines) for project metadata.
+  2. For each changed file path from the diff analyzed in step 3, search the graph by `"filePath"` field to find its node. Also search `"name"` and `"summary"` fields for the module names of changed files.
+  3. For each matched node ID, search the `"edges"` section to find connected nodes (imports, calls, depends_on) — this gives the 1-hop neighborhood and reveals which modules are logically related.
+  4. Search `"layers"` to identify which architectural layers the matched nodes belong to.
+  5. Carry the matched nodes, edges, and layer context forward as supplementary context for commit planning. The layer and dependency information helps write more informative commit messages. Do NOT present this raw context to the user.
+
+- **If the graph does not exist** — skip this step silently and continue. The skill MUST NOT prompt the user to generate a graph.
+
+### 5. Plan the commits
 
 Group files and hunks into commits. The categories to use as a guide:
 
@@ -93,7 +111,7 @@ Mixed changes in a single file are common and MUST be handled with partial stagi
 
 Logical ordering MUST be considered: if commit B depends on commit A, A comes first. Generally: refactoring before feature work, build changes before code that uses them, tests after (or alongside) the code they test.
 
-### 5. Stage and commit sequentially
+### 6. Stage and commit sequentially
 
 For each planned commit, stage exactly the right changes and commit.
 
@@ -139,7 +157,7 @@ git commit -F /tmp/commit_msg.txt
 
 Repeat for each planned commit.
 
-### 6. Review and present
+### 7. Review and present
 
 After all commits:
 
@@ -161,7 +179,7 @@ Or if they prefer to review as a PR first, they can push the staging branch and 
 
 ---
 
-### 7. Prompt the user to move onto the PR step
+### 8. Prompt the user to move onto the PR step
 
 The user MUST be prompted with the next pipeline step: "Ready to create the PR? Run `/pr <number>` to review the changes and open a draft pull request." DO NOT proceed on your own.
 

--- a/llms/skills/implement.md
+++ b/llms/skills/implement.md
@@ -33,9 +33,10 @@ An issue number MUST be provided as the sole argument (e.g., `/implement 103`).
 4. Generate branch name and create branch
 5. Assign the issue
 6. Gather context
-7. Enter plan mode
-8. Execute after approval
-9. Prompt the user to move onto the test or commit step
+7. Gather knowledge graph context
+8. Enter plan mode
+9. Execute after approval
+10. Prompt the user to move onto the test or commit step
 
 ### 1. Resolve target repository
 
@@ -127,7 +128,27 @@ Before entering plan mode, read enough of the codebase to plan confidently:
 - Read the project test guide (`@llm/guides/testguide-python.md`) to internalize testing conventions.
 - Read project-level instructions (`CLAUDE.md`) for build tooling, documentation style, and architecture context.
 
-### 7. Enter plan mode
+### 7. Gather knowledge graph context
+
+Check whether a knowledge graph is available:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+- **If the graph exists** — query it for architectural context relevant to this implementation:
+  1. Read the `"project"` section (first ~25 lines) for project metadata.
+  2. Extract keywords from the issue title and body (fetched in step 2) and search the graph for matching nodes:
+     - Grep `"name"` and `"summary"` fields for keyword matches.
+     - Grep `"tags"` arrays for topic matches.
+     - Note the `id` values of all matching nodes.
+  3. For each matched node ID, search the `"edges"` section to find connected nodes (imports, calls, depends_on) — this gives the 1-hop neighborhood.
+  4. Search `"layers"` to identify which architectural layers the matched nodes belong to.
+  5. Carry the matched nodes, edges, and layer context forward as supplementary context for planning. Do NOT present this raw context to the user.
+
+- **If the graph does not exist** — skip this step silently and continue. The skill MUST NOT prompt the user to generate a graph.
+
+### 8. Enter plan mode
 
 Call `EnterPlanMode` to begin the planning phase. The execution plan:
 
@@ -136,11 +157,11 @@ Call `EnterPlanMode` to begin the planning phase. The execution plan:
 - MUST follow the testing conventions in the project test guide (`@llm/guides/testguide-python.md`). Test case IDs (e.g., WC-001, VP-001) MUST NOT be assigned — the docstring provides sufficient traceability without the maintenance burden of cross-PR ID schemes.
 - MUST include a verification section with the exact command(s) to run the test suite (see the project test guide for the runner command).
 
-### 8. Execute after approval
+### 9. Execute after approval
 
 Once the user approves the plan, implement each step sequentially.
 
-### 9. Prompt the user to move onto the test or commit step
+### 10. Prompt the user to move onto the test or commit step
 
 The user MUST be prompted with the next pipeline step: "Ready to generate tests? Run `/test <number>` to analyze coverage and write tests. Or ready to commit? Run `/commit` to stage and commit the changes." DO NOT proceed on your own.
 

--- a/llms/skills/issue.md
+++ b/llms/skills/issue.md
@@ -23,13 +23,14 @@ This skill is part of the development workflow pipeline: `/issue` → `/implemen
 
 1. Determine the source
 2. Resolve target repository
-3. Draft interactively
-4. Suggest labels
-5. Show draft for approval
-6. Push the issue
-7. Clean up `.issue.md` (if applicable)
-8. Return the issue URL
-9. Prompt the user to move onto the implement step
+3. Gather knowledge graph context
+4. Draft interactively
+5. Suggest labels
+6. Show draft for approval
+7. Push the issue
+8. Clean up `.issue.md` (if applicable)
+9. Return the issue URL
+10. Prompt the user to move onto the implement step
 
 ### 1. Determine the source
 
@@ -54,7 +55,27 @@ If `isFork` is `true`, extract `parent.owner.login` and `parent.name` to form th
 
 All `gh` commands in subsequent steps that reference issues or PRs MUST include `--repo <target>` when the target repo differs from the current repo.
 
-### 3. Draft interactively
+### 3. Gather knowledge graph context
+
+Check whether a knowledge graph is available:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+- **If the graph exists** — query it for architectural context relevant to this issue:
+  1. Read the `"project"` section (first ~25 lines) for project metadata.
+  2. Extract keywords from the user's issue description (or `.issue.md` content if sourced from file) and search the graph for matching nodes:
+     - Grep `"name"` and `"summary"` fields for keyword matches.
+     - Grep `"tags"` arrays for topic matches.
+     - Note the `id` values of all matching nodes.
+  3. For each matched node ID, search the `"edges"` section to find connected nodes (imports, calls, depends_on) — this gives the 1-hop neighborhood.
+  4. Search `"layers"` to identify which architectural layers the matched nodes belong to.
+  5. Carry the matched nodes, edges, and layer context forward as supplementary context for drafting. Do NOT present this raw context to the user.
+
+- **If the graph does not exist** — skip this step silently and continue. The skill MUST NOT prompt the user to generate a graph.
+
+### 4. Draft interactively
 
 Based on conversation context, determine the issue type and draft using the matching template. All templates share the same structure — only the field names and auto-label differ.
 
@@ -176,7 +197,7 @@ When the project defines a GitHub issue form template in `.github/ISSUE_TEMPLATE
 
 The draft MUST be shown to the user and iterated until they approve.
 
-### 4. Suggest labels
+### 5. Suggest labels
 
 The issue content MUST be analyzed and one or more labels suggested from the repository's label set:
 
@@ -193,11 +214,11 @@ Each label SHOULD only be applied when the issue's **primary focus** matches tha
 
 The suggested labels MUST be shown alongside the draft for user approval.
 
-### 5. Show draft for approval
+### 6. Show draft for approval
 
 The full issue (title, body, labels) MUST be presented to the user. The issue MUST NOT be pushed until the user explicitly approves.
 
-### 6. Push the issue
+### 7. Push the issue
 
 A heredoc MUST be used for the body to avoid shell escaping issues:
 
@@ -210,7 +231,7 @@ EOF
 
 The `--repo <target>` flag MUST be included when the target repo differs from the current repo (as resolved in step 2). The `--assignee` flag MUST NOT be used — issues are not auto-assigned.
 
-### 7. Clean up `.issue.md`
+### 8. Clean up `.issue.md`
 
 If the issue was created from `.issue.md`, the user MUST be asked whether to delete the file now that the issue has been pushed. If they agree:
 
@@ -218,12 +239,12 @@ If the issue was created from `.issue.md`, the user MUST be asked whether to del
 rm .issue.md
 ```
 
-### 8. Return the issue URL
+### 9. Return the issue URL
 
 The issue URL returned by `gh issue create` MUST be printed so the user can access it directly.
 
 The user SHOULD be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to create a branch and start planning."
 
-### 9. Prompt the user to move onto the implement step
+### 10. Prompt the user to move onto the implement step
 
 The user MUST be prompted with the next pipeline step: "Ready to implement? Run `/implement <number>` to create a branch and start planning." When working from a fork, note that `<number>` refers to the issue on the upstream repo. DO NOT proceed on your own.

--- a/llms/skills/pr.md
+++ b/llms/skills/pr.md
@@ -28,10 +28,11 @@ An issue number MUST be provided as the sole argument (e.g., `/pr 103`). The iss
 1. Resolve target repository
 2. Identify the issue and branch
 3. Review the branch diff
-4. Draft the PR description
-5. Show draft for approval
-6. Push and create the draft PR
-7. Return the PR URL
+4. Gather knowledge graph context
+5. Draft the PR description
+6. Show draft for approval
+7. Push and create the draft PR
+8. Return the PR URL
 
 ### 1. Resolve target repository
 
@@ -85,7 +86,24 @@ git diff <merge-base>..HEAD --stat
 
 Analyze all committed source and test changes. Understand what was implemented, what was refactored, what tests were added or modified.
 
-### 4. Draft the PR description
+### 4. Gather knowledge graph context
+
+Check whether a knowledge graph is available:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+- **If the graph exists** — query it for architectural context relevant to the branch changes:
+  1. Read the `"project"` section (first ~25 lines) for project metadata.
+  2. For each changed file path from the diff reviewed in step 3, search the graph by `"filePath"` field to find its node. Also search `"name"` and `"summary"` fields for the module names of changed files.
+  3. For each matched node ID, search the `"edges"` section to find connected nodes (imports, calls, depends_on) — this gives the 1-hop neighborhood and reveals cross-module impact.
+  4. Search `"layers"` to identify which architectural layers the matched nodes belong to.
+  5. Carry the matched nodes, edges, and layer context forward as supplementary context for drafting the PR description. The layer and dependency information helps write a more accurate summary and proposed-changes section. Do NOT present this raw context to the user.
+
+- **If the graph does not exist** — skip this step silently and continue. The skill MUST NOT prompt the user to generate a graph.
+
+### 5. Draft the PR description
 
 The PR title MUST match the associated issue title exactly with ` — Closes #<number>` appended to the end.
 
@@ -107,11 +125,11 @@ The PR description MUST contain a **Summary** and **Proposed changes** section. 
 
 The first word of every plain-language table entry MUST be capitalized. Table entries MUST NOT end with punctuation (no trailing periods, commas, etc.). Code spans in entries (e.g., `` `foo.bar()` is called ``) are exempt from the capitalization rule.
 
-### 5. Show draft for approval
+### 6. Show draft for approval
 
 The full PR (title, body, branch name) MUST be presented to the user. The PR MUST NOT be created until the user explicitly approves.
 
-### 6. Push and create the draft PR
+### 7. Push and create the draft PR
 
 Push the branch if not already pushed:
 
@@ -155,7 +173,7 @@ EOF
 
 The `--repo <target>` flag MUST be included when the target repo differs from the current repo.
 
-### 7. Return the PR URL
+### 8. Return the PR URL
 
 The PR URL MUST be printed so the user can access it directly.
 

--- a/llms/skills/test.md
+++ b/llms/skills/test.md
@@ -36,11 +36,12 @@ An issue number MUST be provided as the sole argument (e.g., `/test 103`).
 
 1. Resolve issue, PR, and branch
 2. Analyze code changes
-3. Evaluate existing tests
-4. Generate test plan
-5. Enter plan mode
-6. Implement tests after approval
-7. Prompt the user to move onto the commit step
+3. Gather knowledge graph context
+4. Evaluate existing tests
+5. Generate test plan
+6. Enter plan mode
+7. Implement tests after approval
+8. Prompt the user to move onto the commit step
 
 ### 1. Resolve issue, PR, and branch
 
@@ -80,7 +81,24 @@ git diff <merge-base>..HEAD
 
 Read every changed source file to understand what was implemented. Note which modules have new or modified public APIs.
 
-### 3. Evaluate existing tests
+### 3. Gather knowledge graph context
+
+Check whether a knowledge graph is available:
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+- **If the graph exists** — query it for architectural context relevant to the changed files:
+  1. Read the `"project"` section (first ~25 lines) for project metadata.
+  2. For each changed file path identified in step 2, search the graph by `"filePath"` field to find its node. Also search `"name"` and `"summary"` fields for the module names of changed files.
+  3. For each matched node ID, search the `"edges"` section to find connected nodes (imports, calls, depends_on, tested_by) — this gives the 1-hop neighborhood and reveals testing relationships.
+  4. Search `"layers"` to identify which architectural layers the matched nodes belong to.
+  5. Carry the matched nodes, edges, and layer context forward as supplementary context for test evaluation and planning. Do NOT present this raw context to the user.
+
+- **If the graph does not exist** — skip this step silently and continue. The skill MUST NOT prompt the user to generate a graph.
+
+### 4. Evaluate existing tests
 
 Read the current test files for all affected modules. For each existing test:
 
@@ -89,7 +107,7 @@ Read the current test files for all affected modules. For each existing test:
 - Identify tests that **no longer apply** due to removed or significantly changed functionality — flag these for removal or rewriting.
 - Note gaps that require **new** test cases.
 
-### 4. Generate test plan
+### 5. Generate test plan
 
 Generate a Given-When-Then test plan internally. This plan is an agent planning artifact — do NOT write spec files to disk. The plan MUST:
 
@@ -98,7 +116,7 @@ Generate a Given-When-Then test plan internally. This plan is an agent planning 
 - Follow the structure in [Table Format](#table-format) below.
 - Follow the project test guide conventions.
 
-### 5. Enter plan mode
+### 6. Enter plan mode
 
 Call `EnterPlanMode` to present the test plan to the user for approval. The plan MUST clearly distinguish between:
 
@@ -107,7 +125,7 @@ Call `EnterPlanMode` to present the test plan to the user for approval. The plan
 - **Existing tests to remove** — no longer apply due to removed or changed functionality
 - **New tests to add** — cover genuinely uncovered behavior
 
-### 6. Implement tests after approval
+### 7. Implement tests after approval
 
 Once the user approves the plan, implement the test files:
 
@@ -115,7 +133,7 @@ Once the user approves the plan, implement the test files:
 - Add new test cases where the plan identifies coverage gaps.
 - Follow the project test guide for file naming, class organization, and test conventions.
 
-### 7. Prompt the user to move onto the commit step
+### 8. Prompt the user to move onto the commit step
 
 The user MUST be prompted with the next pipeline step: "Ready to commit? Run `/commit` to stage and commit the changes." DO NOT proceed on your own.
 

--- a/llms/skills/understand-chat.md
+++ b/llms/skills/understand-chat.md
@@ -1,0 +1,97 @@
+---
+name: understand-chat
+description: >
+  Ask questions about the codebase using the knowledge graph. Use this skill
+  whenever the user says "/understand-chat <query>", "ask about the code",
+  "what does X do", or similar. Requires a knowledge graph at
+  .understand-anything/knowledge-graph.json (run /understand to generate one).
+argument-hint: "[query]"
+---
+
+The key words MUST, MUST NOT, SHALL, SHALL NOT, SHOULD, SHOULD NOT, REQUIRED, RECOMMENDED, MAY, and OPTIONAL in this document are to be interpreted as described in RFC 2119.
+
+# Understand-Chat Skill
+
+Answer questions about this codebase using the knowledge graph at `.understand-anything/knowledge-graph.json`.
+
+## Pipeline Context
+
+This skill is a **standalone utility** — it is not part of the SDLC pipeline sequence (`/issue` → `/implement` → `/test` → `/commit` → `/pr`). It can be invoked at any time to query the knowledge graph for architectural context, component relationships, or dependency chains.
+
+## Arguments
+
+A query string MUST be provided as the argument (e.g., `/understand-chat how does transpilation work`).
+
+## Graph Structure Reference
+
+The knowledge graph JSON has this structure:
+
+- `project` — `{name, description, languages, frameworks, analyzedAt, gitCommitHash}`
+- `nodes[]` — each has `{id, type, name, filePath, summary, tags[], complexity, languageNotes?}`
+  - Node types: `file`, `function`, `class`, `module`, `concept`, `config`, `resource`, `pipeline`
+  - ID conventions: `file:path`, `function:path:name`, `class:path:name`
+- `edges[]` — each has `{source, target, type, direction, weight}`
+  - Key edge types: `imports`, `contains`, `calls`, `depends_on`, `tested_by`, `configures`, `extends`
+- `layers[]` — each has `{id, name, description, nodeIds[]}`
+- `tour[]` — each has `{order, title, description, nodeIds[]}`
+
+## How to Read Efficiently
+
+1. Use Grep to search within the JSON for relevant entries BEFORE reading the full file.
+2. Only read sections you need — do NOT load the entire graph into context.
+3. Node `name` and `summary` fields are the most useful for understanding.
+4. Edges tell you how components connect — follow `imports` and `calls` for dependency chains.
+
+## Workflow
+
+### TL;DR
+
+1. Verify graph exists
+2. Read project metadata
+3. Search for relevant nodes
+4. Find connected edges
+5. Read layer context
+6. Answer the query
+
+### 1. Verify graph exists
+
+```bash
+test -f .understand-anything/knowledge-graph.json && echo "exists" || echo "missing"
+```
+
+If the graph does not exist, inform the user and suggest running `/understand` to generate one. MUST NOT proceed without a graph.
+
+### 2. Read project metadata
+
+Read the `"project"` section (first ~25 lines) from the top of the knowledge graph file for high-level context — project name, description, languages, and frameworks.
+
+### 3. Search for relevant nodes
+
+Search the knowledge graph file for nodes matching the user's query keywords:
+
+- Grep `"name"` fields for keyword matches.
+- Grep `"summary"` fields for semantic matches.
+- Grep `"tags"` arrays for topic matches.
+- Note the `id` values of all matching nodes.
+
+### 4. Find connected edges
+
+For each matched node ID, grep for that ID in the `edges` section to find:
+
+- What it imports or depends on (downstream dependencies).
+- What calls or imports it (upstream dependents).
+
+This gives the 1-hop subgraph around the query.
+
+### 5. Read layer context
+
+Grep for `"layers"` to understand which architectural layers the matched nodes belong to. Layer assignments reveal whether matched components are in the core domain, infrastructure, testing, or other architectural tiers.
+
+### 6. Answer the query
+
+Using only the relevant subgraph, answer the user's query:
+
+- Reference specific files, functions, and relationships from the graph.
+- Explain which layer(s) are relevant and why.
+- Be concise but thorough — link concepts to actual code locations.
+- If the query does not match any nodes, say so and suggest related terms from the graph.


### PR DESCRIPTION
## Summary

Internalize the understand-chat skill definition into `llms/skills/` and add a knowledge graph context gathering step to each of the five SDLC pipeline skills (issue, implement, test, commit, pr). When `.understand-anything/knowledge-graph.json` exists, each skill queries it for architectural metadata — component relationships, layer assignments, and dependency structures — before planning or drafting. When no graph is present, the step is skipped silently with no behavior change.

Closes #81

## Proposed changes

### Internalized understand-chat skill

Add `llms/skills/understand-chat.md` as a standalone utility skill for interactive knowledge graph querying. Adapt the external Understand-Anything plugin's skill definition to match the project's conventions: YAML frontmatter, RFC 2119 key words, numbered workflow steps, and a graph structure reference section documenting node types, edge types, layers, and tours. Register the skill via `.claude/skills/understand-chat/SKILL.md` symlink.

### Knowledge graph context step in SDLC skills

Insert a "Gather knowledge graph context" step into each skill at the point where enough information exists to form a query but before planning or analysis begins:

- **issue** (step 3) — extract keywords from the user's description or `.issue.md` content
- **implement** (step 7) — extract keywords from the issue title and body
- **test** (step 3) — search by changed file paths from the diff
- **commit** (step 4) — search by changed file paths from the diff
- **pr** (step 4) — search by changed file paths and module names from the branch diff

Each step follows a consistent template: check for graph existence, read project metadata, grep for matching nodes by name/summary/tags/filePath, follow edges for the 1-hop neighborhood, read layer assignments, and carry the context forward silently.

### README update

Add the understand-chat skill to the directory layout and skill reference table. Add a paragraph to the pipeline overview explaining optional knowledge graph context gathering across all pipeline skills.