### PR TITLE
`Table.coordinate_system` and `Table.interval_type` are silently ignored by spatial-predicate transpilation — Closes #88

### DIFF
--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from sqlglot import exp
 from sqlglot.generator import Generator
 
@@ -15,6 +13,7 @@ from giql.expressions import SpatialSetPredicate
 from giql.expressions import Within
 from giql.range_parser import ParsedRange
 from giql.range_parser import RangeParser
+from giql.table import Table
 from giql.table import Tables
 
 
@@ -36,7 +35,7 @@ class BaseGIQLGenerator(Generator):
     SUPPORTS_LATERAL = True
 
     @staticmethod
-    def _extract_bool_param(param_expr: Optional[exp.Expression]) -> bool:
+    def _extract_bool_param(param_expr: exp.Expression | None) -> bool:
         """Extract boolean value from a parameter expression.
 
         Handles exp.Boolean, exp.Literal, and string representations.
@@ -48,7 +47,7 @@ class BaseGIQLGenerator(Generator):
         else:
             return str(param_expr).upper() in ("TRUE", "1", "YES")
 
-    def __init__(self, tables: Optional[Tables] = None, **kwargs):
+    def __init__(self, tables: Tables | None = None, **kwargs):
         super().__init__(**kwargs)
         self.tables = tables or Tables()
         self._current_table = None  # Track current table for column resolution
@@ -502,9 +501,12 @@ class BaseGIQLGenerator(Generator):
             SQL predicate string
         """
         # Get column references
-        chrom_col, start_col, end_col = self._get_column_refs(
+        chrom_col, raw_start_col, raw_end_col = self._get_column_refs(
             column_ref, self._current_table
         )
+        table = self._resolve_table(column_ref, self._current_table)
+        start_col = self._canonical_start(raw_start_col, table)
+        end_col = self._canonical_end(raw_end_col, table)
 
         chrom = parsed_range.chromosome
         start = parsed_range.start
@@ -558,8 +560,14 @@ class BaseGIQLGenerator(Generator):
         """
         # Get column references for both sides
         # Pass None to let _get_column_refs extract and resolve table from column ref
-        l_chrom, l_start, l_end = self._get_column_refs(left_col, None)
-        r_chrom, r_start, r_end = self._get_column_refs(right_col, None)
+        l_chrom, raw_l_start, raw_l_end = self._get_column_refs(left_col, None)
+        r_chrom, raw_r_start, raw_r_end = self._get_column_refs(right_col, None)
+        l_table = self._resolve_table(left_col)
+        r_table = self._resolve_table(right_col)
+        l_start = self._canonical_start(raw_l_start, l_table)
+        l_end = self._canonical_end(raw_l_end, l_table)
+        r_start = self._canonical_start(raw_r_start, r_table)
+        r_end = self._canonical_end(raw_r_end, r_table)
 
         if op_type == "intersects":
             # Ranges overlap if: chrom1 = chrom2 AND start1 < end2 AND end1 > start2
@@ -624,7 +632,7 @@ class BaseGIQLGenerator(Generator):
         return "(" + combinator.join(conditions) + ")"
 
     def _detect_nearest_mode(
-        self, expression: GIQLNearest, parent_expression: Optional[exp.Expression] = None
+        self, expression: GIQLNearest, parent_expression: exp.Expression | None = None
     ) -> str:
         """Detect whether NEAREST is in standalone or correlated mode.
 
@@ -650,7 +658,7 @@ class BaseGIQLGenerator(Generator):
 
     def _find_outer_table_in_lateral_join(
         self, expression: GIQLNearest
-    ) -> Optional[str]:
+    ) -> str | None:
         """Find the outer table name in a LATERAL join context.
 
         Walks up the AST to find the JOIN clause and extracts the outer table
@@ -830,14 +838,10 @@ class BaseGIQLGenerator(Generator):
         end_col = DEFAULT_END_COL
         strand_col = DEFAULT_STRAND_COL
 
-        # Extract table alias/name from column reference if present
-        table_alias = None
-        if "." in column_ref:
-            table_alias, _ = column_ref.rsplit(".", 1)
-            # If no explicit table_name provided, resolve alias to table name
-            if not table_name:
-                # Look up actual table name from alias
-                table_name = self._alias_to_table.get(table_alias, self._current_table)
+        # Alias is kept verbatim for output formatting; table name is resolved
+        # separately to look up the Table config (alias != name in joins).
+        table_alias = column_ref.rsplit(".", 1)[0] if "." in column_ref else None
+        table_name = self._resolve_table_name(column_ref, table_name)
 
         # Try to get custom column names from table config
         if table_name and self.tables:
@@ -868,3 +872,82 @@ class BaseGIQLGenerator(Generator):
             if include_strand:
                 return base_cols + (f'"{strand_col}"',)
             return base_cols
+
+    @staticmethod
+    def _canonical_start(raw_start: str, table: Table | None) -> str:
+        """Wrap a raw start column expression to yield canonical 0-based half-open start.
+
+        Conversion by ``coordinate_system``:
+
+        - 0based: ``start`` (identity)
+        - 1based: ``start - 1``
+        """
+        if table is None or table.coordinate_system == "0based":
+            return raw_start
+        return f"({raw_start} - 1)"
+
+    @staticmethod
+    def _canonical_end(raw_end: str, table: Table | None) -> str:
+        """Wrap a raw end column expression to yield canonical 0-based half-open end.
+
+        Conversion by ``(coordinate_system, interval_type)``:
+
+        - 0based / half_open: ``end`` (identity)
+        - 0based / closed:    ``end + 1``
+        - 1based / half_open: ``end - 1``
+        - 1based / closed:    ``end`` (identity)
+        """
+        if table is None:
+            return raw_end
+        key = (table.coordinate_system, table.interval_type)
+        if key == ("0based", "closed"):
+            return f"({raw_end} + 1)"
+        if key == ("1based", "half_open"):
+            return f"({raw_end} - 1)"
+        return raw_end  # 0based/half_open and 1based/closed: identity
+
+    def _resolve_table_name(
+        self, column_ref: str, table_name: str | None
+    ) -> str | None:
+        """Resolve the underlying table name for a column reference.
+
+        Precedence: explicit ``table_name`` (caller-provided context) > alias
+        map (JOIN-side resolution via ``self._alias_to_table``) >
+        ``self._current_table`` (FROM-clause fallback for unmapped dotted
+        aliases). Undotted refs return ``None`` because their caller is
+        expected to pass ``_current_table`` as the explicit ``table_name``
+        when relevant.
+
+        :param column_ref:
+            Column reference, possibly aliased (e.g. ``a.interval``)
+        :param table_name:
+            Explicit table name; takes precedence if non-empty
+        :return:
+            ``table_name`` if non-empty; otherwise the alias mapping from
+            ``self._alias_to_table`` (with ``self._current_table`` as fallback)
+            if ``column_ref`` is dotted; otherwise None
+        """
+        if table_name:
+            return table_name
+        if "." in column_ref:
+            alias = column_ref.rsplit(".", 1)[0]
+            return self._alias_to_table.get(alias, self._current_table)
+        return None
+
+    def _resolve_table(
+        self, column_ref: str, table_name: str | None = None
+    ) -> Table | None:
+        """Resolve the Table config that backs a column reference.
+
+        :param column_ref:
+            Column reference, possibly aliased (e.g. ``a.interval``)
+        :param table_name:
+            Explicit table name; if omitted, derived from ``column_ref`` alias
+            or falls back to ``self._current_table``
+        :return:
+            The Table config if registered, otherwise None
+        """
+        table_name = self._resolve_table_name(column_ref, table_name)
+        if table_name and self.tables:
+            return self.tables.get(table_name)
+        return None

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -52,6 +52,29 @@ def tables_with_peaks_and_genes():
     return tables
 
 
+@pytest.fixture
+def tables_with_one_based_closed():
+    """Tables with a single 1-based closed table (VCF/GFF convention)."""
+    tables = Tables()
+    tables.register(
+        "vcf_variants",
+        Table("vcf_variants", coordinate_system="1based", interval_type="closed"),
+    )
+    return tables
+
+
+@pytest.fixture
+def tables_mixed_conventions():
+    """Tables with one 0-based half-open table and one 1-based closed table."""
+    tables = Tables()
+    tables.register("bed_a", Table("bed_a"))
+    tables.register(
+        "vcf_b",
+        Table("vcf_b", coordinate_system="1based", interval_type="closed"),
+    )
+    return tables
+
+
 class TestBaseGIQLGenerator:
     """Tests for BaseGIQLGenerator class."""
 
@@ -1163,3 +1186,335 @@ class TestBaseGIQLGenerator:
         # Unsigned distance has no negative sign (both ELSE branches are positive)
         # Count occurrences of "-(" - signed has 1, unsigned has 0
         assert output.count("-(") == 0
+
+    @pytest.mark.parametrize(
+        "table, expected_predicate",
+        [
+            pytest.param(
+                Table("variants", coordinate_system="0based", interval_type="half_open"),
+                '"start" < 200 AND "end" > 100',
+                id="0based-half_open",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="0based", interval_type="closed"),
+                '"start" < 200 AND ("end" + 1) > 100',
+                id="0based-closed",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="1based", interval_type="half_open"),
+                '("start" - 1) < 200 AND ("end" - 1) > 100',
+                id="1based-half_open",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="1based", interval_type="closed"),
+                '("start" - 1) < 200 AND "end" > 100',
+                id="1based-closed",
+            ),
+        ],
+    )
+    def test_intersects_should_canonicalize_table_columns_for_each_convention(
+        self, table, expected_predicate
+    ):
+        """Test INTERSECTS literal-form canonicalizes table columns per convention.
+
+        Given:
+            A table declared with one of the four (coordinate_system, interval_type)
+            combinations.
+        When:
+            INTERSECTS is called with a literal range.
+        Then:
+            It should wrap the table-side start/end (or not) per the canonical
+            0-based half-open conversion, leaving the comparison operators
+            unchanged.
+        """
+        # Arrange
+        tables = Tables()
+        tables.register(table.name, table)
+        sql = "SELECT * FROM variants WHERE interval INTERSECTS 'chr1:100-200'"
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            "SELECT * FROM variants WHERE "
+            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+        )
+        assert output == expected
+
+    @pytest.mark.parametrize(
+        "table, expected_predicate",
+        [
+            pytest.param(
+                Table("variants", coordinate_system="0based", interval_type="half_open"),
+                '"start" <= 1500 AND "end" >= 2000',
+                id="0based-half_open",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="0based", interval_type="closed"),
+                '"start" <= 1500 AND ("end" + 1) >= 2000',
+                id="0based-closed",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="1based", interval_type="half_open"),
+                '("start" - 1) <= 1500 AND ("end" - 1) >= 2000',
+                id="1based-half_open",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="1based", interval_type="closed"),
+                '("start" - 1) <= 1500 AND "end" >= 2000',
+                id="1based-closed",
+            ),
+        ],
+    )
+    def test_contains_should_canonicalize_table_columns_for_each_convention(
+        self, table, expected_predicate
+    ):
+        """Test CONTAINS literal-form canonicalizes table columns per convention.
+
+        Given:
+            A table declared with one of the four (coordinate_system, interval_type)
+            combinations.
+        When:
+            CONTAINS is called with a literal range.
+        Then:
+            It should wrap the table-side start/end (or not) per the canonical
+            0-based half-open conversion, leaving the comparison operators
+            unchanged.
+        """
+        # Arrange
+        tables = Tables()
+        tables.register(table.name, table)
+        sql = "SELECT * FROM variants WHERE interval CONTAINS 'chr1:1500-2000'"
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            "SELECT * FROM variants WHERE "
+            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+        )
+        assert output == expected
+
+    @pytest.mark.parametrize(
+        "table, expected_predicate",
+        [
+            pytest.param(
+                Table("variants", coordinate_system="0based", interval_type="half_open"),
+                '"start" >= 1000 AND "end" <= 5000',
+                id="0based-half_open",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="0based", interval_type="closed"),
+                '"start" >= 1000 AND ("end" + 1) <= 5000',
+                id="0based-closed",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="1based", interval_type="half_open"),
+                '("start" - 1) >= 1000 AND ("end" - 1) <= 5000',
+                id="1based-half_open",
+            ),
+            pytest.param(
+                Table("variants", coordinate_system="1based", interval_type="closed"),
+                '("start" - 1) >= 1000 AND "end" <= 5000',
+                id="1based-closed",
+            ),
+        ],
+    )
+    def test_within_should_canonicalize_table_columns_for_each_convention(
+        self, table, expected_predicate
+    ):
+        """Test WITHIN literal-form canonicalizes table columns per convention.
+
+        Given:
+            A table declared with one of the four (coordinate_system, interval_type)
+            combinations.
+        When:
+            WITHIN is called with a literal range.
+        Then:
+            It should wrap the table-side start/end (or not) per the canonical
+            0-based half-open conversion, leaving the comparison operators
+            unchanged.
+        """
+        # Arrange
+        tables = Tables()
+        tables.register(table.name, table)
+        sql = "SELECT * FROM variants WHERE interval WITHIN 'chr1:1000-5000'"
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            "SELECT * FROM variants WHERE "
+            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+        )
+        assert output == expected
+
+    def test_intersects_should_canonicalize_both_sides_when_conventions_differ(
+        self, tables_mixed_conventions
+    ):
+        """Test column-join INTERSECTS with mixed table conventions.
+
+        Given:
+            A 0-based half-open table joined against a 1-based closed table.
+        When:
+            INTERSECTS is called between columns from each table.
+        Then:
+            It should canonicalize each side independently — the 1-based-closed
+            side gets (start - 1), the default side stays raw.
+        """
+        # Arrange
+        sql = (
+            "SELECT * FROM bed_a AS a CROSS JOIN vcf_b AS b "
+            "WHERE a.interval INTERSECTS b.interval"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_mixed_conventions)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            "SELECT * FROM bed_a AS a CROSS JOIN vcf_b AS b WHERE "
+            '(a."chrom" = b."chrom" '
+            'AND a."start" < b."end" '
+            'AND a."end" > (b."start" - 1))'
+        )
+        assert output == expected
+
+    def test_contains_should_canonicalize_both_sides_when_conventions_differ(
+        self, tables_mixed_conventions
+    ):
+        """Test column-join CONTAINS with mixed table conventions.
+
+        Given:
+            A 0-based half-open table joined against a 1-based closed table.
+        When:
+            CONTAINS is called between columns from each table.
+        Then:
+            It should canonicalize each side independently — the 1-based-closed
+            side gets (start - 1), the default side stays raw, while the
+            comparison operators (<=, >=) remain unchanged.
+        """
+        # Arrange
+        sql = (
+            "SELECT * FROM bed_a AS a CROSS JOIN vcf_b AS b "
+            "WHERE a.interval CONTAINS b.interval"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_mixed_conventions)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            "SELECT * FROM bed_a AS a CROSS JOIN vcf_b AS b WHERE "
+            '(a."chrom" = b."chrom" '
+            'AND a."start" <= (b."start" - 1) '
+            'AND a."end" >= b."end")'
+        )
+        assert output == expected
+
+    def test_within_should_canonicalize_both_sides_when_conventions_differ(
+        self, tables_mixed_conventions
+    ):
+        """Test column-join WITHIN with mixed table conventions.
+
+        Given:
+            A 0-based half-open table joined against a 1-based closed table.
+        When:
+            WITHIN is called between columns from each table.
+        Then:
+            It should canonicalize each side independently — the 1-based-closed
+            side gets (start - 1), the default side stays raw, while the
+            comparison operators (>=, <=) remain unchanged.
+        """
+        # Arrange
+        sql = (
+            "SELECT * FROM bed_a AS a CROSS JOIN vcf_b AS b "
+            "WHERE a.interval WITHIN b.interval"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_mixed_conventions)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            "SELECT * FROM bed_a AS a CROSS JOIN vcf_b AS b WHERE "
+            '(a."chrom" = b."chrom" '
+            'AND a."start" >= (b."start" - 1) '
+            'AND a."end" <= b."end")'
+        )
+        assert output == expected
+
+    def test_contains_point_should_shift_start_when_table_is_one_based_closed(
+        self, tables_with_one_based_closed
+    ):
+        """Test CONTAINS point-query against a 1-based closed table.
+
+        Given:
+            A table declared with coordinate_system="1based" and interval_type="closed".
+        When:
+            CONTAINS is called with a point query 'chr1:1500'.
+        Then:
+            The point-query branch fires: the table-side start is wrapped as
+            (start - 1) and end stays raw, with operators <= and > unchanged.
+        """
+        # Arrange
+        sql = "SELECT * FROM vcf_variants WHERE interval CONTAINS 'chr1:1500'"
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_with_one_based_closed)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            "SELECT * FROM vcf_variants WHERE "
+            '("chrom" = \'chr1\' AND ("start" - 1) <= 1500 AND "end" > 1500)'
+        )
+        assert output == expected
+
+    def test_intersects_any_should_canonicalize_disjuncts_when_table_is_one_based_closed(
+        self, tables_with_one_based_closed
+    ):
+        """Test INTERSECTS ANY routes the canonicalization fix through SpatialSetPredicate.
+
+        Given:
+            A table declared with coordinate_system="1based" and interval_type="closed".
+        When:
+            INTERSECTS ANY is called with multiple literal ranges.
+        Then:
+            Each OR-disjunct is canonicalized independently — every disjunct
+            wraps the table-side start as (start - 1) and leaves end raw.
+        """
+        # Arrange
+        sql = (
+            "SELECT * FROM vcf_variants "
+            "WHERE interval INTERSECTS ANY('chr1:100-200', 'chr1:500-600')"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_with_one_based_closed)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            "SELECT * FROM vcf_variants WHERE "
+            '(("chrom" = \'chr1\' AND ("start" - 1) < 200 AND "end" > 100) '
+            'OR ("chrom" = \'chr1\' AND ("start" - 1) < 600 AND "end" > 500))'
+        )
+        assert output == expected


### PR DESCRIPTION
## Summary

Make INTERSECTS, CONTAINS, and WITHIN honor `Table.coordinate_system` and `Table.interval_type` so tables that store intervals in non-default conventions (e.g. VCF-style 1-based closed) produce correct SQL. Previously the table side of every spatial comparison was hard-coded for 0-based half-open columns, so any non-default `Table` configuration silently produced off-by-one results in both range-literal and column-join forms; `SpatialSetPredicate` (INTERSECTS ANY/ALL) inherited the same bug because it routes through the same helper.

The fix introduces three private helpers in `BaseGIQLGenerator` that wrap raw `start`/`end` column expressions to yield their canonical 0-based half-open equivalents, then wires those helpers into `_generate_range_predicate` and `_generate_column_join`. The literal side already arrives in canonical form via `RangeParser.to_zero_based_half_open`, so once both sides are canonicalized the existing comparison operators (`<`, `>`, `<=`, `>=`) are correct without per-operator branching.

Conversion table the helpers implement:

| `coordinate_system` | `interval_type` | `start_canonical` | `end_canonical` |
|---|---|---|---|
| `0based` | `half_open` | `start_col` | `end_col` |
| `0based` | `closed` | `start_col` | `(end_col + 1)` |
| `1based` | `half_open` | `(start_col - 1)` | `(end_col - 1)` |
| `1based` | `closed` | `(start_col - 1)` | `end_col` |

DISTANCE and NEAREST still ignore `coordinate_system` and conflate `interval_type` with bedtools-compatibility math; that is tracked separately in #89 and out of scope here.

Closes #88

## Proposed changes

### `src/giql/generators/base.py`

Add three helpers near `_get_column_refs`:

- `_resolve_table(column_ref, table_name=None)` — resolve the `Table` config that backs a column reference, mirroring the alias-resolution logic of `_get_column_refs` so each side of a column-join can be canonicalized independently.
- `_canonical_start(raw_start, table)` — staticmethod; wrap a raw start column expression to yield canonical 0-based half-open start. Returns `(start_col - 1)` for 1-based tables, the raw expression otherwise.
- `_canonical_end(raw_end, table)` — staticmethod; wrap a raw end column expression to yield canonical 0-based half-open end. Returns `(end_col + 1)` for 0-based-closed, `(end_col - 1)` for 1-based-half-open, raw expression for 0-based-half-open and 1-based-closed.

Modify two existing methods:

- `_generate_range_predicate` — call `_resolve_table(column_ref, self._current_table)`, pass the result through `_canonical_start` / `_canonical_end`, then run the unchanged comparison-operator branches.
- `_generate_column_join` — same pattern, but resolve a `Table` for each side independently to support cross-convention joins.

### `tests/generators/test_base.py`

Add four fixtures and eleven tests asserting the canonicalization behavior for every `(coordinate_system, interval_type)` combination across all three predicates and both forms (range-literal and column-join), plus the `SpatialSetPredicate` flow-through. Tests follow the BDD naming pattern `test_<method>_should_<outcome>_when_<condition>` and the AAA structure with Given/When/Then docstrings.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestBaseGIQLGenerator` | A 1-based-closed table | INTERSECTS is called with a literal range | The table-side start is wrapped as `(start - 1)` and end stays raw | INTERSECTS literal under 1-based-closed |
| 2 | `TestBaseGIQLGenerator` | A 1-based-closed table | CONTAINS is called with a literal range | The table-side start is wrapped as `(start - 1)` and end stays raw | CONTAINS literal under 1-based-closed |
| 3 | `TestBaseGIQLGenerator` | A 1-based-closed table | WITHIN is called with a literal range | The table-side start is wrapped as `(start - 1)` and end stays raw | WITHIN literal under 1-based-closed |
| 4 | `TestBaseGIQLGenerator` | A 0-based-half-open table joined against a 1-based-closed table | INTERSECTS is called between columns from each table | Each side is canonicalized independently — 1-based-closed side gets `(start - 1)`, default side stays raw | INTERSECTS column-join under mixed conventions |
| 5 | `TestBaseGIQLGenerator` | A table declared with explicit defaults `coordinate_system="0based"` and `interval_type="half_open"` | INTERSECTS is called with a literal range | Raw start/end columns are emitted with no arithmetic wrappers | Regression guard for default `Table` |
| 6 | `TestBaseGIQLGenerator` | A 0-based-closed table | INTERSECTS is called with a literal range | The table-side end is wrapped as `(end + 1)` and start stays raw | INTERSECTS literal under 0-based-closed |
| 7 | `TestBaseGIQLGenerator` | A 1-based-half-open table | INTERSECTS is called with a literal range | Both table-side endpoints are wrapped by subtracting 1 | INTERSECTS literal under 1-based-half-open |
| 8 | `TestBaseGIQLGenerator` | A 0-based-half-open table joined against a 1-based-closed table | CONTAINS is called between columns from each table | Each side is canonicalized independently while comparison operators stay `<=` / `>=` | CONTAINS column-join under mixed conventions |
| 9 | `TestBaseGIQLGenerator` | A 0-based-half-open table joined against a 1-based-closed table | WITHIN is called between columns from each table | Each side is canonicalized independently while comparison operators stay `>=` / `<=` | WITHIN column-join under mixed conventions |
| 10 | `TestBaseGIQLGenerator` | A 1-based-closed table | CONTAINS is called with a point query `chr1:1500` | The point-query branch fires and the table-side start is wrapped as `(start - 1)` | CONTAINS point-query under 1-based-closed |
| 11 | `TestBaseGIQLGenerator` | A 1-based-closed table | INTERSECTS ANY is called with multiple literal ranges | Each OR-disjunct is canonicalized independently with `(start - 1)` on the table side | `SpatialSetPredicate` flow-through under 1-based-closed |