### PR TITLE
Honor `Table.coordinate_system` and decouple bedtools-compat from `interval_type` in DISTANCE / NEAREST — Closes #89

### DIFF
--- a/docs/transpilation/index.rst
+++ b/docs/transpilation/index.rst
@@ -101,6 +101,18 @@ Each GIQL operator expands to specific SQL patterns.
              ELSE 0
          END
 
+DISTANCE and NEAREST canonicalize each table's ``start``/``end`` to 0-based
+half-open at SQL-emit time based on its ``coordinate_system`` and
+``interval_type``, so logically-equivalent intervals stored in different
+conventions yield the same numeric distance.
+
+.. versionchanged:: 0.4
+   The implicit bedtools-style ``+1`` gap counting that DISTANCE and NEAREST
+   previously applied to tables declared with ``interval_type="closed"`` has
+   been removed. Closed-interval tables now produce the same canonical
+   distances as half-open tables. Callers that need the legacy ``+1``
+   semantics must add it explicitly in the consuming query.
+
 **Intersection joins** expand to inequality joins:
 
 .. tab-set::

--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -158,6 +158,8 @@ class BaseGIQLGenerator(Generator):
         is_stranded = self._extract_bool_param(expression.args.get("stranded"))
         is_signed = self._extract_bool_param(expression.args.get("signed"))
 
+        target_table = self.tables.get(table_name) if self.tables else None
+
         # Resolve strand columns if stranded mode
         ref_strand = None
         target_strand = None
@@ -193,19 +195,16 @@ class BaseGIQLGenerator(Generator):
                         ref_strand = f'{outer_table}."{table.strand_col}"'
 
             # Get strand column for target table
-            target_table = self.tables.get(table_name) if self.tables else None
             if target_table and target_table.strand_col:
                 target_strand = f'{table_name}."{target_table.strand_col}"'
 
-        # Determine if we should add 1 for gap distances (bedtools compatibility)
-        # This depends on the interval types of the tables involved
-        add_one = False
-        if self.tables:
-            target_table = self.tables.get(table_name)
-            if target_table:
-                # Add 1 for closed intervals (bedtools behavior)
-                if target_table.interval_type == "closed":
-                    add_one = True
+        # Distance math below assumes 0-based half-open.
+        target_start_expr = self._canonical_start(
+            f'{table_name}."{target_start}"', target_table
+        )
+        target_end_expr = self._canonical_end(
+            f'{table_name}."{target_end}"', target_table
+        )
 
         # Build distance calculation using CASE expression
         # For NEAREST: ORDER BY absolute distance, but RETURN signed distance
@@ -215,11 +214,10 @@ class BaseGIQLGenerator(Generator):
             ref_end,
             ref_strand,
             f'{table_name}."{target_chrom}"',
-            f'{table_name}."{target_start}"',
-            f'{table_name}."{target_end}"',
+            target_start_expr,
+            target_end_expr,
             target_strand,
             stranded=is_stranded,
-            add_one_for_gap=add_one,
             signed=is_signed,
         )
 
@@ -322,26 +320,13 @@ class BaseGIQLGenerator(Generator):
             # Literal range - not implemented yet
             raise ValueError("Literal range as second argument not yet supported")
 
-        # Determine if we should add 1 for gap distances (bedtools compatibility)
-        # Check interval types from table config
-        add_one = False
-        if self.tables:
-            # Extract table names from column references
-            # Column refs look like "table.column" or "alias.column"
-            table_a = interval_a_sql.split(".")[0] if "." in interval_a_sql else None
-            table_b = interval_b_sql.split(".")[0] if "." in interval_b_sql else None
-
-            # Check if either table uses closed intervals
-            for tbl_name in [table_a, table_b]:
-                if tbl_name:
-                    # Remove quotes if present
-                    tbl_name = tbl_name.strip('"')
-                    # Check if it's an alias first
-                    actual_table = self._alias_to_table.get(tbl_name, tbl_name)
-                    table = self.tables.get(actual_table)
-                    if table and table.interval_type == "closed":
-                        add_one = True
-                        break
+        # Distance math below assumes 0-based half-open.
+        table_a = self._resolve_table(interval_a_sql)
+        table_b = self._resolve_table(interval_b_sql)
+        start_a = self._canonical_start(start_a, table_a)
+        end_a = self._canonical_end(end_a, table_a)
+        start_b = self._canonical_start(start_b, table_b)
+        end_b = self._canonical_end(end_b, table_b)
 
         # Generate CASE expression
         return self._generate_distance_case(
@@ -354,7 +339,6 @@ class BaseGIQLGenerator(Generator):
             end_b,
             strand_b,
             stranded=stranded,
-            add_one_for_gap=add_one,
             signed=signed,
         )
 
@@ -369,7 +353,6 @@ class BaseGIQLGenerator(Generator):
         end_b: str,
         strand_b: str | None,
         stranded: bool = False,
-        add_one_for_gap: bool = False,
         signed: bool = False,
     ) -> str:
         """Generate SQL CASE expression for distance calculation.
@@ -392,17 +375,12 @@ class BaseGIQLGenerator(Generator):
             Strand column for interval B (None if not stranded)
         :param stranded:
             Whether to use strand-aware distance calculation
-        :param add_one_for_gap:
-            Whether to add 1 to non-overlapping distance (bedtools compatibility)
         :param signed:
             Whether to return signed distance (negative for upstream, positive for
             downstream)
         :return:
             SQL CASE expression
         """
-        # Distance adjustment for non-overlapping intervals
-        gap_adj = " + 1" if add_one_for_gap else ""
-
         if not stranded or strand_a is None or strand_b is None:
             # Basic distance calculation without strand awareness
             if signed:
@@ -411,15 +389,15 @@ class BaseGIQLGenerator(Generator):
                 return (
                     f"CASE WHEN {chrom_a} != {chrom_b} THEN NULL "
                     f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
-                    f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a}{gap_adj}) "
-                    f"ELSE -({start_a} - {end_b}{gap_adj}) END"
+                    f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a}) "
+                    f"ELSE -({start_a} - {end_b}) END"
                 )
             # Unsigned (absolute) distance
             return (
                 f"CASE WHEN {chrom_a} != {chrom_b} THEN NULL "
                 f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
-                f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a}{gap_adj}) "
-                f"ELSE ({start_a} - {end_b}{gap_adj}) END"
+                f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a}) "
+                f"ELSE ({start_a} - {end_b}) END"
             )
 
         # Stranded distance calculation
@@ -434,11 +412,11 @@ class BaseGIQLGenerator(Generator):
                 f"WHEN {strand_b} = '.' OR {strand_b} = '?' THEN NULL "
                 f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
                 f"WHEN {end_a} <= {start_b} THEN "
-                f"CASE WHEN {strand_a} = '-' THEN -({start_b} - {end_a}{gap_adj}) "
-                f"ELSE ({start_b} - {end_a}{gap_adj}) END "
+                f"CASE WHEN {strand_a} = '-' THEN -({start_b} - {end_a}) "
+                f"ELSE ({start_b} - {end_a}) END "
                 f"ELSE "
-                f"CASE WHEN {strand_a} = '-' THEN ({start_a} - {end_b}{gap_adj}) "
-                f"ELSE -({start_a} - {end_b}{gap_adj}) END END"
+                f"CASE WHEN {strand_a} = '-' THEN ({start_a} - {end_b}) "
+                f"ELSE -({start_a} - {end_b}) END END"
             )
         # Stranded but not signed: apply strand flip only
         return (
@@ -448,11 +426,11 @@ class BaseGIQLGenerator(Generator):
             f"WHEN {strand_b} = '.' OR {strand_b} = '?' THEN NULL "
             f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
             f"WHEN {end_a} <= {start_b} THEN "
-            f"CASE WHEN {strand_a} = '-' THEN -({start_b} - {end_a}{gap_adj}) "
-            f"ELSE ({start_b} - {end_a}{gap_adj}) END "
+            f"CASE WHEN {strand_a} = '-' THEN -({start_b} - {end_a}) "
+            f"ELSE ({start_b} - {end_a}) END "
             f"ELSE "
-            f"CASE WHEN {strand_a} = '-' THEN -({start_a} - {end_b}{gap_adj}) "
-            f"ELSE ({start_a} - {end_b}{gap_adj}) END END"
+            f"CASE WHEN {strand_a} = '-' THEN -({start_a} - {end_b}) "
+            f"ELSE ({start_a} - {end_b}) END END"
         )
 
     def _generate_spatial_op(self, expression: exp.Binary, op_type: str) -> str:
@@ -716,6 +694,9 @@ class BaseGIQLGenerator(Generator):
         :return:
             Tuple of (chromosome, start, end) or (chromosome, start, end, strand)
             Returns SQL expressions (column refs for correlated, literals for standalone)
+            Endpoints are canonicalized to 0-based half-open: literal references via
+            ``RangeParser.to_zero_based_half_open``, column references via
+            ``_canonical_start`` / ``_canonical_end``.
         :raises ValueError:
             If reference is missing in standalone mode or invalid format
         """
@@ -748,14 +729,18 @@ class BaseGIQLGenerator(Generator):
                         f"{range_str}. Error: {e}"
                     )
             else:
-                # Column reference - resolve via _get_column_refs
-                return self._get_column_refs(reference_sql, None)
+                # Column reference - resolve and canonicalize
+                chrom, start, end = self._get_column_refs(reference_sql, None)
+                ref_table = self._resolve_table(reference_sql)
+                return self._canonical_endpoints(chrom, start, end, ref_table)
 
         else:  # correlated mode
             if reference:
                 # Explicit reference in correlated mode (e.g., peaks.interval)
                 reference_sql = self.sql(reference)
-                return self._get_column_refs(reference_sql, None)
+                chrom, start, end = self._get_column_refs(reference_sql, None)
+                ref_table = self._resolve_table(reference_sql)
+                return self._canonical_endpoints(chrom, start, end, ref_table)
             else:
                 # Implicit reference - resolve from outer table in LATERAL join
                 outer_table = self._find_outer_table_in_lateral_join(expression)
@@ -778,7 +763,8 @@ class BaseGIQLGenerator(Generator):
 
                 # Build column references using the outer table and genomic column
                 reference_sql = f"{outer_table}.{table.genomic_col}"
-                return self._get_column_refs(reference_sql, None)
+                chrom, start, end = self._get_column_refs(reference_sql, None)
+                return self._canonical_endpoints(chrom, start, end, table)
 
     def _resolve_target_table(
         self, expression: GIQLNearest
@@ -905,6 +891,24 @@ class BaseGIQLGenerator(Generator):
         if key == ("1based", "half_open"):
             return f"({raw_end} - 1)"
         return raw_end  # 0based/half_open and 1based/closed: identity
+
+    @staticmethod
+    def _canonical_endpoints(
+        chrom: str,
+        raw_start: str,
+        raw_end: str,
+        table: Table | None,
+    ) -> tuple[str, str, str]:
+        """Canonicalize a ``(chrom, start, end)`` triple to 0-based half-open.
+
+        The chromosome expression passes through unchanged; start and end are
+        wrapped via ``_canonical_start`` / ``_canonical_end``.
+        """
+        return (
+            chrom,
+            BaseGIQLGenerator._canonical_start(raw_start, table),
+            BaseGIQLGenerator._canonical_end(raw_end, table),
+        )
 
     def _resolve_table_name(
         self, column_ref: str, table_name: str | None

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -769,33 +769,82 @@ class TestBaseGIQLGenerator:
         )
         assert output == expected
 
-    def test_giqldistance_with_closed_intervals(self, tables_with_closed_intervals):
+    def test_giqldistance_should_apply_gap_plus_one_when_bedtools_compat_is_set(
+        self, tables_with_closed_intervals
+    ):
+        """Test DISTANCE applies the bedtools "+1" gap adjustment when opted-in.
+
+        Given:
+            Two 0-based closed-interval tables and DISTANCE called with
+            bedtools_compat := true.
+        When:
+            giqldistance_sql is called.
+        Then:
+            It should canonicalize each table-side end as (end + 1) and add
+            the bedtools-compat "+1" to the gap branches.
         """
-        GIVEN intervals from table with CLOSED interval type
-        WHEN Distance calculation is performed
-        THEN Distance includes +1 adjustment (bedtools compatibility).
-        """
-        # Add a second table with closed intervals for distance calculation
+        # Arrange
         tables_with_closed_intervals.register(
             "bed_features_b", Table("bed_features_b", interval_type="closed")
         )
+        sql = (
+            "SELECT DISTANCE(a.interval, b.interval, bedtools_compat := true) as dist "
+            "FROM bed_features a CROSS JOIN bed_features_b b"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_with_closed_intervals)
 
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
+            'WHEN a."start" < (b."end" + 1) '
+            'AND (a."end" + 1) > b."start" THEN 0 '
+            'WHEN (a."end" + 1) <= b."start" '
+            'THEN (b."start" - (a."end" + 1) + 1) '
+            'ELSE (a."start" - (b."end" + 1) + 1) END AS dist '
+            "FROM bed_features AS a CROSS JOIN bed_features_b AS b"
+        )
+        assert output == expected
+
+    def test_giqldistance_should_not_apply_gap_plus_one_when_bedtools_compat_is_unset(
+        self, tables_with_closed_intervals
+    ):
+        """Test DISTANCE on closed-interval tables omits "+1" gap counting by default.
+
+        Given:
+            Two 0-based closed-interval tables and DISTANCE called without a
+            bedtools_compat argument.
+        When:
+            giqldistance_sql is called.
+        Then:
+            It should canonicalize each table-side end as (end + 1) but omit
+            any bedtools-compat "+1" from the gap branches.
+        """
+        # Arrange
+        tables_with_closed_intervals.register(
+            "bed_features_b", Table("bed_features_b", interval_type="closed")
+        )
         sql = (
             "SELECT DISTANCE(a.interval, b.interval) as dist "
             "FROM bed_features a CROSS JOIN bed_features_b b"
         )
         ast = parse_one(sql, dialect=GIQLDialect)
-
         generator = BaseGIQLGenerator(tables=tables_with_closed_intervals)
+
+        # Act
         output = generator.generate(ast)
 
+        # Assert
         expected = (
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
-            'WHEN a."start" < b."end" '
-            'AND a."end" > b."start" THEN 0 '
-            'WHEN a."end" <= b."start" '
-            'THEN (b."start" - a."end" + 1) '
-            'ELSE (a."start" - b."end" + 1) END AS dist '
+            'WHEN a."start" < (b."end" + 1) '
+            'AND (a."end" + 1) > b."start" THEN 0 '
+            'WHEN (a."end" + 1) <= b."start" '
+            'THEN (b."start" - (a."end" + 1)) '
+            'ELSE (a."start" - (b."end" + 1)) END AS dist '
             "FROM bed_features AS a CROSS JOIN bed_features_b AS b"
         )
         assert output == expected
@@ -889,25 +938,39 @@ class TestBaseGIQLGenerator:
         assert 'peaks."strand"' in output
         assert 'genes."strand"' in output
 
-    def test_giqlnearest_sql_closed_intervals(self):
+    def test_giqlnearest_should_apply_gap_plus_one_when_bedtools_compat_is_set(self):
+        """Test NEAREST applies the bedtools "+1" gap adjustment when opted-in.
+
+        Given:
+            A 0-based closed-interval target table and NEAREST called with
+            bedtools_compat := true.
+        When:
+            giqlnearest_sql is called.
+        Then:
+            It should add the bedtools "+1" to the gap branches of the
+            distance CASE expression.
         """
-        GIVEN a GIQLNearest with target table using CLOSED interval type
-        WHEN giqlnearest_sql is called
-        THEN Distance calculation includes +1 adjustment for bedtools compatibility.
-        """
+        # Arrange
         tables = Tables()
         tables.register("genes_closed", Table("genes_closed", interval_type="closed"))
-
         sql = (
-            "SELECT * FROM NEAREST(genes_closed, reference := 'chr1:1000-2000', k := 3)"
+            "SELECT * FROM NEAREST("
+            "genes_closed, reference := 'chr1:1000-2000', k := 3, "
+            "bedtools_compat := true)"
         )
         ast = parse_one(sql, dialect=GIQLDialect)
-
         generator = BaseGIQLGenerator(tables=tables)
+
+        # Act
         output = generator.generate(ast)
 
-        # Should have +1 adjustment for closed intervals
+        # Assert
+        # Bedtools "+1" gap adjustment present in non-overlap branches
         assert "+ 1)" in output
+        assert (
+            'genes_closed."start" - 2000 + 1' in output
+            or '1000 - (genes_closed."end" + 1) + 1' in output
+        )
 
     def test_giqldistance_sql_literal_first_arg_error(self, tables_with_two_tables):
         """
@@ -1518,3 +1581,214 @@ class TestBaseGIQLGenerator:
             'OR ("chrom" = \'chr1\' AND ("start" - 1) < 600 AND "end" > 500))'
         )
         assert output == expected
+
+    @pytest.mark.parametrize(
+        "coordinate_system, interval_type, start_a, end_a, start_b, end_b",
+        [
+            pytest.param(
+                "0based", "half_open",
+                'a."start"', 'a."end"', 'b."start"', 'b."end"',
+                id="0based-half_open",
+            ),
+            pytest.param(
+                "0based", "closed",
+                'a."start"', '(a."end" + 1)', 'b."start"', '(b."end" + 1)',
+                id="0based-closed",
+            ),
+            pytest.param(
+                "1based", "half_open",
+                '(a."start" - 1)', '(a."end" - 1)',
+                '(b."start" - 1)', '(b."end" - 1)',
+                id="1based-half_open",
+            ),
+            pytest.param(
+                "1based", "closed",
+                '(a."start" - 1)', 'a."end"', '(b."start" - 1)', 'b."end"',
+                id="1based-closed",
+            ),
+        ],
+    )
+    def test_giqldistance_should_canonicalize_table_columns_for_each_convention(
+        self, coordinate_system, interval_type, start_a, end_a, start_b, end_b
+    ):
+        """Test DISTANCE canonicalizes both table columns per convention.
+
+        Given:
+            Two tables sharing one of the four (coordinate_system, interval_type)
+            combinations.
+        When:
+            DISTANCE is called between aliased columns from each table.
+        Then:
+            It should wrap each side's start/end (or not) per the canonical
+            0-based half-open conversion, leaving the comparison and gap
+            formulas otherwise unchanged.
+        """
+        # Arrange
+        tables = Tables()
+        tables.register(
+            "dist_a",
+            Table(
+                "dist_a",
+                coordinate_system=coordinate_system,
+                interval_type=interval_type,
+            ),
+        )
+        tables.register(
+            "dist_b",
+            Table(
+                "dist_b",
+                coordinate_system=coordinate_system,
+                interval_type=interval_type,
+            ),
+        )
+        sql = (
+            "SELECT DISTANCE(a.interval, b.interval) as dist "
+            "FROM dist_a a CROSS JOIN dist_b b"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
+            f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
+            f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a}) "
+            f"ELSE ({start_a} - {end_b}) END AS dist "
+            "FROM dist_a AS a CROSS JOIN dist_b AS b"
+        )
+        assert output == expected
+
+    def test_giqldistance_should_canonicalize_each_side_when_conventions_differ(
+        self, tables_mixed_conventions
+    ):
+        """Test DISTANCE canonicalizes each side independently with mixed conventions.
+
+        Given:
+            A 0-based half-open table (bed_a) joined against a 1-based closed
+            table (vcf_b).
+        When:
+            DISTANCE is called between aliased columns from each table.
+        Then:
+            It should leave bed_a's start/end raw and wrap vcf_b's start as
+            (start - 1) while leaving vcf_b's end raw.
+        """
+        # Arrange
+        sql = (
+            "SELECT DISTANCE(a.interval, b.interval) as dist "
+            "FROM bed_a a CROSS JOIN vcf_b b"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_mixed_conventions)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert
+        expected = (
+            'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
+            'WHEN a."start" < b."end" AND a."end" > (b."start" - 1) THEN 0 '
+            'WHEN a."end" <= (b."start" - 1) '
+            'THEN ((b."start" - 1) - a."end") '
+            'ELSE (a."start" - b."end") END AS dist '
+            "FROM bed_a AS a CROSS JOIN vcf_b AS b"
+        )
+        assert output == expected
+
+    @pytest.mark.parametrize(
+        "coordinate_system, interval_type, target_start, target_end",
+        [
+            pytest.param(
+                "0based", "half_open",
+                'genes."start"', 'genes."end"',
+                id="0based-half_open",
+            ),
+            pytest.param(
+                "0based", "closed",
+                'genes."start"', '(genes."end" + 1)',
+                id="0based-closed",
+            ),
+            pytest.param(
+                "1based", "half_open",
+                '(genes."start" - 1)', '(genes."end" - 1)',
+                id="1based-half_open",
+            ),
+            pytest.param(
+                "1based", "closed",
+                '(genes."start" - 1)', 'genes."end"',
+                id="1based-closed",
+            ),
+        ],
+    )
+    def test_giqlnearest_should_canonicalize_target_columns_for_each_convention(
+        self, coordinate_system, interval_type, target_start, target_end
+    ):
+        """Test NEAREST canonicalizes target endpoints per convention.
+
+        Given:
+            A target table declared with one of the four (coordinate_system,
+            interval_type) combinations and a literal reference range.
+        When:
+            giqlnearest_sql is called.
+        Then:
+            It should wrap the target-side start/end (or not) per the
+            canonical 0-based half-open conversion in the distance CASE
+            expression.
+        """
+        # Arrange
+        tables = Tables()
+        tables.register(
+            "genes",
+            Table(
+                "genes",
+                coordinate_system=coordinate_system,
+                interval_type=interval_type,
+            ),
+        )
+        sql = "SELECT * FROM NEAREST(genes, reference := 'chr1:1000-2000', k := 1)"
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert — distance CASE expression uses canonicalized target endpoints
+        # against the (already-canonical) literal reference [1000, 2000).
+        assert (
+            f"WHEN 1000 < {target_end} AND 2000 > {target_start} THEN 0" in output
+        )
+        assert f"WHEN 2000 <= {target_start} THEN ({target_start} - 2000)" in output
+        assert f"ELSE (1000 - {target_end})" in output
+
+    def test_giqlnearest_should_canonicalize_reference_column_when_reference_is_one_based_closed(
+        self, tables_mixed_conventions
+    ):
+        """Test NEAREST canonicalizes a column-ref reference per its table's convention.
+
+        Given:
+            A 0-based half-open target table (bed_a) and an explicit
+            reference column from a 1-based closed table (vcf_b).
+        When:
+            giqlnearest_sql is called.
+        Then:
+            It should wrap the reference-side start as (start - 1), leave
+            its end raw, and leave the target side raw.
+        """
+        # Arrange
+        sql = (
+            "SELECT * FROM vcf_b b CROSS JOIN LATERAL "
+            "NEAREST(bed_a, reference := b.interval, k := 1)"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_mixed_conventions)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert — reference's start canonicalized via _canonical_start
+        assert '(b."start" - 1) < bed_a."end"' in output
+        assert 'bed_a."end" <= (b."start" - 1)' not in output  # reference is left side
+        # Reference's end stays raw (1-based closed → identity for end)
+        assert 'b."end" > bed_a."start" THEN 0' in output

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -769,59 +769,18 @@ class TestBaseGIQLGenerator:
         )
         assert output == expected
 
-    def test_giqldistance_should_apply_gap_plus_one_when_bedtools_compat_is_set(
+    def test_giqldistance_should_not_apply_gap_plus_one_for_closed_intervals(
         self, tables_with_closed_intervals
     ):
-        """Test DISTANCE applies the bedtools "+1" gap adjustment when opted-in.
+        """Test DISTANCE on closed-interval tables omits "+1" gap counting.
 
         Given:
-            Two 0-based closed-interval tables and DISTANCE called with
-            bedtools_compat := true.
-        When:
-            giqldistance_sql is called.
-        Then:
-            It should canonicalize each table-side end as (end + 1) and add
-            the bedtools-compat "+1" to the gap branches.
-        """
-        # Arrange
-        tables_with_closed_intervals.register(
-            "bed_features_b", Table("bed_features_b", interval_type="closed")
-        )
-        sql = (
-            "SELECT DISTANCE(a.interval, b.interval, bedtools_compat := true) as dist "
-            "FROM bed_features a CROSS JOIN bed_features_b b"
-        )
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator(tables=tables_with_closed_intervals)
-
-        # Act
-        output = generator.generate(ast)
-
-        # Assert
-        expected = (
-            'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
-            'WHEN a."start" < (b."end" + 1) '
-            'AND (a."end" + 1) > b."start" THEN 0 '
-            'WHEN (a."end" + 1) <= b."start" '
-            'THEN (b."start" - (a."end" + 1) + 1) '
-            'ELSE (a."start" - (b."end" + 1) + 1) END AS dist '
-            "FROM bed_features AS a CROSS JOIN bed_features_b AS b"
-        )
-        assert output == expected
-
-    def test_giqldistance_should_not_apply_gap_plus_one_when_bedtools_compat_is_unset(
-        self, tables_with_closed_intervals
-    ):
-        """Test DISTANCE on closed-interval tables omits "+1" gap counting by default.
-
-        Given:
-            Two 0-based closed-interval tables and DISTANCE called without a
-            bedtools_compat argument.
+            Two 0-based closed-interval tables and DISTANCE.
         When:
             giqldistance_sql is called.
         Then:
             It should canonicalize each table-side end as (end + 1) but omit
-            any bedtools-compat "+1" from the gap branches.
+            any "+1" from the gap branches.
         """
         # Arrange
         tables_with_closed_intervals.register(
@@ -938,25 +897,25 @@ class TestBaseGIQLGenerator:
         assert 'peaks."strand"' in output
         assert 'genes."strand"' in output
 
-    def test_giqlnearest_should_apply_gap_plus_one_when_bedtools_compat_is_set(self):
-        """Test NEAREST applies the bedtools "+1" gap adjustment when opted-in.
+    def test_giqlnearest_should_not_apply_gap_plus_one_for_closed_intervals(
+        self,
+    ):
+        """Test NEAREST on a closed-interval target omits "+1" gap counting.
 
         Given:
-            A 0-based closed-interval target table and NEAREST called with
-            bedtools_compat := true.
+            A 0-based closed-interval target table and NEAREST.
         When:
             giqlnearest_sql is called.
         Then:
-            It should add the bedtools "+1" to the gap branches of the
-            distance CASE expression.
+            It should canonicalize the target end as (target."end" + 1) but
+            omit any "+1" from the gap branches.
         """
         # Arrange
         tables = Tables()
         tables.register("genes_closed", Table("genes_closed", interval_type="closed"))
         sql = (
             "SELECT * FROM NEAREST("
-            "genes_closed, reference := 'chr1:1000-2000', k := 3, "
-            "bedtools_compat := true)"
+            "genes_closed, reference := 'chr1:1000-2000', k := 3)"
         )
         ast = parse_one(sql, dialect=GIQLDialect)
         generator = BaseGIQLGenerator(tables=tables)
@@ -964,13 +923,13 @@ class TestBaseGIQLGenerator:
         # Act
         output = generator.generate(ast)
 
-        # Assert
-        # Bedtools "+1" gap adjustment present in non-overlap branches
-        assert "+ 1)" in output
-        assert (
-            'genes_closed."start" - 2000 + 1' in output
-            or '1000 - (genes_closed."end" + 1) + 1' in output
-        )
+        # Assert — canonicalization is applied, but neither gap branch carries
+        # a trailing "+ 1".
+        assert '(genes_closed."end" + 1)' in output
+        assert 'THEN (genes_closed."start" - 2000)' in output
+        assert 'ELSE (1000 - (genes_closed."end" + 1))' in output
+        assert '(genes_closed."start" - 2000 + 1)' not in output
+        assert '(1000 - (genes_closed."end" + 1) + 1)' not in output
 
     def test_giqldistance_sql_literal_first_arg_error(self, tables_with_two_tables):
         """
@@ -1792,3 +1751,39 @@ class TestBaseGIQLGenerator:
         assert 'bed_a."end" <= (b."start" - 1)' not in output  # reference is left side
         # Reference's end stays raw (1-based closed → identity for end)
         assert 'b."end" > bed_a."start" THEN 0' in output
+
+    def test_giqlnearest_should_canonicalize_outer_table_columns_when_reference_is_implicit(
+        self, tables_mixed_conventions
+    ):
+        """Test NEAREST in correlated/implicit mode canonicalizes the outer table.
+
+        Given:
+            A 1-based closed outer table (vcf_b) and a 0-based half-open
+            target table (bed_a) joined via CROSS JOIN LATERAL with no
+            ``reference`` argument on NEAREST.
+        When:
+            giqlnearest_sql is called.
+        Then:
+            It should canonicalize the outer table's columns based on
+            vcf_b's convention — wrapping start as (vcf_b."start" - 1) and
+            leaving end raw — while leaving bed_a's target columns raw.
+        """
+        # Arrange
+        sql = (
+            "SELECT * FROM vcf_b CROSS JOIN LATERAL NEAREST(bed_a, k := 1)"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_mixed_conventions)
+
+        # Act
+        output = generator.generate(ast)
+
+        # Assert — distance CASE uses canonicalized outer-table columns and
+        # raw target-table columns.
+        assert (
+            'WHEN (vcf_b."start" - 1) < bed_a."end" '
+            'AND vcf_b."end" > bed_a."start" THEN 0'
+        ) in output
+        assert 'WHEN vcf_b."end" <= bed_a."start"' in output
+        assert 'THEN (bed_a."start" - vcf_b."end")' in output
+        assert 'ELSE ((vcf_b."start" - 1) - bed_a."end")' in output

--- a/tests/integration/coordinate_space/conftest.py
+++ b/tests/integration/coordinate_space/conftest.py
@@ -1,0 +1,46 @@
+"""Pytest fixtures for coordinate-space matrix integration tests.
+
+These tests assert convention-invariance of GIQL DISTANCE / NEAREST against
+itself via DuckDB. They do not invoke ``bedtools`` or ``pybedtools`` -- the
+comparison reference is GIQL with the canonical 0-based half-open encoding.
+"""
+
+import pytest
+
+from giql import transpile
+from giql.table import Table
+
+duckdb = pytest.importorskip("duckdb")
+
+pytestmark = pytest.mark.integration
+
+from tests.integration.bedtools.utils.duckdb_loader import (  # noqa: E402
+    load_intervals,
+)
+
+
+@pytest.fixture(scope="function")
+def duckdb_connection():
+    """Provide a clean DuckDB connection for each test."""
+    conn = duckdb.connect(":memory:")
+    yield conn
+    conn.close()
+
+
+@pytest.fixture(scope="function")
+def giql_query(duckdb_connection):
+    """Provide a helper that loads encoded intervals, transpiles, and executes.
+
+    The caller passes ``tables`` as a list of :class:`giql.table.Table`
+    objects (with ``coordinate_system`` / ``interval_type`` already set) and
+    ``**table_data`` mapping table name to a list of pre-encoded
+    ``(chrom, stored_start, stored_end, name, score, strand)`` tuples.
+    """
+
+    def _run(query: str, *, tables: list[Table], **table_data):
+        for name, rows in table_data.items():
+            load_intervals(duckdb_connection, name, rows)
+        sql = transpile(query, tables=tables)
+        return duckdb_connection.execute(sql).fetchall()
+
+    return _run

--- a/tests/integration/coordinate_space/encodings.py
+++ b/tests/integration/coordinate_space/encodings.py
@@ -1,0 +1,75 @@
+"""Encoding helpers for coordinate-space matrix integration tests.
+
+A *canonical* interval in this module is always 0-based half-open. The
+:func:`encode` helper translates a canonical ``(start, end)`` pair into the
+integer values that should be stored under each of the four
+``(coordinate_system, interval_type)`` combinations supported by GIQL.
+
+The translation is the inverse of
+:func:`giql.generators.base.BaseGIQLGenerator._canonical_start` /
+``_canonical_end``: re-encoding a canonical interval and feeding the stored
+values back through the canonicalization helpers must yield the original
+canonical values.
+"""
+
+from giql.table import Table
+
+CONVENTIONS: list[tuple[str, str]] = [
+    ("0based", "half_open"),
+    ("0based", "closed"),
+    ("1based", "half_open"),
+    ("1based", "closed"),
+]
+
+
+def encode(
+    canonical_start: int,
+    canonical_end: int,
+    coordinate_system: str,
+    interval_type: str,
+) -> tuple[int, int]:
+    """Translate a canonical 0-based half-open interval to a stored encoding.
+
+    :param canonical_start:
+        Canonical start (0-based half-open).
+    :param canonical_end:
+        Canonical end (0-based half-open).
+    :param coordinate_system:
+        Either ``"0based"`` or ``"1based"``.
+    :param interval_type:
+        Either ``"half_open"`` or ``"closed"``.
+    :return:
+        ``(stored_start, stored_end)`` for the given convention.
+    :raises ValueError:
+        If ``coordinate_system`` or ``interval_type`` is not a recognized
+        value.
+    """
+    if coordinate_system == "0based":
+        stored_start = canonical_start
+    elif coordinate_system == "1based":
+        stored_start = canonical_start + 1
+    else:
+        raise ValueError(f"Unknown coordinate_system: {coordinate_system!r}")
+
+    key = (coordinate_system, interval_type)
+    if key == ("0based", "half_open"):
+        stored_end = canonical_end
+    elif key == ("0based", "closed"):
+        stored_end = canonical_end - 1
+    elif key == ("1based", "half_open"):
+        stored_end = canonical_end + 1
+    elif key == ("1based", "closed"):
+        stored_end = canonical_end
+    else:
+        raise ValueError(f"Unknown interval_type: {interval_type!r}")
+
+    return stored_start, stored_end
+
+
+def make_table(name: str, coordinate_system: str, interval_type: str) -> Table:
+    """Build a :class:`giql.table.Table` for the given convention."""
+    return Table(
+        name,
+        coordinate_system=coordinate_system,
+        interval_type=interval_type,
+    )

--- a/tests/integration/coordinate_space/test_distance_coordinate_space.py
+++ b/tests/integration/coordinate_space/test_distance_coordinate_space.py
@@ -1,0 +1,307 @@
+"""Integration tests asserting DISTANCE is convention-invariant.
+
+For a fixed pair of canonical 0-based half-open intervals, encoding the same
+logical pair under any of the four ``(coordinate_system, interval_type)``
+combinations -- on either or both sides of the join -- must produce the same
+numeric distance through the GIQL transpiler and DuckDB.
+"""
+
+import pytest
+
+from .encodings import CONVENTIONS
+from .encodings import encode
+from .encodings import make_table
+
+pytestmark = pytest.mark.integration
+
+
+def _row(chrom: str, start: int, end: int, name: str) -> tuple:
+    """Build a 6-tuple suitable for ``load_intervals`` with strand ``+``."""
+    return (chrom, start, end, name, 100, "+")
+
+
+class TestDistanceCoordinateSpace:
+    """Convention-invariance of DISTANCE end-to-end via DuckDB."""
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_distance_returns_canonical_gap_when_both_sides_share_convention(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test DISTANCE returns 100 for a 100 bp gap in any same-convention encoding.
+
+        Given:
+            Two non-overlapping intervals (canonical [100, 200) and
+            [300, 400)) re-encoded under the same convention on both sides.
+        When:
+            DISTANCE(a.interval, b.interval) is executed.
+        Then:
+            It should return 100, matching the canonical 0-based half-open
+            gap, regardless of how the intervals are stored.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, coordinate_system, interval_type)
+        s_b, e_b = encode(300, 400, coordinate_system, interval_type)
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(100,)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_distance_returns_zero_when_intervals_overlap(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test DISTANCE returns 0 for overlapping intervals in any encoding.
+
+        Given:
+            Canonical intervals [100, 300) and [200, 400) re-encoded under
+            the same convention on both sides.
+        When:
+            DISTANCE is executed.
+        Then:
+            It should return 0 regardless of encoding.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 300, coordinate_system, interval_type)
+        s_b, e_b = encode(200, 400, coordinate_system, interval_type)
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(0,)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_distance_returns_zero_for_adjacent_half_open_boundary(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test DISTANCE returns 0 when intervals touch at the half-open boundary.
+
+        Given:
+            Canonical adjacent intervals [100, 200) and [200, 300)
+            re-encoded under the same convention on both sides.
+        When:
+            DISTANCE is executed.
+        Then:
+            It should return 0 regardless of encoding.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, coordinate_system, interval_type)
+        s_b, e_b = encode(200, 300, coordinate_system, interval_type)
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(0,)]
+
+    @pytest.mark.parametrize(
+        ("conv_a", "conv_b"),
+        [(a, b) for a in CONVENTIONS for b in CONVENTIONS],
+        ids=lambda v: str(v),
+    )
+    def test_distance_is_invariant_under_mixed_conventions(
+        self, giql_query, conv_a, conv_b
+    ):
+        """Test DISTANCE returns 100 for any pair of (convention_a, convention_b).
+
+        Given:
+            Canonical intervals [100, 200) and [300, 400) encoded in
+            convention_a on table A and convention_b on table B.
+        When:
+            DISTANCE is executed.
+        Then:
+            It should return 100 for every (convention_a, convention_b)
+            pair, demonstrating that each side is canonicalized
+            independently.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, *conv_a)
+        s_b, e_b = encode(300, 400, *conv_b)
+        tables = [
+            make_table("intervals_a", *conv_a),
+            make_table("intervals_b", *conv_b),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(100,)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_distance_returns_null_for_cross_chromosome_pair(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test DISTANCE returns NULL across chromosomes regardless of encoding.
+
+        Given:
+            Canonical [100, 200) on chr1 and [100, 200) on chr2 re-encoded
+            under the same convention on both sides.
+        When:
+            DISTANCE is executed.
+        Then:
+            It should return NULL regardless of encoding.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, coordinate_system, interval_type)
+        s_b, e_b = encode(100, 200, coordinate_system, interval_type)
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr2", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(None,)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_signed_distance_returns_positive_when_b_is_downstream(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test signed DISTANCE returns +100 when B is downstream in any encoding.
+
+        Given:
+            Canonical A=[100, 200) and B=[300, 400) re-encoded under the
+            same convention on both sides, queried with ``signed := true``.
+        When:
+            DISTANCE runs.
+        Then:
+            It should return +100 regardless of encoding.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, coordinate_system, interval_type)
+        s_b, e_b = encode(300, 400, coordinate_system, interval_type)
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval, signed := true) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(100,)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_signed_distance_returns_negative_when_b_is_upstream(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test signed DISTANCE returns -100 when B is upstream in any encoding.
+
+        Given:
+            Canonical A=[300, 400) and B=[100, 200) re-encoded under the
+            same convention on both sides, queried with ``signed := true``.
+        When:
+            DISTANCE runs.
+        Then:
+            It should return -100 regardless of encoding.
+        """
+        # Arrange
+        s_a, e_a = encode(300, 400, coordinate_system, interval_type)
+        s_b, e_b = encode(100, 200, coordinate_system, interval_type)
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval, signed := true) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(-100,)]

--- a/tests/integration/coordinate_space/test_nearest_coordinate_space.py
+++ b/tests/integration/coordinate_space/test_nearest_coordinate_space.py
@@ -1,0 +1,331 @@
+"""Integration tests asserting NEAREST is convention-invariant.
+
+For a fixed canonical configuration, encoding the same logical intervals
+under any of the four ``(coordinate_system, interval_type)`` combinations
+must select the same neighbor row(s) through GIQL transpilation and DuckDB.
+"""
+
+import pytest
+
+from .encodings import CONVENTIONS
+from .encodings import encode
+from .encodings import make_table
+
+pytestmark = pytest.mark.integration
+
+
+def _row(chrom: str, start: int, end: int, name: str) -> tuple:
+    """Build a 6-tuple suitable for ``load_intervals`` with strand ``+``."""
+    return (chrom, start, end, name, 100, "+")
+
+
+# Canonical layout reused by NC-001 / NC-005 to keep the matched-name baseline
+# stable across same- and mixed-convention parametrizations.
+#
+#   A: [200, 300)
+#   B candidates: b_far  [100, 150) -> gap 50
+#                 b_near [310, 350) -> gap 10  <-- nearest
+#                 b_mid  [500, 600) -> gap 200
+_CANONICAL_A = [(200, 300, "a1")]
+_CANONICAL_B = [
+    (100, 150, "b_far"),
+    (310, 350, "b_near"),
+    (500, 600, "b_mid"),
+]
+
+
+def _encode_rows(rows: list[tuple], coordinate_system: str, interval_type: str):
+    """Re-encode canonical (start, end, name) tuples for the given convention."""
+    encoded = []
+    for canonical_start, canonical_end, name in rows:
+        s, e = encode(canonical_start, canonical_end, coordinate_system, interval_type)
+        encoded.append(_row("chr1", s, e, name))
+    return encoded
+
+
+class TestNearestCoordinateSpace:
+    """Convention-invariance of NEAREST end-to-end via DuckDB."""
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_correlated_nearest_picks_canonical_neighbor_in_any_encoding(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test correlated NEAREST k=1 selects the same B row in any same-convention encoding.
+
+        Given:
+            Canonical A=[200, 300) and three B candidates re-encoded under
+            the same convention on both sides.
+        When:
+            ``NEAREST(intervals_b, reference := a.interval, k := 1)`` runs
+            via LATERAL join.
+        Then:
+            It should return ``b_near`` regardless of encoding.
+        """
+        # Arrange
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+        intervals_a = _encode_rows(_CANONICAL_A, coordinate_system, interval_type)
+        intervals_b = _encode_rows(_CANONICAL_B, coordinate_system, interval_type)
+
+        # Act
+        result = giql_query(
+            """
+            SELECT a.name, b.name
+            FROM intervals_a a
+            CROSS JOIN LATERAL NEAREST(
+                intervals_b,
+                reference := a.interval,
+                k := 1
+            ) b
+            """,
+            tables=tables,
+            intervals_a=intervals_a,
+            intervals_b=intervals_b,
+        )
+
+        # Assert
+        assert result == [("a1", "b_near")]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_correlated_nearest_k3_returns_all_three_candidates_in_any_encoding(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test correlated NEAREST k=3 returns all candidates in any encoding.
+
+        Given:
+            Canonical A=[200, 300) and three B candidates re-encoded under
+            the same convention on both sides.
+        When:
+            NEAREST with ``k := 3`` runs via LATERAL join.
+        Then:
+            It should return all three B rows regardless of encoding.
+        """
+        # Arrange
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+        intervals_a = _encode_rows(_CANONICAL_A, coordinate_system, interval_type)
+        intervals_b = _encode_rows(_CANONICAL_B, coordinate_system, interval_type)
+
+        # Act
+        result = giql_query(
+            """
+            SELECT b.name
+            FROM intervals_a a
+            CROSS JOIN LATERAL NEAREST(
+                intervals_b,
+                reference := a.interval,
+                k := 3
+            ) b
+            """,
+            tables=tables,
+            intervals_a=intervals_a,
+            intervals_b=intervals_b,
+        )
+
+        # Assert
+        assert {row[0] for row in result} == {"b_near", "b_far", "b_mid"}
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_correlated_nearest_max_distance_filters_by_canonical_gap(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test correlated NEAREST honors max_distance against the canonical gap.
+
+        Given:
+            Canonical A=[200, 300) and the same three B candidates,
+            re-encoded under the same convention on both sides; ``k := 3``
+            and ``max_distance := 50`` is supplied.
+        When:
+            NEAREST runs via LATERAL join.
+        Then:
+            It should return only ``b_near`` (10 bp) and ``b_far`` (50 bp,
+            inclusive boundary) regardless of encoding; ``b_mid`` (200 bp)
+            should be excluded.
+        """
+        # Arrange
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+        intervals_a = _encode_rows(_CANONICAL_A, coordinate_system, interval_type)
+        intervals_b = _encode_rows(_CANONICAL_B, coordinate_system, interval_type)
+
+        # Act
+        result = giql_query(
+            """
+            SELECT b.name
+            FROM intervals_a a
+            CROSS JOIN LATERAL NEAREST(
+                intervals_b,
+                reference := a.interval,
+                k := 3,
+                max_distance := 50
+            ) b
+            """,
+            tables=tables,
+            intervals_a=intervals_a,
+            intervals_b=intervals_b,
+        )
+
+        # Assert
+        assert sorted(row[0] for row in result) == ["b_far", "b_near"]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_standalone_nearest_with_literal_reference_resolves_across_encodings(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test standalone NEAREST with a 0-based half-open literal works under any target encoding.
+
+        Given:
+            Three canonical B candidates re-encoded under the given
+            convention; the literal reference ``'chr1:350-360'`` is parsed
+            as 0-based half-open [350, 360).
+        When:
+            ``SELECT * FROM NEAREST(intervals_b, reference := ..., k := 2)``
+            runs in standalone mode.
+        Then:
+            It should return ``b_near`` (10 bp) and ``b_far`` (200 bp)
+            regardless of target encoding; ``b_mid`` (140 bp) is the
+            second-nearest, so the expected pair is ``{b_near, b_mid}``.
+        """
+        # Arrange
+        tables = [make_table("intervals_b", coordinate_system, interval_type)]
+        intervals_b = _encode_rows(_CANONICAL_B, coordinate_system, interval_type)
+
+        # Act
+        result = giql_query(
+            """
+            SELECT name
+            FROM NEAREST(
+                intervals_b,
+                reference := 'chr1:350-360',
+                k := 2
+            )
+            """,
+            tables=tables,
+            intervals_b=intervals_b,
+        )
+
+        # Assert
+        # Distances from [350, 360): b_near [310,350) -> 0 (touching),
+        # b_mid [500,600) -> 140, b_far [100,150) -> 200.
+        assert sorted(row[0] for row in result) == ["b_mid", "b_near"]
+
+    @pytest.mark.parametrize(
+        ("conv_a", "conv_b"),
+        [(a, b) for a in CONVENTIONS for b in CONVENTIONS],
+        ids=lambda v: str(v),
+    )
+    def test_correlated_nearest_is_invariant_under_mixed_conventions(
+        self, giql_query, conv_a, conv_b
+    ):
+        """Test correlated NEAREST k=1 picks the same B row for any mixed-convention pair.
+
+        Given:
+            Canonical A=[200, 300) on table A encoded in convention_a, and
+            three canonical B candidates on table B encoded in convention_b.
+        When:
+            NEAREST k=1 runs via LATERAL join.
+        Then:
+            It should return ``b_near`` for every (convention_a,
+            convention_b) pair.
+        """
+        # Arrange
+        tables = [
+            make_table("intervals_a", *conv_a),
+            make_table("intervals_b", *conv_b),
+        ]
+        intervals_a = _encode_rows(_CANONICAL_A, *conv_a)
+        intervals_b = _encode_rows(_CANONICAL_B, *conv_b)
+
+        # Act
+        result = giql_query(
+            """
+            SELECT a.name, b.name
+            FROM intervals_a a
+            CROSS JOIN LATERAL NEAREST(
+                intervals_b,
+                reference := a.interval,
+                k := 1
+            ) b
+            """,
+            tables=tables,
+            intervals_a=intervals_a,
+            intervals_b=intervals_b,
+        )
+
+        # Assert
+        assert result == [("a1", "b_near")]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_correlated_nearest_picks_adjacent_neighbor_when_touching_half_open_boundary(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test correlated NEAREST picks the touching candidate (gap 0) in any encoding.
+
+        Given:
+            Canonical A=[100, 200) with two B candidates -- b_adjacent at
+            canonical [200, 300) (touching half-open boundary, gap 0) and
+            b_far at [500, 600) -- re-encoded under the same convention on
+            both sides.
+        When:
+            NEAREST k=1 runs via LATERAL join.
+        Then:
+            It should return ``b_adjacent`` regardless of encoding.
+        """
+        # Arrange
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+        intervals_a = _encode_rows(
+            [(100, 200, "a1")], coordinate_system, interval_type
+        )
+        intervals_b = _encode_rows(
+            [(200, 300, "b_adjacent"), (500, 600, "b_far")],
+            coordinate_system,
+            interval_type,
+        )
+
+        # Act
+        result = giql_query(
+            """
+            SELECT a.name, b.name
+            FROM intervals_a a
+            CROSS JOIN LATERAL NEAREST(
+                intervals_b,
+                reference := a.interval,
+                k := 1
+            ) b
+            """,
+            tables=tables,
+            intervals_a=intervals_a,
+            intervals_b=intervals_b,
+        )
+
+        # Assert
+        assert result == [("a1", "b_adjacent")]


### PR DESCRIPTION
## Summary

Make DISTANCE and NEAREST honor `Table.coordinate_system` and stop conflating `Table.interval_type` with bedtools-style "+1" gap counting, so logically-equivalent intervals stored under different conventions yield the same numeric distance. Reuse the `_canonical_start` and `_canonical_end` helpers introduced in #88 to canonicalize all four endpoint expressions to 0-based half-open before they reach `_generate_distance_case`, and drop the implicit "+1" gap counting that closed-interval tables previously triggered.

This is a behavior change with no opt-in: tables declared with `interval_type="closed"` no longer apply the "+1" gap quirk for either DISTANCE or NEAREST, and `interval_type` no longer drives any gap arithmetic. Callers who relied on the legacy "+1" must add it explicitly in the consuming query (e.g. wrap the result in `... + 1`). The two pre-existing bedtools-compat tests are rewritten to assert the new behavior, and parametrized regression tests cover canonicalization across all four `(coordinate_system, interval_type)` combinations for both operators.

Literal-form DISTANCE (still `NotImplementedError`) and the spatial-predicate code paths fixed in #88 are out of scope.

Closes #89

## Proposed changes

### `src/giql/generators/base.py`

- `giqldistance_sql`: resolve each side's `Table` config via `_resolve_table` and wrap raw `start`/`end` with `_canonical_start` / `_canonical_end` before they reach `_generate_distance_case`.
- `giqlnearest_sql`: hoist the target-`Table` lookup and wrap target endpoints via the helpers.
- `_resolve_nearest_reference`: canonicalize column-ref returns via `_canonical_start` / `_canonical_end` in all three branches — standalone column reference, correlated explicit reference, and correlated implicit reference (literal returns are already canonical via `RangeParser.to_zero_based_half_open`).
- `_generate_distance_case`: drop the `add_one_for_gap` parameter and the `gap_adj` term; the CASE expression now operates entirely in canonical 0-based half-open space.

### `tests/generators/test_base.py`

- Rename the two pre-existing closed-interval tests to the BDD pattern and rewrite them to assert that closed-interval tables emit no `+1` gap counting.
- Add parametrized canonicalization tests for DISTANCE across all four `(coordinate_system, interval_type)` combinations, a mixed-conventions DISTANCE test, parametrized NEAREST target-side tests, a column-ref reference NEAREST test (standalone mode), and a correlated/implicit-reference NEAREST test that exercises canonicalization of the outer table's columns.
- Tighten the NEAREST gap-counting assertions to require both gap branches to carry the expected formulas (the previous `or` chain would have silently passed even if only one branch were correct).

### `docs/transpilation/index.rst`

- Note that DISTANCE/NEAREST canonicalize table-side endpoints based on their `(coordinate_system, interval_type)` config, and add a `.. versionchanged::` directive flagging the removal of the implicit `+1` gap counting.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|---|---|---|---|---|
| 1 | `TestBaseGIQLGenerator` | Two 0-based closed tables joined under DISTANCE | `giqldistance_sql` is called | The CASE expression canonicalizes each `end` as `(end + 1)` and emits no `+ 1` in the gap branches | Removal of the legacy implicit "+1" in DISTANCE for closed-interval tables |
| 2 | `TestBaseGIQLGenerator` | A 0-based closed target table for NEAREST | `giqlnearest_sql` is called | The distance CASE expression canonicalizes the target `end` as `(end + 1)` and emits no `+ 1` in the gap branches | Removal of the legacy implicit "+1" in NEAREST for closed-interval target tables |
| 3 | `TestBaseGIQLGenerator` | Two tables sharing one of the four `(coordinate_system, interval_type)` combinations | DISTANCE is called between aliased columns from each table | Each side's `start`/`end` is wrapped per the canonical 0-based half-open conversion, leaving comparison and gap formulas otherwise unchanged | DISTANCE canonicalization across all four conventions |
| 4 | `TestBaseGIQLGenerator` | A 0-based half-open table joined against a 1-based closed table | DISTANCE is called between aliased columns from each table | The 1-based-closed side's `start` is wrapped as `(start - 1)`, the default side stays raw, and the comparison/gap formulas use the canonicalized expressions | DISTANCE under mixed conventions |
| 5 | `TestBaseGIQLGenerator` | A target table declared with one of the four `(coordinate_system, interval_type)` combinations and a literal reference range | `giqlnearest_sql` is called | The distance CASE expression wraps target `start`/`end` per the canonical 0-based half-open conversion against the already-canonical literal reference | NEAREST target canonicalization across all four conventions |
| 6 | `TestBaseGIQLGenerator` | A 0-based half-open target table and an explicit reference column from a 1-based closed table | `giqlnearest_sql` is called | The reference's `start` is wrapped as `(start - 1)`, the reference's `end` stays raw, and the target side stays raw | NEAREST reference canonicalization for column-ref references in standalone mode |
| 7 | `TestBaseGIQLGenerator` | A 1-based closed outer table and a 0-based half-open target table joined via `CROSS JOIN LATERAL` with no `reference` argument | `giqlnearest_sql` is called | The distance CASE expression wraps the outer table's `start` as `(start - 1)`, leaves its `end` raw, and leaves the target side raw | NEAREST reference canonicalization for the correlated/implicit-reference branch |
