### PR TITLE
Transpile INTERSECTS joins to per-chromosome IEJoin queries for DuckDB — Closes #85

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ print(sql)
 
 The transpiled SQL can be executed with fast genome-unaware databases or in-memory analytic engines like DuckDB.
 
+For column-to-column `INTERSECTS` joins (INNER, SEMI, or ANTI) targeting DuckDB, pass `dialect="duckdb"` to opt into a per-chromosome IEJoin plan that avoids the row inflation of the default binned equi-join. See [DuckDB IEJoin Dialect](https://giql.readthedocs.io/en/latest/transpilation/performance.html#duckdb-iejoin-dialect) for the supported shapes and fallback rules.
+
 You can also use [oxbow](https://oxbow.readthedocs.io) to efficiently stream specialized genomics formats into DuckDB. 
 
 ```python

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -224,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -3755,7 +3755,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "giql",
+   "display_name": "giql (3.13.3)",
    "language": "python",
    "name": "python3"
   },
@@ -3769,7 +3769,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/docs/transpilation/performance.rst
+++ b/docs/transpilation/performance.rst
@@ -301,6 +301,252 @@ Analyze query execution plans by running EXPLAIN on the transpiled SQL:
 Backend-Specific Tips
 ---------------------
 
+DuckDB IEJoin Dialect
+~~~~~~~~~~~~~~~~~~~~~
+
+For column-to-column ``INTERSECTS`` joins (INNER, SEMI, or ANTI) on
+DuckDB, the ``dialect="duckdb"`` opt-in transpiles the join into a
+per-chromosome dynamic-SQL pattern. Each per-chromosome subquery contains
+only inequality predicates, which DuckDB plans through its range-join
+family (``IE_JOIN`` or ``PIECEWISE_MERGE_JOIN``) — avoiding the
+row-inflation and deduplication cost of the default binned equi-join plan
+(the ``dialect=None`` path, controlled by ``intersects_bin_size``, which
+expands each interval into ``UNNEST``-generated bins and deduplicates
+the resulting matches).
+
+.. code-block:: python
+
+   from giql import transpile
+
+   sql = transpile(
+       """
+       SELECT a.chrom, a.start, b.start
+       FROM peaks a
+       JOIN genes b ON a.interval INTERSECTS b.interval
+       """,
+       tables=["peaks", "genes"],
+       dialect="duckdb",
+   )
+   # sql is a two-statement script — see the next example for execution.
+
+The output is a multi-statement string of the form::
+
+   SET VARIABLE __giql_iejoin_<token> = COALESCE((... string_agg per chromosome ...), '<empty schema>');
+   SELECT ... FROM query(getvariable('__giql_iejoin_<token>')) AS __giql_iejoin_wrapper
+
+The ``<token>`` is a per-call ``uuid4().hex`` (128 bits) suffix so the
+``SET VARIABLE`` name is collision-resistant even when outputs from many
+``transpile()`` calls are interleaved in a single DuckDB session
+(session variables are global session state). The outer SELECT's
+wrapper-relation alias is constant (``__giql_iejoin_wrapper``) because
+it isn't user-visible and doesn't need to vary per call.
+
+Inside the per-chromosome string-builder, chromosome names are emitted
+via ``replace(chrom, '''', '''''')`` wrapped in single quotes, so
+chromosome identifiers containing literal single quotes interpolate
+safely into the dynamic SQL.
+
+Because the output is a two-statement script that depends on session
+state, execute it through a single DuckDB connection's ``.execute()`` —
+DuckDB ≥1.4 (the version pinned by GIQL's development and CI
+environment) accepts multi-statement strings in one call and returns
+the result of the final statement. SQLAlchemy's ``text()``,
+``pandas.read_sql_query``, and similar wrappers that split or rewrite
+the string may drop the ``SET VARIABLE`` and produce empty or NULL
+results.
+
+.. code-block:: python
+
+   import duckdb
+   from giql import transpile
+
+   conn = duckdb.connect()
+   conn.execute("CREATE TABLE peaks (chrom VARCHAR, \"start\" INTEGER, \"end\" INTEGER)")
+   conn.execute("CREATE TABLE genes (chrom VARCHAR, \"start\" INTEGER, \"end\" INTEGER)")
+   sql = transpile(
+       """
+       SELECT a.chrom, a.start, b.start
+       FROM peaks a
+       JOIN genes b ON a.interval INTERSECTS b.interval
+       """,
+       tables=["peaks", "genes"],
+       dialect="duckdb",
+   )
+   rows = conn.execute(sql).fetchall()
+
+The dialect rewrites the whole query, so the supported shape is
+``SELECT <qualified projections> FROM <base table> {INNER|SEMI|ANTI}
+JOIN <base table> {ON|WHERE} <one column-to-column INTERSECTS>`` — the
+JOIN and the column-to-column ``INTERSECTS`` are both required
+(literal-range ``INTERSECTS`` against a single table falls through to
+the default predicate generator).
+
+**Join variants.** ``INNER JOIN`` is the default. ``SEMI JOIN`` returns
+distinct left rows that have at least one overlapping match; ``ANTI
+JOIN`` returns left rows with no overlapping match. Both restrict the
+outer SELECT to left-side projections — any reference to the right
+side (``b.col`` / ``b.*`` / aggregate over ``b.*``) raises
+``ValueError``. ANTI uses a left-distinct chromosome partition rather
+than the chromosome INTERSECT used by INNER / SEMI, so left rows on
+chromosomes absent from the right table are preserved.
+
+DuckDB plans INNER through the IE_JOIN / PIECEWISE_MERGE_JOIN
+sort-merge family. SEMI and ANTI with inequality predicates plan
+through ``BLOCKWISE_NL_JOIN`` instead — still avoiding the UNNEST
+row-inflation of the binned plan, but not the IE_JOIN sort-merge fast
+path. Expect substantial speedups vs. the binned plan for SEMI / ANTI
+where the chromosome partition already filters most pairs; INNER gets
+the largest speedup.
+
+On top of the core shape the dialect also absorbs several common
+decorations:
+
+- **Outer modifiers.** ``ORDER BY`` / ``LIMIT`` / ``OFFSET`` /
+  ``DISTINCT`` on the outer query are appended to the outer SELECT;
+  column references in ``ORDER BY`` are rewritten to the wrapper
+  relation's inner aliases.
+- **Aggregates.** ``GROUP BY`` / ``HAVING`` with aggregate functions
+  (``COUNT``, ``SUM``, ``MIN``, ``MAX``, ``AVG``, ``COUNT(DISTINCT
+  a.col)``, ...) are appended to the outer SELECT. Aggregate arguments
+  must be table-qualified (``COUNT(*)`` and ``COUNT(a.col)`` are both
+  accepted).
+- **Extra JOIN / WHERE predicates.** Additional non-INTERSECTS
+  predicates ANDed onto the join ON or WHERE (e.g. ``a.score >
+  b.score`` or ``WHERE a.score > 100``) are inlined into each
+  per-chromosome subquery's ON, so DuckDB filters them inside each
+  IEJoin candidate set. **Limitations:** the dialect peels extra
+  predicates only across top-level ``AND`` connectives, so predicates
+  that wrap the ``INTERSECTS`` in ``OR`` / ``NOT`` / parentheses still
+  fall back. Predicates whose AND-tree residual contains a subquery,
+  aggregate, or window function fall back too (DuckDB forbids window
+  functions inside ``JOIN ON``, and subqueries / aggregates inside an
+  IEJoin candidate set would either break the planner or produce
+  semantically wrong results). If you hit the
+  WHERE-INTERSECTS-plus-extra-JOIN-ON-predicate shape described in
+  `#94 <https://github.com/abdenlab/giql/issues/94>`_ on the default
+  ``dialect=None`` path, ``dialect="duckdb"`` is one workaround — the
+  dialect inlines extras directly into each per-chromosome subquery
+  and is unaffected by that bug.
+- **Star projections (``a.*`` / ``b.*``).** Expanded to the genomic
+  columns declared by the corresponding :class:`Table` config (chrom
+  / start / end, plus strand when set). This narrows the result schema
+  relative to the binned plan, which delegates star expansion to
+  DuckDB and projects every base-table column. Users with additional
+  non-genomic columns should list them explicitly.
+
+The dialect splits unsupported shapes into two buckets. Soft-fallback
+shapes route to the binned plan automatically and return correct
+results; within those shapes the ``dialect`` kwarg is safe to set
+without risk of silent incorrectness. Hard-error shapes (enumerated
+further below) raise ``ValueError`` at transpile time — the dialect
+deliberately refuses them rather than silently producing the wrong
+SQL.
+
+The soft-fallback shapes are:
+
+- **Outer joins.** ``LEFT`` / ``RIGHT`` / ``FULL`` ``JOIN ... ON ...
+  INTERSECTS ...`` falls back to the binned plan. The same applies
+  when the join keeps its side modifier and the ``INTERSECTS`` lives in
+  the top-level ``WHERE`` (e.g. ``LEFT JOIN ... ON TRUE WHERE
+  a.interval INTERSECTS b.interval``).
+- **NATURAL joins.** ``NATURAL JOIN`` falls back because the dialect
+  cannot enumerate shared columns at transpile time (only the
+  registered ``chrom`` / ``start`` / ``end`` / ``strand`` columns are
+  known).
+- **USING joins.** Single-column ``USING(<chrom_col>)`` admits (the
+  per-chromosome partition is exactly the equi-join). Multi-column
+  ``USING`` and ``USING(<non-chrom-col>)`` fall back; inline support
+  is a documented follow-up.
+- **Multiple INTERSECTS predicates.** Queries with more than one
+  column-to-column ``INTERSECTS`` (anywhere in the AST, including
+  subqueries) fall back.
+- **INTERSECTS references unrecognized join sides.** A column-to-column
+  INTERSECTS whose operands don't reference the FROM table's alias,
+  or where the second operand's alias doesn't resolve to a registered
+  JOIN target, falls back to the binned plan.
+- **Self-joins.** Joining a table to itself falls back.
+- **OR / NOT / paren-wrapped extra predicates.** See the Extra JOIN /
+  WHERE predicates note above.
+- **Subquery, aggregate, or window-function extra predicates.**
+  Predicates whose AND-tree residual contains a subquery, an aggregate
+  function, or a window function (``ROW_NUMBER() OVER (...)`` etc.)
+  fall back rather than inline into the per-chromosome subquery's
+  ``ON`` (DuckDB forbids window functions in ``ON`` clauses, and
+  aggregates / subqueries inside an IEJoin candidate set would either
+  break the planner or produce semantically wrong results).
+- **Subquery inside GROUP BY / HAVING / ORDER BY.** A modifier clause
+  containing a nested subquery (including ``EXISTS (SELECT ...)``)
+  falls back to the binned plan, because the dialect's modifier-ref
+  rewriter is not scope-aware and would corrupt the subquery's
+  column scope. Subqueries hidden inside aggregate arguments in the
+  SELECT list fall back for the same reason.
+- **Top-level WITH clauses.** A query with a leading ``WITH`` falls
+  back so the CTE survives.
+- **More than two tables.** Any extra FROM-clause table (auxiliary
+  comma-join or non-INTERSECTS ``JOIN``) falls back.
+- **Non-base-table operands.** A subquery, CTE, or GIQL table-function
+  (e.g. ``DISJOIN(genes)``) used as a join operand falls back.
+- **DISTINCT ON (...).** Only plain ``DISTINCT`` is absorbed; the
+  ``DISTINCT ON`` variant falls back.
+
+Query-shape ``ValueError`` raises (the dialect deliberately refuses
+these rather than silently miscompile):
+
+- **Bare** ``SELECT *`` **and unqualified columns.** The dialect path
+  needs to know which side each output column comes from. Use ``a.*``,
+  ``b.*``, ``a.col``, or ``a.col AS x``.
+- **Expression-form projections.** ``a.start + 1`` and other non-column
+  expressions (other than aggregates) raise. Project the underlying
+  column and compute in a wrapping query around the dialect's output,
+  or omit ``dialect="duckdb"`` to use the binned plan.
+- **Unknown table qualifier.** ``c.col`` when the only sides are ``a``
+  and ``b``.
+- **Unknown alias in GROUP BY / HAVING / ORDER BY.** A modifier-clause
+  column qualified with a table alias outside the join's two sides
+  (``c.col``) raises with a ``cannot resolve … in <CLAUSE>`` message
+  naming the expected aliases.
+- **Right-side reference in SEMI / ANTI joins.** ``b.col`` / ``b.*`` /
+  aggregate over ``b.*`` in the outer SELECT, GROUP BY, HAVING, ORDER
+  BY, or aggregate argument under ``SEMI JOIN`` / ``ANTI JOIN`` raises;
+  SEMI / ANTI return left-side columns only.
+- **Aggregate of unqualified column.** ``SUM(score)`` raises; use
+  ``SUM(a.score)`` or ``SUM(b.score)``.
+- **Star projection with a user alias.** ``a.* AS x`` raises (most
+  engines reject star-with-alias outright); either drop the alias and
+  use ``a.*``, or list the columns explicitly with per-column aliases.
+- **Window aggregates and FILTER clauses.** ``SUM(a.score) OVER
+  (...)`` and ``SUM(a.score) FILTER (WHERE ...)`` raise with a
+  dedicated error; rewrite the projection or omit ``dialect="duckdb"``.
+- **Aggregates inside expressions.** ``COUNT(*) * 2`` and similar
+  arithmetic-over-aggregate projections raise; project the aggregate
+  on its own and do arithmetic in a wrapping query.
+- **Scalar subqueries in the SELECT list.** ``(SELECT SUM(x) FROM
+  other_table) AS s`` raises; rewrite without the subquery or omit
+  ``dialect="duckdb"``.
+- **Catalog/schema-qualified extra predicates.** ``mycat.myschema.a.col``
+  in an extra predicate raises; the alias rewriter would leave the
+  catalog/schema qualifier intact in the inner subquery, where it
+  references a different relation than intended.
+- **Unqualified or unknown-aliased extra predicates.** ``WHERE strand
+  = '+'`` (unqualified) or ``WHERE c.score > 0`` (alias outside the
+  join's two sides) raise with an actionable message naming the
+  expected aliases. The binned plan would either silently bind the
+  column wrong or defer the error to the downstream engine, so the
+  dialect surfaces the user mistake at transpile time instead.
+
+Argument-validation ``ValueError`` raises (these fire before any AST
+inspection and are independent of the query shape):
+
+- **Mutually exclusive with** ``intersects_bin_size``. The two
+  parameters cannot be combined; pass one or the other.
+- **Unknown dialect string.** Anything other than ``"duckdb"`` or
+  ``None`` raises with the offending value echoed.
+
+Literal-range ``INTERSECTS`` (e.g. ``WHERE interval INTERSECTS
+'chr1:1000-2000'``) is single-table and has no column-to-column join
+to rewrite, so the dialect declines and the standard range-predicate
+emission handles it identically to the ``dialect=None`` path.
+
 DuckDB Optimizations
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/src/giql/canonical.py
+++ b/src/giql/canonical.py
@@ -1,0 +1,91 @@
+"""Convert raw column expressions to and from canonical 0-based half-open coordinates.
+
+Genomic intervals can be expressed in 0-based half-open, 0-based closed,
+1-based half-open, or 1-based closed coordinates. The transpiler emits SQL
+in 0-based half-open by canonicalizing every column endpoint at the source.
+These helpers wrap a raw column reference with the offset needed for that
+canonicalization based on the source table's declared coordinate system.
+The ``decanonical_*`` helpers apply the inverse offset to emit an endpoint
+back in the table's own coordinate system. (Literal ranges go through
+:meth:`giql.range_parser.RangeParser.to_zero_based_half_open`.)
+"""
+
+from giql.table import Table
+
+
+def canonical_start(raw_start: str, table: Table | None) -> str:
+    """Wrap a raw start column expression to canonical 0-based half-open start.
+
+    When ``table`` is ``None``, the raw expression is returned unchanged
+    (treated as 0-based half-open).
+
+    Conversion by :attr:`Table.coordinate_system`:
+
+    - ``0based``: ``start`` (identity)
+    - ``1based``: ``start - 1``
+    """
+    if table is None or table.coordinate_system == "0based":
+        return raw_start
+    return f"({raw_start} - 1)"
+
+
+def canonical_end(raw_end: str, table: Table | None) -> str:
+    """Wrap a raw end column expression to canonical 0-based half-open end.
+
+    When ``table`` is ``None``, the raw expression is returned unchanged
+    (treated as 0-based half-open).
+
+    Conversion by (:attr:`Table.coordinate_system`, :attr:`Table.interval_type`):
+
+    - ``0based`` / ``half_open``: ``end`` (identity)
+    - ``0based`` / ``closed``:    ``end + 1``
+    - ``1based`` / ``half_open``: ``end - 1``
+    - ``1based`` / ``closed``:    ``end`` (identity)
+    """
+    if table is None:
+        return raw_end
+    key = (table.coordinate_system, table.interval_type)
+    if key == ("0based", "closed"):
+        return f"({raw_end} + 1)"
+    if key == ("1based", "half_open"):
+        return f"({raw_end} - 1)"
+    return raw_end
+
+
+def decanonical_start(canonical_expr: str, table: Table | None) -> str:
+    """Convert a canonical 0-based half-open start to the table's encoding.
+
+    Inverse of :func:`canonical_start`. When ``table`` is ``None``, the
+    expression is returned unchanged (treated as 0-based half-open).
+
+    Conversion by :attr:`Table.coordinate_system`:
+
+    - ``0based``: ``start`` (identity)
+    - ``1based``: ``start + 1``
+    """
+    if table is None or table.coordinate_system == "0based":
+        return canonical_expr
+    return f"({canonical_expr} + 1)"
+
+
+def decanonical_end(canonical_expr: str, table: Table | None) -> str:
+    """Convert a canonical 0-based half-open end to the table's encoding.
+
+    Inverse of :func:`canonical_end`. When ``table`` is ``None``, the
+    expression is returned unchanged (treated as 0-based half-open).
+
+    Conversion by (:attr:`Table.coordinate_system`, :attr:`Table.interval_type`):
+
+    - ``0based`` / ``half_open``: ``end`` (identity)
+    - ``0based`` / ``closed``:    ``end - 1``
+    - ``1based`` / ``half_open``: ``end + 1``
+    - ``1based`` / ``closed``:    ``end`` (identity)
+    """
+    if table is None:
+        return canonical_expr
+    key = (table.coordinate_system, table.interval_type)
+    if key == ("0based", "closed"):
+        return f"({canonical_expr} - 1)"
+    if key == ("1based", "half_open"):
+        return f"({canonical_expr} + 1)"
+    return canonical_expr

--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -35,19 +35,6 @@ class BaseGIQLGenerator(Generator):
     # SQLite does not support LATERAL, so it overrides this to False
     SUPPORTS_LATERAL = True
 
-    @staticmethod
-    def _extract_bool_param(param_expr: exp.Expression | None) -> bool:
-        """Extract boolean value from a parameter expression.
-
-        Handles exp.Boolean, exp.Literal, and string representations.
-        """
-        if not param_expr:
-            return False
-        elif isinstance(param_expr, exp.Boolean):
-            return param_expr.this
-        else:
-            return str(param_expr).upper() in ("TRUE", "1", "YES")
-
     def __init__(self, tables: Tables | None = None, **kwargs):
         super().__init__(**kwargs)
         self.tables = tables or Tables()
@@ -1025,6 +1012,20 @@ class BaseGIQLGenerator(Generator):
             "nor a CTE defined in this query. Register the table or define "
             "the CTE before transpiling."
         )
+
+    @staticmethod
+    def _extract_bool_param(param_expr: exp.Expression | None) -> bool:
+        """Extract boolean value from a parameter expression.
+
+        Handles :class:`exp.Boolean`, :class:`exp.Literal`, and string
+        representations.
+        """
+        if not param_expr:
+            return False
+        elif isinstance(param_expr, exp.Boolean):
+            return param_expr.this
+        else:
+            return str(param_expr).upper() in ("TRUE", "1", "YES")
 
     @staticmethod
     def _enclosing_cte_names(expression: exp.Expression) -> set[str]:

--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -1,6 +1,10 @@
 from sqlglot import exp
 from sqlglot.generator import Generator
 
+from giql.canonical import canonical_end
+from giql.canonical import canonical_start
+from giql.canonical import decanonical_end
+from giql.canonical import decanonical_start
 from giql.constants import DEFAULT_CHROM_COL
 from giql.constants import DEFAULT_END_COL
 from giql.constants import DEFAULT_START_COL
@@ -187,12 +191,10 @@ class BaseGIQLGenerator(Generator):
                 target_strand = f'{table_name}."{target_table.strand_col}"'
 
         # Distance math below assumes 0-based half-open.
-        target_start_expr = self._canonical_start(
+        target_start_expr = canonical_start(
             f'{table_name}."{target_start}"', target_table
         )
-        target_end_expr = self._canonical_end(
-            f'{table_name}."{target_end}"', target_table
-        )
+        target_end_expr = canonical_end(f'{table_name}."{target_end}"', target_table)
 
         # Build distance calculation using CASE expression
         # For NEAREST: ORDER BY absolute distance, but RETURN signed distance
@@ -272,6 +274,10 @@ class BaseGIQLGenerator(Generator):
         filter drops sub-intervals overlapping no reference interval. When no
         ``reference`` is given it defaults to the target set.
 
+        Coordinate-system round-tripping is handled by
+        :func:`giql.canonical.decanonical_start` /
+        :func:`giql.canonical.decanonical_end`.
+
         :param expression:
             GIQLDisjoin expression node
         :return:
@@ -304,21 +310,21 @@ class BaseGIQLGenerator(Generator):
 
         # Canonical target endpoints, qualified by the __giql_dj_tgt alias.
         t_chrom = f't."{target_chrom}"'
-        t_start = self._canonical_start(f't."{target_start}"', target_table)
-        t_end = self._canonical_end(f't."{target_end}"', target_table)
+        t_start = canonical_start(f't."{target_start}"', target_table)
+        t_end = canonical_end(f't."{target_end}"', target_table)
 
         # Canonical reference endpoints: unqualified for the breakpoint CTE,
         # qualified by 'r' for the coverage EXISTS filter.
-        bp_start = self._canonical_start(f'"{ref_start}"', ref_table)
-        bp_end = self._canonical_end(f'"{ref_end}"', ref_table)
-        r_start = self._canonical_start(f'r."{ref_start}"', ref_table)
-        r_end = self._canonical_end(f'r."{ref_end}"', ref_table)
+        bp_start = canonical_start(f'"{ref_start}"', ref_table)
+        bp_end = canonical_end(f'"{ref_end}"', ref_table)
+        r_start = canonical_start(f'r."{ref_start}"', ref_table)
+        r_end = canonical_end(f'r."{ref_end}"', ref_table)
 
         # disjoin_start / disjoin_end are emitted in the target table's
         # coordinate system so an output row carries one convention; the cut
         # math above stays canonical internally.
-        out_start = self._decanonical_start("s.seg_start", target_table)
-        out_end = self._decanonical_end("s.seg_end", target_table)
+        out_start = decanonical_start("s.seg_start", target_table)
+        out_end = decanonical_end("s.seg_end", target_table)
 
         # Build the WITH clause one named fragment per __giql_dj_* CTE so each
         # block reads on its own. The `seg_end > seg_start` guard in the final
@@ -425,10 +431,10 @@ class BaseGIQLGenerator(Generator):
         # Distance math below assumes 0-based half-open.
         table_a = self._resolve_table(interval_a_sql)
         table_b = self._resolve_table(interval_b_sql)
-        start_a = self._canonical_start(start_a, table_a)
-        end_a = self._canonical_end(end_a, table_a)
-        start_b = self._canonical_start(start_b, table_b)
-        end_b = self._canonical_end(end_b, table_b)
+        start_a = canonical_start(start_a, table_a)
+        end_a = canonical_end(end_a, table_a)
+        start_b = canonical_start(start_b, table_b)
+        end_b = canonical_end(end_b, table_b)
 
         # Generate CASE expression
         return self._generate_distance_case(
@@ -585,8 +591,8 @@ class BaseGIQLGenerator(Generator):
             column_ref, self._current_table
         )
         table = self._resolve_table(column_ref, self._current_table)
-        start_col = self._canonical_start(raw_start_col, table)
-        end_col = self._canonical_end(raw_end_col, table)
+        start_col = canonical_start(raw_start_col, table)
+        end_col = canonical_end(raw_end_col, table)
 
         chrom = parsed_range.chromosome
         start = parsed_range.start
@@ -644,10 +650,10 @@ class BaseGIQLGenerator(Generator):
         r_chrom, raw_r_start, raw_r_end = self._get_column_refs(right_col, None)
         l_table = self._resolve_table(left_col)
         r_table = self._resolve_table(right_col)
-        l_start = self._canonical_start(raw_l_start, l_table)
-        l_end = self._canonical_end(raw_l_end, l_table)
-        r_start = self._canonical_start(raw_r_start, r_table)
-        r_end = self._canonical_end(raw_r_end, r_table)
+        l_start = canonical_start(raw_l_start, l_table)
+        l_end = canonical_end(raw_l_end, l_table)
+        r_start = canonical_start(raw_r_start, r_table)
+        r_end = canonical_end(raw_r_end, r_table)
 
         if op_type == "intersects":
             # Ranges overlap if: chrom1 = chrom2 AND start1 < end2 AND end1 > start2
@@ -795,8 +801,9 @@ class BaseGIQLGenerator(Generator):
             Tuple of (chromosome, start, end) or (chromosome, start, end, strand)
             Returns SQL expressions (column refs for correlated, literals for standalone)
             Endpoints are canonicalized to 0-based half-open: literal references via
-            ``RangeParser.to_zero_based_half_open``, column references via
-            ``_canonical_start`` / ``_canonical_end``.
+            :meth:`~giql.range_parser.RangeParser.to_zero_based_half_open`, column
+            references via :func:`giql.canonical.canonical_start` /
+            :func:`giql.canonical.canonical_end`.
         :raises ValueError:
             If reference is missing in standalone mode or invalid format
         """
@@ -832,7 +839,11 @@ class BaseGIQLGenerator(Generator):
                 # Column reference - resolve and canonicalize
                 chrom, start, end = self._get_column_refs(reference_sql, None)
                 ref_table = self._resolve_table(reference_sql)
-                return self._canonical_endpoints(chrom, start, end, ref_table)
+                return (
+                    chrom,
+                    canonical_start(start, ref_table),
+                    canonical_end(end, ref_table),
+                )
 
         else:  # correlated mode
             if reference:
@@ -840,7 +851,11 @@ class BaseGIQLGenerator(Generator):
                 reference_sql = self.sql(reference)
                 chrom, start, end = self._get_column_refs(reference_sql, None)
                 ref_table = self._resolve_table(reference_sql)
-                return self._canonical_endpoints(chrom, start, end, ref_table)
+                return (
+                    chrom,
+                    canonical_start(start, ref_table),
+                    canonical_end(end, ref_table),
+                )
             else:
                 # Implicit reference - resolve from outer table in LATERAL join
                 outer_table = self._find_outer_table_in_lateral_join(expression)
@@ -864,7 +879,11 @@ class BaseGIQLGenerator(Generator):
                 # Build column references using the outer table and genomic column
                 reference_sql = f"{outer_table}.{table.genomic_col}"
                 chrom, start, end = self._get_column_refs(reference_sql, None)
-                return self._canonical_endpoints(chrom, start, end, table)
+                return (
+                    chrom,
+                    canonical_start(start, table),
+                    canonical_end(end, table),
+                )
 
     def _resolve_target_table(
         self, expression: GIQLNearest | GIQLDisjoin
@@ -1105,91 +1124,6 @@ class BaseGIQLGenerator(Generator):
             if include_strand:
                 return base_cols + (f'"{strand_col}"',)
             return base_cols
-
-    @staticmethod
-    def _canonical_start(raw_start: str, table: Table | None) -> str:
-        """Wrap a raw start column expression to yield canonical 0-based half-open start.
-
-        Conversion by ``coordinate_system``:
-
-        - 0based: ``start`` (identity)
-        - 1based: ``start - 1``
-        """
-        if table is None or table.coordinate_system == "0based":
-            return raw_start
-        return f"({raw_start} - 1)"
-
-    @staticmethod
-    def _canonical_end(raw_end: str, table: Table | None) -> str:
-        """Wrap a raw end column expression to yield canonical 0-based half-open end.
-
-        Conversion by ``(coordinate_system, interval_type)``:
-
-        - 0based / half_open: ``end`` (identity)
-        - 0based / closed:    ``end + 1``
-        - 1based / half_open: ``end - 1``
-        - 1based / closed:    ``end`` (identity)
-        """
-        if table is None:
-            return raw_end
-        key = (table.coordinate_system, table.interval_type)
-        if key == ("0based", "closed"):
-            return f"({raw_end} + 1)"
-        if key == ("1based", "half_open"):
-            return f"({raw_end} - 1)"
-        return raw_end  # 0based/half_open and 1based/closed: identity
-
-    @staticmethod
-    def _decanonical_start(canonical_start: str, table: Table | None) -> str:
-        """Convert a canonical 0-based half-open start to the table's encoding.
-
-        Inverse of ``_canonical_start``. Conversion by ``coordinate_system``:
-
-        - 0based: ``start`` (identity)
-        - 1based: ``start + 1``
-        """
-        if table is None or table.coordinate_system == "0based":
-            return canonical_start
-        return f"({canonical_start} + 1)"
-
-    @staticmethod
-    def _decanonical_end(canonical_end: str, table: Table | None) -> str:
-        """Convert a canonical 0-based half-open end to the table's encoding.
-
-        Inverse of ``_canonical_end``. Conversion by ``(coordinate_system,
-        interval_type)``:
-
-        - 0based / half_open: ``end`` (identity)
-        - 0based / closed:    ``end - 1``
-        - 1based / half_open: ``end + 1``
-        - 1based / closed:    ``end`` (identity)
-        """
-        if table is None:
-            return canonical_end
-        key = (table.coordinate_system, table.interval_type)
-        if key == ("0based", "closed"):
-            return f"({canonical_end} - 1)"
-        if key == ("1based", "half_open"):
-            return f"({canonical_end} + 1)"
-        return canonical_end  # 0based/half_open and 1based/closed: identity
-
-    @staticmethod
-    def _canonical_endpoints(
-        chrom: str,
-        raw_start: str,
-        raw_end: str,
-        table: Table | None,
-    ) -> tuple[str, str, str]:
-        """Canonicalize a ``(chrom, start, end)`` triple to 0-based half-open.
-
-        The chromosome expression passes through unchanged; start and end are
-        wrapped via ``_canonical_start`` / ``_canonical_end``.
-        """
-        return (
-            chrom,
-            BaseGIQLGenerator._canonical_start(raw_start, table),
-            BaseGIQLGenerator._canonical_end(raw_end, table),
-        )
 
     def _resolve_table_name(self, column_ref: str, table_name: str | None) -> str | None:
         """Resolve the underlying table name for a column reference.

--- a/src/giql/transformer.py
+++ b/src/giql/transformer.py
@@ -644,7 +644,7 @@ class IntersectsBinnedJoinTransformer:
             Table configurations for column mapping
         :param bin_size:
             Bin width for the equi-join rewrite. Defaults to
-            DEFAULT_BIN_SIZE if not specified.
+            :data:`~giql.constants.DEFAULT_BIN_SIZE` if not specified.
         """
         self.tables = tables
         resolved = bin_size if bin_size is not None else DEFAULT_BIN_SIZE
@@ -842,7 +842,9 @@ class IntersectsBinnedJoinTransformer:
         from_cols = self._get_columns(from_table_name)
         join_cols = self._get_columns(join_table_name)
 
-        # Determine which INTERSECTS side maps to FROM vs JOIN table
+        # Prefix assignment encodes which INTERSECTS argument feeds the
+        # left vs right bin column of the pairs CTE, so the downstream
+        # equi-join compares matching halves regardless of FROM order.
         if left_alias == from_alias:
             l_table_name, r_table_name = from_table_name, join_table_name
             l_cols, r_cols = from_cols, join_cols
@@ -852,11 +854,9 @@ class IntersectsBinnedJoinTransformer:
             l_cols, r_cols = join_cols, from_cols
             from_prefix, join_prefix = "__giql_r", "__giql_l"
 
-        # Ensure key-only bin CTEs exist
         l_cte = self._ensure_key_binned(query, l_table_name, key_binned)
         r_cte = self._ensure_key_binned(query, r_table_name, key_binned)
 
-        # Build and attach the pairs CTE
         pairs_name = f"__giql_pairs_{pairs_idx}"
         pairs_cte = self._build_pairs_cte(pairs_name, l_cte, r_cte, l_cols, r_cols)
         existing_with = query.args.get("with_")
@@ -868,7 +868,6 @@ class IntersectsBinnedJoinTransformer:
         side = join.args.get("side")
         p_alias = f"__giql_p{pairs_idx}"
 
-        # join1: [SIDE] JOIN pairs ON from.key = pairs.from_key
         join1_on = self._build_key_match(from_alias, from_cols, p_alias, from_prefix)
         join1_kwargs: dict = {
             "this": exp.Table(
@@ -881,7 +880,6 @@ class IntersectsBinnedJoinTransformer:
             join1_kwargs["side"] = side
         join1 = exp.Join(**join1_kwargs)
 
-        # join2: [SIDE] JOIN join_table ON join.key = pairs.join_key
         join2_on = self._build_key_match(join_alias, join_cols, p_alias, join_prefix)
         if extra:
             join2_on = exp.And(this=join2_on, expression=extra)

--- a/src/giql/transformer.py
+++ b/src/giql/transformer.py
@@ -5,10 +5,15 @@ operations (like CLUSTER, MERGE, and binned INTERSECTS joins) into equivalent
 SQL with CTEs.
 """
 
-import itertools
+from dataclasses import dataclass
+from typing import ClassVar
+from typing import Literal
+from uuid import uuid4
 
 from sqlglot import exp
 
+from giql.canonical import canonical_end
+from giql.canonical import canonical_start
 from giql.constants import DEFAULT_BIN_SIZE
 from giql.constants import DEFAULT_CHROM_COL
 from giql.constants import DEFAULT_END_COL
@@ -17,7 +22,210 @@ from giql.constants import DEFAULT_STRAND_COL
 from giql.expressions import GIQLCluster
 from giql.expressions import GIQLMerge
 from giql.expressions import Intersects
+from giql.table import Table
 from giql.table import Tables
+
+
+class _UnqualifiedProjectionError(Exception):
+    """Signal an unrecoverable projection-resolution failure in the DuckDB IEJoin path.
+
+    Raised by :class:`IntersectsDuckDBIEJoinTransformer` when a query engages
+    the dialect path but contains a SELECT-list shape the dialect cannot
+    translate (bare ``*``, unqualified column, expression-form projection,
+    unknown table qualifier, ``a.* AS x``, window aggregate, ``FILTER`` clause,
+    arithmetic over an aggregate, or a scalar subquery in the projection list),
+    or an extras predicate that references an unqualified or unknown-aliased
+    column. Caught and re-raised as :class:`ValueError` at the dialect's public
+    boundary.
+    """
+
+
+# These predicates are shared between :class:`IntersectsBinnedJoinTransformer`
+# and :class:`IntersectsDuckDBIEJoinTransformer`; they live at module scope
+# rather than on either class so neither owns them. Style §2's strict
+# "functions after classes" ordering is relaxed here under the
+# topic-interleaved exception, generalized to "shared by multiple consumer
+# classes."
+
+
+def _is_column_intersects(node: Intersects) -> bool:
+    """Return True if *node* is column-to-column :class:`Intersects`.
+
+    Both operands must be table-qualified column references.
+    """
+    return (
+        isinstance(node.this, exp.Column)
+        and bool(node.this.table)
+        and isinstance(node.expression, exp.Column)
+        and bool(node.expression.table)
+    )
+
+
+def _find_column_intersects_in(expr: exp.Expression) -> Intersects | None:
+    """Return the first column-to-column :class:`Intersects` in *expr*, or ``None``."""
+    return next(
+        (n for n in expr.find_all(Intersects) if _is_column_intersects(n)),
+        None,
+    )
+
+
+def _normalize_alias(name: str, *, quoted: bool = False) -> str:
+    """Return *name* case-folded unless it was a quoted identifier.
+
+    DuckDB (and standard SQL) treat unquoted identifiers case-insensitively.
+    Comparing aliases via raw Python equality rejects valid mixed-case queries
+    that the binned plan accepts; normalize via :py:meth:`str.casefold` so the
+    dialect matches DuckDB's identifier semantics. Quoted identifiers stay
+    case-sensitive per the SQL standard.
+    """
+    return name if quoted else name.casefold()
+
+
+def _has_outer_join_intersects(query: exp.Select) -> bool:
+    """Return True if any outer JOIN has a column-to-column :class:`Intersects`.
+
+    Handles two surfaces the user can write the INTERSECTS under an outer
+    join: directly in the join's ``ON`` clause, or in the top-level
+    ``WHERE`` while the join keeps its ``LEFT``/``RIGHT``/``FULL`` side
+    modifier (``LEFT JOIN ... ON TRUE WHERE a.interval INTERSECTS
+    b.interval``). The dialect's inner-join IEJoin rewrite would silently
+    drop the outer-join's unmatched-row guarantee in the second shape,
+    so we fall back whenever an outer-join is present and an
+    INTERSECTS sits anywhere it could influence the join result.
+    """
+    if not isinstance(query, exp.Select):
+        return False
+    outer_joins = [
+        join for join in query.args.get("joins") or [] if join.args.get("side")
+    ]
+    if not outer_joins:
+        return False
+    for join in outer_joins:
+        on = join.args.get("on")
+        if on is not None and _find_column_intersects_in(on):
+            return True
+    where = query.args.get("where")
+    if where and _find_column_intersects_in(where.this):
+        return True
+    return False
+
+
+def _strip_intersects(
+    expr: exp.Expression | None, intersects: Intersects
+) -> exp.Expression | None:
+    """Return the parts of an AND tree that aren't the given :class:`Intersects`."""
+    if expr is None or expr is intersects:
+        return None
+    if isinstance(expr, exp.And):
+        if expr.this is intersects:
+            return expr.expression
+        if expr.expression is intersects:
+            return expr.this
+        left = _strip_intersects(expr.this, intersects)
+        right = _strip_intersects(expr.expression, intersects)
+        if left is None:
+            return right
+        if right is None:
+            return left
+        return exp.And(this=left, expression=right)
+    return expr
+
+
+def _count_column_intersects(query: exp.Select) -> int:
+    """Count column-to-column :class:`Intersects` predicates anywhere in *query*.
+
+    Walks the full AST so the dialect's "exactly one INTERSECTS" gate cannot
+    be circumvented by an INTERSECTS hidden inside a subquery (e.g. inside
+    a SELECT-list scalar subquery or inside ``EXISTS (SELECT ...)``). The
+    SELECT-list / modifier-clause subquery gates in ``transform_to_sql``
+    already reject those shapes, but this widened count is defense-in-depth
+    against future gate relaxations.
+    """
+    if not isinstance(query, exp.Select):
+        return 0
+    return sum(1 for n in query.find_all(Intersects) if _is_column_intersects(n))
+
+
+@dataclass(frozen=True)
+class _IEJoinSides:
+    """Resolved two-sided join shape for the DuckDB IEJoin dialect path.
+
+    Bundles the left/right user aliases (normalized via :func:`_normalize_alias`)
+    with the un-aliased :class:`~sqlglot.expressions.Table` AST nodes and a
+    ``kind`` discriminator identifying the join variant. The hardcoded inner
+    aliases ``a`` and ``b`` used inside each per-chromosome subquery are
+    exposed as :data:`left_inner_alias` and :data:`right_inner_alias`.
+
+    The :attr:`is_left_only_join` property is True for SEMI and ANTI shapes,
+    which restrict the outer SELECT to left-side projections only.
+    """
+
+    left_user_alias: str
+    right_user_alias: str
+    left_table: exp.Table
+    right_table: exp.Table
+    kind: Literal["INNER", "SEMI", "ANTI"]
+
+    left_inner_alias: ClassVar[str] = "a"
+    right_inner_alias: ClassVar[str] = "b"
+
+    @property
+    def is_left_only_join(self) -> bool:
+        """True when the join's output only references the left side (SEMI / ANTI)."""
+        return self.kind in ("SEMI", "ANTI")
+
+    @classmethod
+    def from_intersects(
+        cls,
+        from_table: exp.Table,
+        join: exp.Join,
+        intersects: Intersects,
+    ) -> "_IEJoinSides | None":
+        """Resolve sides, run the FROM-side orientation swap, normalize aliases.
+
+        Returns ``None`` when the join's table operand isn't a base
+        :class:`~sqlglot.expressions.Table`, when neither side of the
+        :class:`Intersects` predicate references the FROM table's alias, or
+        when the join's ``kind`` is outside the supported set
+        (``INNER`` / ``CROSS`` / ``SEMI`` / ``ANTI``; ``CROSS`` folds to
+        ``INNER`` because per-chromosome partitioning makes them equivalent
+        inside the inner subquery).
+        """
+        join_table = join.this
+        if not isinstance(join_table, exp.Table):
+            return None
+        from_alias = _normalize_alias(from_table.alias_or_name)
+        left_alias = _normalize_alias(intersects.this.table)
+        right_alias = _normalize_alias(intersects.expression.table)
+        if left_alias == from_alias:
+            l_user_alias = from_alias
+            l_table = from_table
+            r_user_alias = right_alias
+            r_table = join_table
+        elif right_alias == from_alias:
+            # Inner subquery template hardcodes "a" to the FROM side; swap so
+            # that contract holds regardless of which operand the user put
+            # first in INTERSECTS.
+            l_user_alias = from_alias
+            l_table = from_table
+            r_user_alias = left_alias
+            r_table = join_table
+        else:
+            return None
+        raw_kind = (join.args.get("kind") or "").upper()
+        if raw_kind in ("", "CROSS"):
+            kind: Literal["INNER", "SEMI", "ANTI"] = "INNER"
+        elif raw_kind in ("SEMI", "ANTI"):
+            kind = raw_kind  # type: ignore[assignment]
+        else:
+            return None
+        return cls(
+            left_user_alias=l_user_alias,
+            right_user_alias=r_user_alias,
+            left_table=l_table,
+            right_table=r_table,
+            kind=kind,
+        )
 
 
 class ClusterTransformer:
@@ -581,60 +789,49 @@ class MergeTransformer:
 
 
 class IntersectsBinnedJoinTransformer:
-    """Transforms column-to-column INTERSECTS into binned equi-joins.
+    """Transform column-to-column INTERSECTS into binned equi-joins.
 
-    Handles both explicit JOIN ON and implicit cross-join (WHERE) patterns.
-    Two rewrite strategies are selected based on the SELECT list:
-
-    **No wildcards** (``SELECT a.chrom, b.start, ...``) — ``__giql_bin``
-    cannot appear in the output regardless of CTE content, so the simpler
-    1-join full-CTE approach is used:
-
-        WITH __giql_a_binned AS (
-            SELECT *, UNNEST(range(
-                CAST("start" / B AS BIGINT),
-                CAST(("end" - 1) / B + 1 AS BIGINT)
-            )) AS __giql_bin FROM peaks
-        ),
-        __giql_b_binned AS (...)
-        SELECT DISTINCT a.chrom, b.start, ...
-        FROM __giql_a_binned AS a
-        JOIN __giql_b_binned AS b
-          ON a."chrom" = b."chrom" AND a.__giql_bin = b.__giql_bin
-          AND a."start" < b."end" AND a."end" > b."start"
-
-    **Wildcards present** (``SELECT a.*, b.*``) — ``__giql_bin`` would leak
-    into ``a.*`` expansion if ``a`` aliases a full-select CTE. A key-only
-    bridge CTE pattern is used instead, keeping original table references:
+    Handles both explicit ``JOIN ... ON`` and implicit cross-join (WHERE)
+    INTERSECTS patterns. Each rewrite emits a pairs CTE that holds the
+    matching ``(left_key, right_key)`` tuples computed by an INNER binned
+    join with ``SELECT DISTINCT`` on the join keys, then bridges the
+    original tables through that pairs CTE::
 
         WITH __giql_peaks_bins AS (
             SELECT "chrom", "start", "end",
                    UNNEST(range(...)) AS __giql_bin FROM peaks
         ),
-        __giql_genes_bins AS (...)
-        SELECT DISTINCT a.*, b.*
+        __giql_genes_bins AS (...),
+        __giql_pairs_0 AS (
+            SELECT DISTINCT
+                __giql_l.<chrom> AS __giql_l_chrom, ...,
+                __giql_r.<chrom> AS __giql_r_chrom, ...
+            FROM __giql_peaks_bins AS __giql_l
+            JOIN __giql_genes_bins AS __giql_r
+              ON __giql_l.<chrom> = __giql_r.<chrom>
+                 AND __giql_l.__giql_bin = __giql_r.__giql_bin
+                 AND __giql_l.<start> < __giql_r.<end>
+                 AND __giql_l.<end> > __giql_r.<start>
+        )
+        SELECT a.*, b.*
         FROM peaks a
-        JOIN __giql_peaks_bins __giql_c0
-          ON a."chrom" = __giql_c0."chrom" AND a."start" = __giql_c0."start"
-          AND a."end" = __giql_c0."end"
-        JOIN __giql_genes_bins __giql_c1
-          ON __giql_c0."chrom" = __giql_c1."chrom"
-          AND __giql_c0.__giql_bin = __giql_c1.__giql_bin
+        JOIN __giql_pairs_0 AS __giql_p0
+          ON a.<chrom> = __giql_p0.__giql_l_chrom
+             AND a.<start> = __giql_p0.__giql_l_start
+             AND a.<end> = __giql_p0.__giql_l_end
         JOIN genes b
-          ON b."chrom" = __giql_c1."chrom" AND b."start" = __giql_c1."start"
-          AND b."end" = __giql_c1."end"
-          AND a."start" < b."end" AND a."end" > b."start"
+          ON b.<chrom> = __giql_p0.__giql_r_chrom
+             AND b.<start> = __giql_p0.__giql_r_start
+             AND b.<end> = __giql_p0.__giql_r_end
+
+    Deduplication happens inside the pairs CTE on the join keys, so the
+    output query does NOT carry a ``SELECT DISTINCT`` — source rows that
+    differ only in unselected columns are preserved. Outer joins ride
+    safely on top of this because the bridge-join structure prevents bin
+    fan-out from creating spurious NULL rows.
 
     Literal-range INTERSECTS (e.g., ``WHERE interval INTERSECTS 'chr1:...'``)
     are left untouched.
-
-    SELECT DISTINCT is added to deduplicate rows produced by multi-bin
-    matches.  This means rows that are identical across every selected
-    column will be collapsed — include a distinguishing column (e.g., an
-    id or score) to preserve duplicates that differ only in unselected
-    columns.  The bridge path's key-match joins on ``(chrom, start,
-    end)`` and may fan out if multiple source rows share those values;
-    DISTINCT corrects for this.
     """
 
     def __init__(self, tables: Tables, bin_size: int | None = None):
@@ -653,35 +850,34 @@ class IntersectsBinnedJoinTransformer:
         self.bin_size = resolved
 
     def transform(self, query: exp.Expression) -> exp.Expression:
+        """Rewrite column-to-column INTERSECTS joins as a pairs-CTE binned plan.
+
+        Walks ``query.args["joins"]`` and the top-level ``WHERE`` for
+        column-to-column :class:`Intersects` predicates and replaces each one
+        with a bridge through a freshly-allocated pairs CTE
+        (``__giql_pairs_<n>``) plus the per-table bin CTEs that feed it.
+        Non-INTERSECTS predicates are preserved verbatim; literal-range
+        ``INTERSECTS`` (``WHERE interval INTERSECTS 'chr1:100-200'``) is
+        left untouched and emitted by the default generator.
+
+        :param query:
+            Parsed query AST.
+        :return:
+            The transformed AST (mutated in place when an INTERSECTS join
+            is rewritten; returned unchanged for non-``Select`` inputs).
+        """
         if not isinstance(query, exp.Select):
             return query
 
         # The pairs-CTE approach computes matching (left_key, right_key)
         # pairs via an INNER binned join with DISTINCT on key columns,
-        # then joins the original tables through the pairs CTE.  This
+        # then joins the original tables through the pairs CTE. This
         # avoids adding SELECT DISTINCT to the output query, which would
         # collapse legitimately different source rows that happen to
-        # have identical selected columns.  It also handles outer joins
+        # have identical selected columns. It also handles outer joins
         # correctly by preventing bin fan-out from creating spurious
         # NULL rows.
         return self._transform_with_pairs(query)
-
-    def _select_has_wildcards(self, query: exp.Select) -> bool:
-        """Return True if any SELECT item is a wildcard (* or table.*)."""
-        for expr in query.expressions:
-            if isinstance(expr, exp.Star):
-                return True
-            if isinstance(expr, exp.Column) and isinstance(expr.this, exp.Star):
-                return True
-        return False
-
-    def _has_outer_join_intersects(self, query: exp.Select) -> bool:
-        """Return True if any outer JOIN has an INTERSECTS predicate."""
-        for join in query.args.get("joins") or []:
-            if join.args.get("side") and join.args.get("on"):
-                if self._find_column_intersects_in(join.args["on"]):
-                    return True
-        return False
 
     def _transform_with_pairs(self, query: exp.Select) -> exp.Select:
         """Transform INTERSECTS joins using the pairs-CTE approach.
@@ -702,9 +898,9 @@ class IntersectsBinnedJoinTransformer:
         for join in joins:
             on = join.args.get("on")
             if on:
-                intersects = self._find_column_intersects_in(on)
+                intersects = _find_column_intersects_in(on)
                 if intersects:
-                    extra = self._extract_non_intersects(on, intersects)
+                    extra = _strip_intersects(on, intersects)
                     replacement = self._build_pairs_replacement_joins(
                         query, join, intersects, extra, key_binned, pairs_idx
                     )
@@ -716,7 +912,7 @@ class IntersectsBinnedJoinTransformer:
 
         where = query.args.get("where")
         if where:
-            intersects = self._find_column_intersects_in(where.this)
+            intersects = _find_column_intersects_in(where.this)
             if intersects:
                 cross_join = self._find_cross_join_for_intersects(
                     query, intersects, new_joins
@@ -921,158 +1117,6 @@ class IntersectsBinnedJoinTransformer:
             ),
         )
 
-    def _transform_full_cte(self, query: exp.Select) -> exp.Select:
-        joins = query.args.get("joins") or []
-        binned: dict[str, tuple[str, str, str]] = {}
-        rewrote_any = False
-
-        for join in joins:
-            on = join.args.get("on")
-            if on:
-                intersects = self._find_column_intersects_in(on)
-                if intersects:
-                    self._rewrite_join_on_full_cte(query, join, intersects, binned)
-                    rewrote_any = True
-
-        # Implicit cross-join: FROM a, b WHERE a.interval INTERSECTS b.interval
-        where = query.args.get("where")
-        if where:
-            intersects = self._find_column_intersects_in(where.this)
-            if intersects:
-                cross_join = self._find_cross_join_for_intersects(
-                    query, intersects, joins
-                )
-                if cross_join is not None:
-                    self._rewrite_cross_join_full_cte(
-                        query, cross_join, intersects, binned
-                    )
-                    rewrote_any = True
-
-        if rewrote_any:
-            query.set("distinct", exp.Distinct())
-
-        return query
-
-    def _rewrite_join_on_full_cte(
-        self,
-        query: exp.Select,
-        join: exp.Join,
-        intersects: Intersects,
-        binned: dict[str, tuple[str, str, str]],
-    ) -> None:
-        from_table = query.args["from_"].this
-        join_table = join.this
-        if not isinstance(from_table, exp.Table) or not isinstance(
-            join_table, exp.Table
-        ):
-            return
-
-        from_alias, from_cols = self._ensure_table_binned_full(
-            query, from_table, query.args["from_"], binned
-        )
-        join_alias, join_cols = self._ensure_table_binned_full(
-            query, join_table, join, binned
-        )
-
-        extra = self._extract_non_intersects(join.args.get("on"), intersects)
-
-        equi_join = exp.And(
-            this=exp.EQ(
-                this=exp.column(from_cols[0], table=from_alias, quoted=True),
-                expression=exp.column(join_cols[0], table=join_alias, quoted=True),
-            ),
-            expression=exp.EQ(
-                this=exp.column("__giql_bin", table=from_alias),
-                expression=exp.column("__giql_bin", table=join_alias),
-            ),
-        )
-        # Place both equi-join and overlap in ON so LEFT/RIGHT/FULL semantics hold.
-        new_on = exp.And(
-            this=equi_join,
-            expression=self._build_overlap(from_alias, join_alias, from_cols, join_cols),
-        )
-        if extra:
-            new_on = exp.And(this=new_on, expression=extra)
-        join.set("on", new_on)
-
-    def _rewrite_cross_join_full_cte(
-        self,
-        query: exp.Select,
-        cross_join: exp.Join,
-        intersects: Intersects,
-        binned: dict[str, tuple[str, str, str]],
-    ) -> None:
-        from_table = query.args["from_"].this
-        join_table = cross_join.this
-        if not isinstance(from_table, exp.Table) or not isinstance(
-            join_table, exp.Table
-        ):
-            return
-
-        from_alias, from_cols = self._ensure_table_binned_full(
-            query, from_table, query.args["from_"], binned
-        )
-        join_alias, join_cols = self._ensure_table_binned_full(
-            query, join_table, cross_join, binned
-        )
-
-        equi_join = exp.And(
-            this=exp.EQ(
-                this=exp.column(from_cols[0], table=from_alias, quoted=True),
-                expression=exp.column(join_cols[0], table=join_alias, quoted=True),
-            ),
-            expression=exp.EQ(
-                this=exp.column("__giql_bin", table=from_alias),
-                expression=exp.column("__giql_bin", table=join_alias),
-            ),
-        )
-        cross_join.set(
-            "on",
-            exp.And(
-                this=equi_join,
-                expression=self._build_overlap(
-                    from_alias, join_alias, from_cols, join_cols
-                ),
-            ),
-        )
-        self._remove_intersects_from_where(query, intersects)
-
-    def _ensure_table_binned_full(
-        self,
-        query: exp.Select,
-        table: exp.Table,
-        parent: exp.Expression,
-        binned: dict[str, tuple[str, str, str]],
-    ) -> tuple[str, tuple[str, str, str]]:
-        """Create a full SELECT * CTE for *table* if needed; replace ref in *parent*."""
-        alias = table.alias or table.name
-        if alias in binned:
-            return alias, binned[alias]
-
-        table_name = table.name
-        cols = self._get_columns(table_name)
-        cte_name = f"__giql_{alias}_binned"
-
-        cte = exp.CTE(
-            this=self._build_full_binned_select(table_name, cols),
-            alias=exp.TableAlias(this=exp.Identifier(this=cte_name)),
-        )
-        existing_with = query.args.get("with_")
-        if existing_with:
-            existing_with.append("expressions", cte)
-        else:
-            query.set("with_", exp.With(expressions=[cte]))
-
-        parent.set(
-            "this",
-            exp.Table(
-                this=exp.Identifier(this=cte_name),
-                alias=exp.TableAlias(this=exp.Identifier(this=alias)),
-            ),
-        )
-        binned[alias] = cols
-        return alias, cols
-
     def _build_bin_range(
         self, start: str, end: str
     ) -> tuple[exp.Expression, exp.Expression]:
@@ -1101,95 +1145,6 @@ class IntersectsBinnedJoinTransformer:
             expression=exp.Literal.number(1),
         )
         return low, high
-
-    def _build_full_binned_select(
-        self, table_name: str, cols: tuple[str, str, str]
-    ) -> exp.Select:
-        """Build ``SELECT *, UNNEST(range(...)) AS __giql_bin FROM <table>``."""
-        _chrom, start, end = cols
-        low, high = self._build_bin_range(start, end)
-
-        range_fn = exp.Anonymous(this="range", expressions=[low, high])
-        unnest_fn = exp.Anonymous(this="UNNEST", expressions=[range_fn])
-        bin_alias = exp.Alias(
-            this=unnest_fn,
-            alias=exp.Identifier(this="__giql_bin"),
-        )
-
-        select = exp.Select()
-        select.select(exp.Star(), copy=False)
-        select.select(bin_alias, append=True, copy=False)
-        select.from_(exp.Table(this=exp.Identifier(this=table_name)), copy=False)
-        return select
-
-    def _transform_bridge(self, query: exp.Select) -> exp.Select:
-        joins = query.args.get("joins") or []
-        key_binned: dict[str, str] = {}
-        connector_counter = itertools.count()
-        new_joins: list[exp.Join] = []
-        rewrote_any = False
-
-        for join in joins:
-            on = join.args.get("on")
-            if on:
-                intersects = self._find_column_intersects_in(on)
-                if intersects:
-                    extra = self._build_join_back_joins(
-                        query,
-                        join,
-                        intersects,
-                        key_binned,
-                        connector_counter,
-                        preserve_kind=True,
-                    )
-                    new_joins.extend(extra)
-                    rewrote_any = True
-                    continue
-            new_joins.append(join)
-
-        where = query.args.get("where")
-        if where:
-            intersects = self._find_column_intersects_in(where.this)
-            if intersects:
-                cross_join = self._find_cross_join_for_intersects(
-                    query, intersects, new_joins
-                )
-                if cross_join is not None:
-                    new_joins.remove(cross_join)
-                    extra = self._build_join_back_joins(
-                        query,
-                        cross_join,
-                        intersects,
-                        key_binned,
-                        connector_counter,
-                        preserve_kind=False,
-                    )
-                    new_joins.extend(extra)
-                    self._remove_intersects_from_where(query, intersects)
-                    rewrote_any = True
-
-        if rewrote_any:
-            query.set("joins", new_joins)
-            query.set("distinct", exp.Distinct())
-
-        return query
-
-    def _find_column_intersects_in(self, expr: exp.Expression) -> Intersects | None:
-        """Return the first column-to-column Intersects node in *expr*, or None.
-
-        Only the first match is returned.  A single JOIN with multiple
-        INTERSECTS conditions in its ON clause is not supported; only the
-        first will be rewritten.
-        """
-        for node in expr.find_all(Intersects):
-            if (
-                isinstance(node.this, exp.Column)
-                and node.this.table
-                and isinstance(node.expression, exp.Column)
-                and node.expression.table
-            ):
-                return node
-        return None
 
     def _find_cross_join_for_intersects(
         self,
@@ -1226,31 +1181,11 @@ class IntersectsBinnedJoinTransformer:
         where = query.args.get("where")
         if not where:
             return
-        remainder = self._extract_non_intersects(where.this, intersects)
+        remainder = _strip_intersects(where.this, intersects)
         if remainder is None:
             query.set("where", None)
         else:
             query.set("where", exp.Where(this=remainder))
-
-    def _extract_non_intersects(
-        self, expr: exp.Expression | None, intersects: Intersects
-    ) -> exp.Expression | None:
-        """Return the parts of an AND tree that are not the INTERSECTS node."""
-        if expr is None or expr is intersects:
-            return None
-        if isinstance(expr, exp.And):
-            if expr.this is intersects:
-                return expr.expression
-            if expr.expression is intersects:
-                return expr.this
-            left = self._extract_non_intersects(expr.this, intersects)
-            right = self._extract_non_intersects(expr.expression, intersects)
-            if left is None:
-                return right
-            if right is None:
-                return left
-            return exp.And(this=left, expression=right)
-        return expr
 
     def _get_columns(self, table_name: str) -> tuple[str, str, str]:
         """Return (chrom, start, end) column names for a table."""
@@ -1294,7 +1229,11 @@ class IntersectsBinnedJoinTransformer:
     def _build_key_only_bins_select(
         self, table_name: str, cols: tuple[str, str, str]
     ) -> exp.Select:
-        """Build ``SELECT chrom, start, end, UNNEST(range(...)) AS __giql_bin FROM table``."""
+        """Build the binned-key SELECT for *table_name*.
+
+        Emits ``SELECT chrom, start, end, UNNEST(range(...)) AS __giql_bin
+        FROM <table_name>``.
+        """
         chrom, start, end = cols
         low, high = self._build_bin_range(start, end)
 
@@ -1339,134 +1278,977 @@ class IntersectsBinnedJoinTransformer:
         key_binned[table_name] = cte_name
         return cte_name
 
-    def _build_join_back_joins(
+
+class IntersectsDuckDBIEJoinTransformer:
+    """Transform column-to-column INTERSECTS joins into a DuckDB IEJoin pattern.
+
+    Emits a two-step dynamic SQL output:
+
+    1. ``SET VARIABLE __giql_iejoin_<token> = COALESCE(<dynamic-sql>, <empty-schema>);``
+       where ``<dynamic-sql>`` is a ``string_agg`` over the chromosome
+       partition that emits one ``SELECT ... FROM (... WHERE chrom = '<c>')
+       a JOIN (... WHERE chrom = '<c>') b ON <range-overlap>`` per
+       chromosome, joined by ``UNION ALL``.
+    2. ``SELECT <projections> FROM query(getvariable('__giql_iejoin_<token>'))``
+
+    Each per-chromosome subquery uses pure inequality predicates which DuckDB
+    plans through its range-join family (``IE_JOIN`` or ``PIECEWISE_MERGE_JOIN``).
+    The dialect supports INNER, SEMI, and ANTI variants — the per-chromosome
+    join keyword switches accordingly, and SEMI / ANTI restrict the outer
+    SELECT to left-side projections only.
+
+    See :doc:`/transpilation/performance` for the full join-shape support
+    matrix, fallback enumeration, and hard-error projection shapes.
+
+    Notes:
+
+    - ``a.*`` / ``b.*`` star projections expand to the genomic columns
+      declared by the corresponding :class:`~giql.table.Table` config
+      (chrom / start / end, plus strand when set). This narrows the result
+      schema relative to the binned plan, which delegates star expansion
+      to DuckDB and projects every base-table column. Users with additional
+      non-genomic columns should list them explicitly.
+    - ``SEMI JOIN`` and ``ANTI JOIN`` outputs are left-side only. Any
+      ``b.col`` / ``b.*`` reference in the outer SELECT, aggregate
+      arguments, GROUP BY, HAVING, or ORDER BY raises
+      :class:`_UnqualifiedProjectionError` (wrapped to :class:`ValueError`
+      at the public boundary).
+    - ``ANTI JOIN`` partitions on the left table's distinct chromosomes
+      only (not the chromosome INTERSECT used by INNER / SEMI) so that
+      left rows on chromosomes absent from the right table are preserved.
+    """
+
+    def __init__(self, tables: Tables):
+        """Initialize transformer.
+
+        :param tables:
+            Table configurations for column mapping.
+        """
+        self.tables = tables
+
+    def transform_to_sql(self, query: exp.Expression) -> str | None:
+        """Return DuckDB IEJoin SQL for *query* if applicable, else None.
+
+        The dialect rewrites the *whole* query as
+        ``SET VARIABLE __giql_iejoin_<token> = ...; SELECT ... FROM
+        query(getvariable(...))``, so any top-level clause :meth:`_build_sql`
+        does not read would be silently dropped. The check below is a
+        whitelist: engage the dialect path only for a query that is
+        exactly ``SELECT <qualified projections> FROM <registered base
+        table> [JOIN <registered base table>] {ON|WHERE} <one
+        column-to-column INTERSECTS>`` with no other top-level clause.
+        Everything else returns ``None`` so the binned plan handles it.
+        """
+        if not isinstance(query, exp.Select):
+            return None
+
+        # Top-level WITH (CTEs) still falls back to the binned plan.
+        # ORDER BY / LIMIT / OFFSET / DISTINCT / GROUP BY / HAVING ride
+        # on the outer SELECT wrapper. ``DISTINCT ON (...)`` is the one
+        # DISTINCT variant we don't try to translate — it would interact
+        # with the outer alias rewrite in ways the binned plan handles
+        # for free.
+        if query.args.get("with_"):
+            return None
+        distinct_node = query.args.get("distinct")
+        if distinct_node is not None and distinct_node.args.get("on"):
+            return None
+
+        if _has_outer_join_intersects(query):
+            return None
+
+        if _count_column_intersects(query) != 1:
+            return None
+
+        # The wrapper-relation rewriter is not scope-aware: any subquery in
+        # GROUP BY / HAVING / ORDER BY (or inside a SELECT-list aggregate
+        # argument) would have its inner column refs substituted with
+        # wrapper-relation aliases that don't exist in the subquery's own
+        # scope. Reject those shapes here. ``EXISTS (SELECT ...)`` parses
+        # as ``Exists(Select(...))`` without an ``exp.Subquery`` wrapper,
+        # so we also check ``exp.Select`` directly. Bare scalar subqueries
+        # in the SELECT list (``SELECT (SELECT SUM(x) FROM ...)``) get a
+        # targeted error from :meth:`_resolve_projections` rather than a
+        # silent fallback — only subqueries hidden inside aggregate args
+        # fall back here.
+        for clause_key in ("group", "having", "order"):
+            modifier = query.args.get(clause_key)
+            if modifier is None:
+                continue
+            if (
+                modifier.find(exp.Subquery) is not None
+                or modifier.find(exp.Select) is not None
+            ):
+                return None
+        for sel in query.expressions:
+            target = sel.this if isinstance(sel, exp.Alias) else sel
+            while isinstance(target, exp.Paren):
+                target = target.this
+            if isinstance(target, exp.AggFunc) and (
+                target.find(exp.Subquery) is not None
+                or target.find(exp.Select) is not None
+            ):
+                return None
+
+        # The supported shape connects exactly two tables via one INTERSECTS,
+        # so the top level has exactly one join (either an explicit JOIN ...
+        # ON or an implicit comma-join in WHERE). A third comma/CROSS-joined
+        # table would otherwise be silently dropped by _build_sql.
+        joins = query.args.get("joins") or []
+        if len(joins) != 1:
+            return None
+        the_join = joins[0]
+
+        # NATURAL needs schema introspection we don't have at transpile time
+        # (Table configs only expose chrom/start/end/strand; user columns
+        # like name/score are invisible). The binned plan defers to DuckDB,
+        # which does see the schema, so falling back IS the optimal plan.
+        if the_join.args.get("method"):
+            return None
+
+        # USING admits only the single-column form whose column matches both
+        # tables' ``chrom_col`` (the per-chromosome partition is exactly the
+        # equi-join that ``USING(chrom)`` requests). The chrom-equivalence
+        # check itself happens in ``_build_sql`` after ``l_table`` /
+        # ``r_table`` are resolved. Multi-column USING and USING(non-chrom)
+        # fall back; inline support for those is a documented follow-up.
+        using_cols = the_join.args.get("using") or []
+        if using_cols and len(using_cols) != 1:
+            return None
+
+        # INNER (the default), CROSS (functionally equivalent to INNER once
+        # the chromosome partition is in place), SEMI, and ANTI all engage.
+        # Everything else falls back so the binned plan can preserve its
+        # semantics (e.g. RIGHT / FULL outer joins).
+        kind_str = the_join.args.get("kind")
+        if kind_str and kind_str.upper() not in ("INNER", "CROSS", "SEMI", "ANTI"):
+            return None
+
+        intersects, the_join = self._find_target_join(query)
+        if intersects is None or the_join is None:
+            return None
+
+        from_table = query.args["from_"].this
+        if not isinstance(from_table, exp.Table):
+            return None
+
+        # Reject non-base-table operands. A GIQL table-function operand such
+        # as ``DISJOIN(genes)`` parses as an ``exp.Table`` with an empty
+        # ``name`` and would be interpolated as an empty identifier into
+        # broken SQL. (A CTE-named operand is already handled by the
+        # ``with_`` guard above; an unregistered base table is fine — the
+        # dialect uses default columns just like the binned path does.)
+        if not from_table.name:
+            return None
+        join_table = the_join.this
+        if not isinstance(join_table, exp.Table) or not join_table.name:
+            return None
+
+        sides = _IEJoinSides.from_intersects(from_table, the_join, intersects)
+        if sides is None:
+            return None
+
+        if sides.left_user_alias == sides.right_user_alias:
+            # Same alias on both sides of the INTERSECTS — the inner subquery
+            # would alias the same underlying relation as both "a" and "b",
+            # which the binned plan handles correctly via its bridge CTE.
+            return None
+
+        # Compare fully-qualified identifiers (catalog/db/name) so two
+        # distinct same-named tables in different schemas are not treated
+        # as a self-join. Same qualified identifier still falls back so the
+        # binned plan handles the legitimate self-join shape.
+        if self._qualified_table_ident(sides.left_table) == self._qualified_table_ident(
+            sides.right_table
+        ):
+            return None
+
+        # Extra predicates are inlined into each per-chromosome subquery's
+        # join ON (see :meth:`_build_sql`). Soft-fallback residuals (subquery,
+        # aggregate, window, or an INTERSECTS still wrapped in OR/NOT/Paren)
+        # cause ``_build_sql`` to return None. User-mistake residuals
+        # (unqualified or unknown-aliased columns, or columns with a
+        # catalog/schema qualifier) raise :class:`_UnqualifiedProjectionError`,
+        # which we wrap to :class:`ValueError` here so the public surface is
+        # uniform.
+        try:
+            return self._build_sql(query, intersects, sides, the_join)
+        except _UnqualifiedProjectionError as exc:
+            raise ValueError(str(exc)) from exc
+
+    @staticmethod
+    def _sql_escape(s: str) -> str:
+        """Return *s* with single quotes doubled for safe SQL string literal use."""
+        return s.replace("'", "''")
+
+    @staticmethod
+    def _sql_quote_ident(name: str) -> str:
+        """Render *name* as a DuckDB-quoted identifier.
+
+        Delegates to sqlglot's identifier emitter so embedded double quotes
+        are doubled correctly and DuckDB-specific quoting rules (case,
+        reserved words) are honored. Used at every identifier-interpolation
+        site in the dialect's dynamic SQL.
+        """
+        return exp.to_identifier(name, quoted=True).sql(dialect="duckdb")
+
+    @staticmethod
+    def _qualified_table_ident(table: exp.Table) -> str:
+        """Render *table*'s catalog/db/name as a qualified DuckDB identifier.
+
+        Drops the user-supplied alias (``peaks AS a``) so the rendered string
+        is suitable both as a bare ``FROM`` operand (where the caller adds
+        its own alias) and as a subquery source. Catalog and schema qualifiers
+        survive — sqlglot's :meth:`~sqlglot.expressions.Expression.sql` emitter
+        handles identifier quoting per DuckDB's rules (reserved words and
+        special characters get quoted; safe unquoted identifiers stay
+        unquoted).
+        """
+        no_alias = table.copy()
+        no_alias.set("alias", None)
+        return no_alias.sql(dialect="duckdb")
+
+    @staticmethod
+    def _classify_extras(
+        extras: list[exp.Expression],
+    ) -> Literal["inline", "fallback"]:
+        """Return ``"fallback"`` if any extra has a shape the binned plan must handle.
+
+        Soft-fallback shapes: an INTERSECTS still embedded in the residual
+        (because :func:`_strip_intersects` couldn't peel an OR/NOT/Paren
+        wrapper), a subquery, an aggregate function, or a window function.
+        Returns ``"inline"`` when every extra is safe to inline into the
+        per-chromosome subquery's join ON clause.
+        """
+        for predicate in extras:
+            if predicate.find(Intersects) is not None:
+                return "fallback"  # INTERSECTS wrapped in OR/NOT/Paren
+            if predicate.find(exp.Subquery) is not None:
+                return "fallback"
+            if predicate.find(exp.Select) is not None:
+                return "fallback"
+            if predicate.find(exp.AggFunc) is not None:
+                return "fallback"
+            if predicate.find(exp.Window) is not None:
+                return "fallback"
+        return "inline"
+
+    @staticmethod
+    def _validate_extra_qualifiers(
+        extras: list[exp.Expression],
+        sides: "_IEJoinSides",
+    ) -> None:
+        """Raise for unqualified, unknown-aliased, or schema-qualified columns.
+
+        Surfaces user mistakes at transpile time rather than deferring to a
+        downstream binder error. Three failure modes raise:
+
+        - **Unqualified column:** no ``.table`` qualifier.
+        - **Unknown alias:** ``.table`` doesn't match either side of the join.
+        - **Catalog/schema-qualified column:** ``mycat.myschema.a.score``
+          would silently mis-bind once the alias-rewriter remaps ``a`` to
+          the inner subquery's hardcoded ``a`` alias (the ``mycat.myschema``
+          qualifier survives the rewrite and addresses a different relation
+          than intended).
+        """
+        valid_aliases = {sides.left_user_alias, sides.right_user_alias}
+        for predicate in extras:
+            for col in predicate.find_all(exp.Column):
+                col_table = _normalize_alias(col.table) if col.table else ""
+                if not col_table:
+                    raise _UnqualifiedProjectionError(
+                        f"dialect='duckdb' cannot inline extra predicate "
+                        f"{predicate.sql()!r}: column {col.sql()!r} must be "
+                        f"qualified with {sides.left_user_alias!r} or "
+                        f"{sides.right_user_alias!r}."
+                    )
+                if col_table not in valid_aliases:
+                    raise _UnqualifiedProjectionError(
+                        f"dialect='duckdb' cannot inline extra predicate "
+                        f"{predicate.sql()!r}: column references unknown "
+                        f"table qualifier {col.table!r}; expected "
+                        f"{sides.left_user_alias!r} or "
+                        f"{sides.right_user_alias!r}."
+                    )
+                if col.args.get("db") or col.args.get("catalog"):
+                    raise _UnqualifiedProjectionError(
+                        f"dialect='duckdb' cannot inline extra predicate "
+                        f"{predicate.sql()!r}: column {col.sql()!r} carries "
+                        f"a catalog/schema qualifier; use the alias-only "
+                        f"form ({sides.left_user_alias!r}.<col> or "
+                        f"{sides.right_user_alias!r}.<col>)."
+                    )
+
+    @staticmethod
+    def _rewrite_refs_for_per_chrom_subquery(
+        node: exp.Expression,
+        sides: "_IEJoinSides",
+    ) -> str:
+        """Render a residual predicate against the inner subquery's ``a``/``b`` scope.
+
+        The user's AST references their original aliases (``peaks a`` /
+        ``genes b`` or ``peaks p`` / ``genes g``), but the per-chromosome
+        inner subquery is emitted with hardcoded aliases ``a`` and ``b``
+        regardless of what the user wrote. Rewrite each column reference
+        accordingly before emitting the residual SQL into the inner join's
+        ON clause. Alias matching is case-folded so mixed-case identifiers
+        match the DuckDB-equivalent contract.
+
+        Assumes residuals have already been validated to reference only
+        ``sides.left_user_alias`` or ``sides.right_user_alias``; columns
+        without a table qualifier or pointing at an unknown alias must
+        have been rejected upstream.
+        """
+
+        def replace(n: exp.Expression) -> exp.Expression:
+            if not isinstance(n, exp.Column):
+                return n
+            col_table = _normalize_alias(n.table) if n.table else ""
+            if col_table == sides.left_user_alias:
+                new = n.copy()
+                new.set("table", exp.to_identifier(sides.left_inner_alias))
+                return new
+            if col_table == sides.right_user_alias:
+                new = n.copy()
+                new.set("table", exp.to_identifier(sides.right_inner_alias))
+                return new
+            return n
+
+        rewritten = node.transform(replace, copy=True)
+        return rewritten.sql(dialect="duckdb")
+
+    @staticmethod
+    def _rewrite_refs_for_wrapper_relation(
+        node: exp.Expression,
+        projection_map: dict[tuple[str, str], str],
+        sides: "_IEJoinSides",
+        clause_label: str,
+    ) -> str:
+        """Rewrite table-qualified column refs to the wrapper relation's inner alias.
+
+        The dialect's outer ``SELECT`` reads from ``query(getvariable(...)) AS
+        <alias>``. The wrapper relation's columns are whatever the inner
+        per-chromosome subqueries projected — i.e., the ``__giql_p<n>`` names
+        on the left-hand side of each ``AS`` in the inner SELECT. Any user
+        ``ORDER BY`` / ``GROUP BY`` / ``HAVING`` (and any aggregate-function
+        argument) written against the original table aliases (``a.start``,
+        ``b.score``) must be rewritten to those inner alias names so DuckDB
+        can resolve them against the wrapper relation. Alias matching is
+        case-folded for DuckDB-equivalent semantics.
+
+        An upstream pre-allocation step ensures every referenced column has
+        an entry in ``projection_map``; missing keys raise
+        :class:`_UnqualifiedProjectionError` as a guard against future scope
+        relaxations that would otherwise produce silent miscompiles.
+
+        Scope caveat: this walker is not scope-aware — it rewrites every
+        :class:`~sqlglot.expressions.Column` whose ``.table`` matches either
+        side's alias anywhere inside ``node``, including correlated or
+        non-correlated subqueries that may rebind those aliases to a
+        different table. The dispatcher gates already reject any subquery
+        in GROUP BY / HAVING / ORDER BY / SELECT list so the unsafe shape
+        can't reach here today. A future relaxation of those gates must
+        add a scope-aware walker here.
+        """
+        valid_aliases = (sides.left_user_alias, sides.right_user_alias)
+
+        def replace(n: exp.Expression) -> exp.Expression:
+            if not isinstance(n, exp.Column):
+                return n
+            col_table = _normalize_alias(n.table) if n.table else ""
+            if col_table not in valid_aliases:
+                return n
+            key = (col_table, n.name)
+            if key not in projection_map:
+                raise _UnqualifiedProjectionError(
+                    f"dialect='duckdb' cannot resolve {n.sql()!r} in "
+                    f"{clause_label}: ensure the column is referenced "
+                    f"with a table qualifier matching the join's left "
+                    f"or right alias."
+                )
+            return exp.column(projection_map[key])
+
+        rewritten = node.transform(replace, copy=True)
+        return rewritten.sql(dialect="duckdb")
+
+    def _extract_extra_predicates(
         self,
         query: exp.Select,
-        join: exp.Join,
         intersects: Intersects,
-        key_binned: dict[str, str],
-        connector_counter: itertools.count,
-        *,
-        preserve_kind: bool,
-    ) -> list[exp.Join]:
-        """Build three replacement JOINs for one INTERSECTS using the join-back pattern.
+    ) -> list[exp.Expression]:
+        """Return the non-INTERSECTS predicate residuals from joins and WHERE.
 
-        join1 is always INNER because it key-matches a table against its
-        own bin CTE — every row has a corresponding bin entry by
-        construction, so the join side has no effect.
+        Walks the AND tree under each JOIN ON and the WHERE, strips the
+        target INTERSECTS node, and returns the residual predicates in
+        document order. An empty list means the query has no extras
+        beyond the target INTERSECTS.
 
-        join2 and join3 inherit the original join's side (LEFT, RIGHT)
-        when *preserve_kind* is True.
+        Note: :func:`_strip_intersects` only descends ``exp.And``. Predicates
+        whose AND tree wraps the INTERSECTS in ``exp.Or`` / ``exp.Not`` /
+        ``exp.Paren`` surface here with the INTERSECTS still embedded;
+        :meth:`_classify_extras` then routes them to the binned plan, while
+        :meth:`_validate_extra_qualifiers` enforces qualifier rules for the
+        remaining inlinable residuals.
         """
-        join_table = join.this
-        if not isinstance(join_table, exp.Table):
-            return [join]
+        residuals: list[exp.Expression] = []
+        for join in query.args.get("joins") or []:
+            on = join.args.get("on")
+            if on is None:
+                continue
+            residual = _strip_intersects(on, intersects)
+            if residual is not None:
+                residuals.append(residual)
+        where = query.args.get("where")
+        if where:
+            residual = _strip_intersects(where.this, intersects)
+            if residual is not None:
+                residuals.append(residual)
+        return residuals
 
-        join_alias = join_table.alias or join_table.name
-        join_table_name = join_table.name
+    def _find_target_join(
+        self, query: exp.Select
+    ) -> tuple[Intersects | None, exp.Join | None]:
+        """Locate the single INTERSECTS join target.
 
-        left_alias = intersects.this.table
-        right_alias = intersects.expression.table
-        other_alias = left_alias if right_alias == join_alias else right_alias
-        if other_alias == join_alias:
-            return [join]  # can't determine structure
+        Returns ``(intersects_node, join)`` where ``join`` is the
+        :class:`~sqlglot.expressions.Join` AST node carrying the target
+        INTERSECTS — either directly via its ``ON`` clause, or via an
+        implicit cross-join whose ``INTERSECTS`` predicate lives in the
+        top-level ``WHERE``. Alias matching on the WHERE-branch is
+        case-folded for DuckDB-equivalent semantics.
+        """
+        for join in query.args.get("joins") or []:
+            on = join.args.get("on")
+            if on:
+                intersects = _find_column_intersects_in(on)
+                if intersects:
+                    if not isinstance(join.this, exp.Table):
+                        return None, None
+                    return intersects, join
 
-        extra = self._extract_non_intersects(join.args.get("on"), intersects)
+        where = query.args.get("where")
+        if where:
+            intersects = _find_column_intersects_in(where.this)
+            if intersects:
+                from_table = query.args["from_"].this
+                if not isinstance(from_table, exp.Table):
+                    return None, None
+                from_alias = _normalize_alias(from_table.alias_or_name)
+                left_alias = _normalize_alias(intersects.this.table)
+                right_alias = _normalize_alias(intersects.expression.table)
+                target_alias = right_alias if left_alias == from_alias else left_alias
+                for join in query.args.get("joins") or []:
+                    if isinstance(join.this, exp.Table):
+                        if _normalize_alias(join.this.alias_or_name) == target_alias:
+                            return intersects, join
 
-        other_table_name = self._find_table_name_for_alias(query, other_alias)
-        other_cols = self._get_columns(other_table_name)
-        join_cols = self._get_columns(join_table_name)
+        return None, None
 
-        other_cte = self._ensure_key_binned(query, other_table_name, key_binned)
-        join_cte = self._ensure_key_binned(query, join_table_name, key_binned)
+    def _build_sql(
+        self,
+        query: exp.Select,
+        intersects: Intersects,
+        sides: "_IEJoinSides",
+        the_join: exp.Join,
+    ) -> str | None:
+        """Render the multi-statement DuckDB IEJoin SQL string for *query*.
 
-        c0 = f"__giql_c{next(connector_counter)}"
-        c1 = f"__giql_c{next(connector_counter)}"
+        Returns ``None`` when a soft-fallback condition fires (the residual
+        of the join carries a shape the binned plan can handle but the
+        dialect cannot inline, or a single-column USING references a column
+        that is not both tables' ``chrom_col``). Raises
+        :class:`_UnqualifiedProjectionError` when a user-mistake condition
+        fires; callers translating to the public surface wrap the raise to
+        :class:`ValueError`.
+        """
+        extras = self._extract_extra_predicates(query, intersects)
+        if extras and self._classify_extras(extras) == "fallback":
+            return None
+        if extras:
+            self._validate_extra_qualifiers(extras, sides)
 
-        join_side = None
-        if preserve_kind:
-            join_side = join.args.get("side")
+        # Tables registry is keyed by the bare table name; an unregistered
+        # table uses default column names like the binned plan does.
+        l_table = self.tables.get(sides.left_table.name)
+        r_table = self.tables.get(sides.right_table.name)
+        l_chrom = l_table.chrom_col if l_table else DEFAULT_CHROM_COL
+        l_start = l_table.start_col if l_table else DEFAULT_START_COL
+        l_end = l_table.end_col if l_table else DEFAULT_END_COL
+        r_chrom = r_table.chrom_col if r_table else DEFAULT_CHROM_COL
+        r_start = r_table.start_col if r_table else DEFAULT_START_COL
+        r_end = r_table.end_col if r_table else DEFAULT_END_COL
 
-        # join1: key-match from other_alias to its bin CTE
-        join1 = exp.Join(
-            this=exp.Table(
-                this=exp.Identifier(this=other_cte),
-                alias=exp.TableAlias(this=exp.Identifier(this=c0)),
-            ),
-            on=exp.And(
-                this=exp.And(
-                    this=exp.EQ(
-                        this=exp.column(other_cols[0], table=other_alias, quoted=True),
-                        expression=exp.column(other_cols[0], table=c0, quoted=True),
-                    ),
-                    expression=exp.EQ(
-                        this=exp.column(other_cols[1], table=other_alias, quoted=True),
-                        expression=exp.column(other_cols[1], table=c0, quoted=True),
-                    ),
-                ),
-                expression=exp.EQ(
-                    this=exp.column(other_cols[2], table=other_alias, quoted=True),
-                    expression=exp.column(other_cols[2], table=c0, quoted=True),
-                ),
-            ),
+        # USING(<col>) admission check (the gate already restricted to
+        # single-column USING). The dialect's per-chromosome partition IS
+        # the equi-join that USING(<chrom_col>) requests; if the USING
+        # column doesn't match both tables' chrom_col (or the chrom_cols
+        # diverge), fall back so the binned plan emits the proper
+        # equi-join.
+        using_cols = the_join.args.get("using") or []
+        if using_cols:
+            using_name = _normalize_alias(using_cols[0].name)
+            if (
+                _normalize_alias(l_chrom) != _normalize_alias(r_chrom)
+                or _normalize_alias(l_chrom) != using_name
+            ):
+                return None
+
+        (
+            inner_projections,
+            outer_projections,
+            projection_map,
+        ) = self._resolve_projections(
+            query,
+            sides,
+            l_table,
+            r_table,
+            (l_chrom, l_start, l_end),
+            (r_chrom, r_start, r_end),
         )
 
-        # join2: bin equi-join (chrom + __giql_bin match)
-        join2_kwargs: dict = {
-            "this": exp.Table(
-                this=exp.Identifier(this=join_cte),
-                alias=exp.TableAlias(this=exp.Identifier(this=c1)),
-            ),
-            "on": exp.And(
-                this=exp.EQ(
-                    this=exp.column(other_cols[0], table=c0, quoted=True),
-                    expression=exp.column(join_cols[0], table=c1, quoted=True),
-                ),
-                expression=exp.EQ(
-                    this=exp.column("__giql_bin", table=c0),
-                    expression=exp.column("__giql_bin", table=c1),
-                ),
-            ),
-        }
-        if join_side:
-            join2_kwargs["side"] = join_side
-        join2 = exp.Join(**join2_kwargs)
+        # Per-call random token (full uuid4 hex = 128 bits) so the SET
+        # VARIABLE name is collision-resistant even across many transpile()
+        # calls interleaved in one DuckDB session. DuckDB session variables
+        # are global session state, so token collision would silently
+        # rebind the wrapper query to a different intersection.
+        token = uuid4().hex
+        var_name = f"__giql_iejoin_{token}"
 
-        # join3: key-match from join CTE back to actual join table + overlap
-        key_match = exp.And(
-            this=exp.And(
-                this=exp.EQ(
-                    this=exp.column(join_cols[0], table=join_alias, quoted=True),
-                    expression=exp.column(join_cols[0], table=c1, quoted=True),
-                ),
-                expression=exp.EQ(
-                    this=exp.column(join_cols[1], table=join_alias, quoted=True),
-                    expression=exp.column(join_cols[1], table=c1, quoted=True),
-                ),
-            ),
-            expression=exp.EQ(
-                this=exp.column(join_cols[2], table=join_alias, quoted=True),
-                expression=exp.column(join_cols[2], table=c1, quoted=True),
-            ),
+        # Canonicalize endpoints to 0-based half-open and use strict
+        # operators. Mixing inclusive operators with raw closed-closed
+        # coordinates would silently report non-overlapping touching
+        # intervals as overlapping.
+        q = self._sql_quote_ident
+        l_start_expr = canonical_start(f"a.{q(l_start)}", l_table)
+        l_end_expr = canonical_end(f"a.{q(l_end)}", l_table)
+        r_start_expr = canonical_start(f"b.{q(r_start)}", r_table)
+        r_end_expr = canonical_end(f"b.{q(r_end)}", r_table)
+
+        # Render each table operand qualified (catalog/db/name) without the
+        # user's alias so the empty-schema fallback can supply its own
+        # ``a``/``b`` alias without producing ``FROM peaks AS a a`` shapes.
+        l_table_ident = self._qualified_table_ident(sides.left_table)
+        r_table_ident = self._qualified_table_ident(sides.right_table)
+
+        # Join keyword switches by ``sides.kind``: SEMI / ANTI engage
+        # DuckDB's IE_JOIN with the corresponding semi/anti semantics; INNER
+        # is the default. (CROSS folded to INNER inside ``_IEJoinSides``.)
+        join_keyword = {
+            "INNER": "JOIN",
+            "SEMI": "SEMI JOIN",
+            "ANTI": "ANTI JOIN",
+        }[sides.kind]
+
+        inner_select_list = ", ".join(inner_projections)
+        per_chrom_select_prefix = f"SELECT {inner_select_list} "
+        from_left = f"FROM (SELECT * FROM {l_table_ident} WHERE {q(l_chrom)} = "
+        from_right_open = (
+            f") a {join_keyword} (SELECT * FROM {r_table_ident} WHERE {q(r_chrom)} = "
         )
-        join3_on = exp.And(
-            this=key_match,
-            expression=self._build_overlap(
-                other_alias, join_alias, other_cols, join_cols
-            ),
+        on_clause_predicates = [
+            f"{l_start_expr} < {r_end_expr}",
+            f"{l_end_expr} > {r_start_expr}",
+        ]
+        for residual in extras:
+            on_clause_predicates.append(
+                self._rewrite_refs_for_per_chrom_subquery(residual, sides)
+            )
+        on_clause = ") b ON " + " AND ".join(on_clause_predicates)
+
+        # The dynamic SQL builder, expressed as a SQL string-concat that
+        # ``string_agg`` aggregates per-chromosome. Single quotes are
+        # doubled because the result is itself an SQL string literal that
+        # contains SQL.
+        chrom_literal = "'''' || replace(chrom, '''', '''''') || ''''"
+
+        esc = self._sql_escape
+        per_chrom_sql_expr = (
+            f"'{esc(per_chrom_select_prefix)}{esc(from_left)}' "
+            f"|| {chrom_literal} "
+            f"|| '{esc(from_right_open)}' "
+            f"|| {chrom_literal} "
+            f"|| '{esc(on_clause)}'"
         )
-        if extra:
-            join3_on = exp.And(this=join3_on, expression=extra)
-        join3_kwargs: dict = {
-            "this": exp.Table(
-                this=exp.Identifier(this=join_table_name),
-                alias=exp.TableAlias(this=exp.Identifier(this=join_alias)),
-            ),
-            "on": join3_on,
-        }
-        if join_side:
-            join3_kwargs["side"] = join_side
 
-        join3 = exp.Join(**join3_kwargs)
+        # Empty-schema fallback when no chromosomes pass the partition
+        # filter. Project from the source tables under WHERE FALSE so
+        # DuckDB resolves every output column to its real declared type.
+        # SEMI / ANTI outputs reference only the left side, so we drop
+        # the right operand from the empty-schema FROM clause.
+        empty_select_list = ", ".join(inner_projections)
+        if sides.is_left_only_join:
+            empty_schema = (
+                f"SELECT {empty_select_list} FROM {l_table_ident} a WHERE FALSE"
+            )
+        else:
+            empty_schema = (
+                f"SELECT {empty_select_list} "
+                f"FROM {l_table_ident} a, {r_table_ident} b WHERE FALSE"
+            )
 
-        return [join1, join2, join3]
+        # Partition source: INTERSECT for INNER / SEMI (a chromosome only
+        # on one side produces no matches anyway), left-distinct for ANTI
+        # (a chromosome present only on the left must still emit its rows
+        # under ANTI semantics).
+        if sides.kind == "ANTI":
+            chrom_partition_subquery = (
+                f"SELECT DISTINCT {q(l_chrom)} AS chrom FROM {l_table_ident}"
+            )
+        else:
+            chrom_partition_subquery = (
+                f"SELECT DISTINCT {q(l_chrom)} AS chrom FROM {l_table_ident} "
+                f"INTERSECT SELECT DISTINCT {q(r_chrom)} AS chrom "
+                f"FROM {r_table_ident}"
+            )
+
+        set_var_stmt = (
+            f"SET VARIABLE {var_name} = COALESCE((\n"
+            f"  SELECT string_agg(\n"
+            f"    {per_chrom_sql_expr},\n"
+            f"    ' UNION ALL '\n"
+            f"  )\n"
+            f"  FROM ({chrom_partition_subquery})\n"
+            f"), '{esc(empty_schema)}')"
+        )
+
+        # Constant wrapper alias — uniqueness is provided by the
+        # token-bearing session variable; the outer SELECT's relation
+        # alias is never user-visible and doesn't need to vary per call.
+        wrapper_alias = "__giql_iejoin_wrapper"
+        outer_projection = ", ".join(outer_projections)
+        distinct_kw = "DISTINCT " if query.args.get("distinct") else ""
+        outer_select_parts = [
+            f"SELECT {distinct_kw}{outer_projection} "
+            f"FROM query(getvariable('{var_name}')) AS {wrapper_alias}"
+        ]
+
+        # The rewriter translates any ``a.col`` / ``b.col`` references in
+        # the GROUP BY / HAVING / ORDER BY clauses to the wrapper
+        # relation's inner-alias column names (``__giql_p<n>``), since
+        # the user's original aliases are not in scope in the outer SELECT.
+        group_node = query.args.get("group")
+        if group_node is not None:
+            outer_select_parts.append(
+                self._rewrite_refs_for_wrapper_relation(
+                    group_node, projection_map, sides, "GROUP BY"
+                )
+            )
+
+        having_node = query.args.get("having")
+        if having_node is not None:
+            outer_select_parts.append(
+                self._rewrite_refs_for_wrapper_relation(
+                    having_node, projection_map, sides, "HAVING"
+                )
+            )
+
+        order_node = query.args.get("order")
+        if order_node is not None:
+            outer_select_parts.append(
+                self._rewrite_refs_for_wrapper_relation(
+                    order_node, projection_map, sides, "ORDER BY"
+                )
+            )
+
+        limit_node = query.args.get("limit")
+        if limit_node is not None:
+            outer_select_parts.append(limit_node.sql(dialect="duckdb"))
+
+        offset_node = query.args.get("offset")
+        if offset_node is not None:
+            outer_select_parts.append(offset_node.sql(dialect="duckdb"))
+
+        outer_select = " ".join(outer_select_parts)
+
+        return set_var_stmt + ";\n" + outer_select
+
+    def _resolve_projections(
+        self,
+        query: exp.Select,
+        sides: "_IEJoinSides",
+        l_table: Table | None,
+        r_table: Table | None,
+        l_cols: tuple[str, str, str],
+        r_cols: tuple[str, str, str],
+    ) -> tuple[list[str], list[str], dict[tuple[str, str], str]]:
+        """Resolve the SELECT list (and any modifier-referenced columns).
+
+        Returns ``(inner_projections, outer_projections, projection_map)``:
+
+        * ``inner_projections`` is the per-chromosome subquery's SELECT
+          list — every column the query touches in any clause, projected
+          once each under a unique ``__giql_p<n>`` alias.
+        * ``outer_projections`` is the outer SELECT's projection list,
+          rendered using the inner aliases (qualified columns, aggregate
+          calls, ``a.*``/``b.*`` expansions including ``strand_col`` when
+          the corresponding :class:`~giql.table.Table` config declares one).
+        * ``projection_map`` binds each ``(normalized_alias, column_name)``
+          referenced anywhere in the query to its inner alias name so the
+          wrapper-relation rewriter and aggregate-argument rewriting can
+          translate user-written references to the wrapper relation.
+
+        Raises :class:`_UnqualifiedProjectionError` for SELECT-list shapes
+        the dialect cannot translate (bare ``*``, unqualified column,
+        unknown table qualifier, ``a.* AS x``, window aggregate, ``FILTER``
+        clause, scalar subquery, arithmetic over an aggregate, aggregate
+        over an unqualified column), and (when ``sides.is_left_only_join``)
+        any reference to the right side of the join.
+        """
+        l_chrom, l_start, l_end = l_cols
+        r_chrom, r_start, r_end = r_cols
+        q = self._sql_quote_ident
+        l_alias = sides.left_user_alias
+        r_alias = sides.right_user_alias
+
+        def star_columns(
+            table: Table | None, defaults: tuple[str, str, str]
+        ) -> tuple[str, ...]:
+            """Expand ``a.*`` / ``b.*`` to the genomic columns declared by
+            the :class:`~giql.table.Table` config (chrom / start / end, plus
+            ``strand_col`` when set). Without this, ``strand_col`` would
+            silently disappear under ``dialect='duckdb'`` even when the
+            user has registered it.
+            """
+            chrom, start, end = defaults
+            if table is not None and table.strand_col:
+                return (chrom, start, end, table.strand_col)
+            return (chrom, start, end)
+
+        inner_projections: list[str] = []
+        projection_map: dict[tuple[str, str], str] = {}
+
+        def reject_right_side_if_left_only(tbl_normalized: str, source_sql: str) -> None:
+            """Raise when a SEMI / ANTI join projects from the right side."""
+            if sides.is_left_only_join and tbl_normalized == r_alias:
+                raise _UnqualifiedProjectionError(
+                    f"dialect='duckdb' with kind={sides.kind!r} only "
+                    f"projects left-side columns; got {source_sql!r} "
+                    f"which references the right side "
+                    f"({sides.right_user_alias!r})."
+                )
+
+        def allocate(tbl: str, col: str) -> str:
+            """Return the inner alias for ``(tbl, col)``, allocating if new.
+
+            Allocation order is deterministic per query but depends on
+            (a) the fixed pre-walk order in :meth:`_resolve_projections` —
+            modifier columns first (``("group", "having", "order")``),
+            then aggregate-argument columns, then the SELECT list — and
+            (b) sqlglot's ``find_all`` traversal order within each
+            sub-clause. Tests therefore should NOT couple to a specific
+            ``__giql_p<n>`` ↔ source-column mapping (e.g.
+            ``assert projection_map[(a, start)] == "__giql_p3"``).
+            """
+            tbl = _normalize_alias(tbl)
+            key = (tbl, col)
+            existing = projection_map.get(key)
+            if existing is not None:
+                return existing
+            if tbl == l_alias:
+                side = sides.left_inner_alias
+            elif tbl == r_alias:
+                side = sides.right_inner_alias
+            else:
+                raise _UnqualifiedProjectionError(
+                    f"Unknown table qualifier {tbl!r} in projection; "
+                    f"expected {l_alias!r} or {r_alias!r}."
+                )
+            alias = f"__giql_p{len(inner_projections)}"
+            inner_projections.append(f"{side}.{q(col)} AS {alias}")
+            projection_map[key] = alias
+            return alias
+
+        def render_aggregate(agg_node: exp.Expression, user_alias: str | None) -> None:
+            """Validate aggregate-argument qualifiers and emit the outer projection."""
+            for col in agg_node.find_all(exp.Column):
+                col_table = _normalize_alias(col.table) if col.table else ""
+                if col_table not in (l_alias, r_alias):
+                    raise _UnqualifiedProjectionError(
+                        "dialect='duckdb' requires qualified aggregate "
+                        f"arguments; got {agg_node.sql()!r}. Use a "
+                        "qualified column reference like "
+                        f"'{type(agg_node).__name__.upper()}(a.col)' or "
+                        f"'{type(agg_node).__name__.upper()}(b.col)'."
+                    )
+                reject_right_side_if_left_only(col_table, agg_node.sql())
+            rewritten_agg = self._rewrite_refs_for_wrapper_relation(
+                agg_node, projection_map, sides, "aggregate argument"
+            )
+            outer_name = (
+                user_alias
+                if user_alias is not None
+                else f"__giql_agg_{len(outer_projections)}"
+            )
+            outer_projections.append(f"{rewritten_agg} AS {q(outer_name)}")
+
+        # Pre-allocate inner aliases for every column referenced in
+        # GROUP BY / HAVING / ORDER BY so the wrapper relation exposes
+        # them even if the user didn't put them in the SELECT list.
+        for clause_key in ("group", "having", "order"):
+            modifier_node = query.args.get(clause_key)
+            if modifier_node is None:
+                continue
+            for col in modifier_node.find_all(exp.Column):
+                col_table = _normalize_alias(col.table) if col.table else ""
+                if col_table in (l_alias, r_alias):
+                    reject_right_side_if_left_only(col_table, col.sql())
+                    allocate(col_table, col.name)
+
+        # Pre-allocate inner aliases for columns referenced inside any
+        # aggregate function in the SELECT list (we'll rewrite the
+        # aggregate's argument to use the inner alias when rendering the
+        # outer projection below). Peel any ``exp.Paren`` wrapper first
+        # so a paren-wrapped aggregate like ``(SUM(a.score)) AS s`` is
+        # treated identically to its bare form.
+        for sel in query.expressions:
+            target = sel.this if isinstance(sel, exp.Alias) else sel
+            while isinstance(target, exp.Paren):
+                target = target.this
+            if isinstance(target, exp.AggFunc):
+                for col in target.find_all(exp.Column):
+                    col_table = _normalize_alias(col.table) if col.table else ""
+                    if col_table in (l_alias, r_alias):
+                        reject_right_side_if_left_only(col_table, col.sql())
+                        allocate(col_table, col.name)
+
+        outer_projections: list[str] = []
+
+        for sel in query.expressions:
+            target = sel.this if isinstance(sel, exp.Alias) else sel
+            user_alias = sel.alias if isinstance(sel, exp.Alias) else None
+            # Peel paren wrappers at the top of dispatch so paren-wrapped
+            # aggregates like ``(SUM(a.score)) AS s`` route through the
+            # AggFunc branch below, and paren-wrapped diagnostic shapes
+            # (``(SUM(a.score) OVER (...))``) hit the targeted error
+            # branches below rather than the generic catch-all.
+            while isinstance(target, exp.Paren):
+                target = target.this
+
+            if isinstance(target, exp.Star) and not isinstance(sel, exp.Column):
+                raise _UnqualifiedProjectionError(
+                    "dialect='duckdb' requires qualified projections; bare '*' "
+                    "is not supported. Use 'a.*', 'b.*', or qualified columns."
+                )
+
+            if isinstance(target, exp.Column) and isinstance(target.this, exp.Star):
+                # Reject ``a.* AS x`` — most SQL engines reject
+                # star-with-alias outright, and the dialect has no
+                # reasonable interpretation (apply ``x`` as a prefix?
+                # as a single composite column name?).
+                if user_alias is not None:
+                    raise _UnqualifiedProjectionError(
+                        "dialect='duckdb' does not support star projections "
+                        f"with a user alias; got {sel.sql()!r}. Either drop "
+                        "the alias (use ``a.*``) or list the columns "
+                        "explicitly with per-column aliases."
+                    )
+                tbl = _normalize_alias(target.table) if target.table else ""
+                if tbl == l_alias:
+                    cols = star_columns(l_table, (l_chrom, l_start, l_end))
+                elif tbl == r_alias:
+                    cols = star_columns(r_table, (r_chrom, r_start, r_end))
+                else:
+                    raise _UnqualifiedProjectionError(
+                        f"Unknown table qualifier {target.table!r} in projection; "
+                        f"expected {l_alias!r} or {r_alias!r}."
+                    )
+                reject_right_side_if_left_only(tbl, sel.sql())
+                # Expand to the genomic columns the Table config knows
+                # about; arbitrary additional columns require explicit
+                # listing since schema introspection isn't available at
+                # transpile time.
+                for col in cols:
+                    alias = allocate(tbl, col)
+                    outer_projections.append(f"{alias} AS {q(col)}")
+                continue
+
+            if isinstance(target, exp.AggFunc):
+                render_aggregate(target, user_alias)
+                continue
+
+            if isinstance(target, exp.Column) and target.table:
+                tbl = _normalize_alias(target.table)
+                reject_right_side_if_left_only(tbl, target.sql())
+                col = target.name
+                alias = allocate(tbl, col)
+                outer_name = user_alias if user_alias is not None else col
+                outer_projections.append(f"{alias} AS {q(outer_name)}")
+                continue
+
+            # Diagnostic branches for shapes the dialect deliberately
+            # rejects. Specialize the error message when we can recognize
+            # the unsupported shape so the user isn't told "use a
+            # qualified column" when they actually wrote an aggregate
+            # variant the dispatcher couldn't classify. Direct-isinstance
+            # branches catch bare shapes; the ``target.find(...)`` branches
+            # below catch nested forms (``CAST(SUM(a.x) OVER (...) AS
+            # DOUBLE)`` etc.) before they fall through to the generic
+            # AggFunc-found catch-all.
+            if isinstance(target, exp.Window):
+                raise _UnqualifiedProjectionError(
+                    "dialect='duckdb' does not support window aggregates "
+                    f"in the SELECT list; got {target.sql()!r}. Either "
+                    "drop the OVER (...) clause, or omit dialect='duckdb' "
+                    "to use the binned plan."
+                )
+            if isinstance(target, exp.Filter):
+                raise _UnqualifiedProjectionError(
+                    "dialect='duckdb' does not support FILTER (WHERE ...) "
+                    f"clauses on aggregates; got {target.sql()!r}. Either "
+                    "rewrite the FILTER as a WHERE predicate alongside "
+                    "the INTERSECTS, or omit dialect='duckdb'."
+                )
+            if isinstance(target, exp.Subquery):
+                # A scalar subquery in the SELECT list (e.g.
+                # ``(SELECT SUM(x) FROM other_table)``) is shaped like an
+                # aggregate but doesn't fit the dialect's projection rules.
+                raise _UnqualifiedProjectionError(
+                    "dialect='duckdb' does not support scalar subqueries in "
+                    f"the SELECT list; got {target.sql()!r}. Either rewrite "
+                    "without the subquery, or omit dialect='duckdb' to use "
+                    "the binned plan."
+                )
+            if target.find(exp.Window) is not None:
+                raise _UnqualifiedProjectionError(
+                    "dialect='duckdb' does not support window aggregates "
+                    f"in the SELECT list; got {target.sql()!r}. Either "
+                    "drop the OVER (...) clause, or omit dialect='duckdb' "
+                    "to use the binned plan."
+                )
+            if target.find(exp.Filter) is not None:
+                raise _UnqualifiedProjectionError(
+                    "dialect='duckdb' does not support FILTER (WHERE ...) "
+                    f"clauses on aggregates; got {target.sql()!r}. Either "
+                    "rewrite the FILTER as a WHERE predicate alongside "
+                    "the INTERSECTS, or omit dialect='duckdb'."
+                )
+            if target.find(exp.AggFunc) is not None:
+                raise _UnqualifiedProjectionError(
+                    "dialect='duckdb' does not support aggregates inside "
+                    f"arithmetic or function expressions; got {target.sql()!r}. "
+                    "Project the underlying aggregate as its own column and "
+                    "do the arithmetic in a wrapping query, or omit "
+                    "dialect='duckdb'."
+                )
+            raise _UnqualifiedProjectionError(
+                "dialect='duckdb' requires qualified projections; got "
+                f"{target.sql()!r}. Use a qualified column reference like "
+                "'a.col' or 'b.col [AS x]'."
+            )
+
+        if not outer_projections:
+            raise _UnqualifiedProjectionError(
+                "dialect='duckdb' requires at least one qualified projection."
+            )
+
+        # An aggregate without any source-column argument (e.g.
+        # ``COUNT(*)``) leaves ``inner_projections`` empty in queries that
+        # have no other column references. The per-chromosome subquery
+        # still needs at least one column to project, so emit a constant
+        # placeholder that DuckDB optimizes away. (Without this the
+        # generated SQL ``SELECT  FROM (...) a JOIN (...) b ON ...`` would
+        # fail to parse.)
+        if not inner_projections:
+            inner_projections.append("1 AS __giql_placeholder")
+
+        return inner_projections, outer_projections, projection_map

--- a/src/giql/transpile.py
+++ b/src/giql/transpile.py
@@ -4,6 +4,11 @@ This module provides the main entry point for transpiling GIQL queries
 to standard SQL.
 """
 
+from contextlib import contextmanager
+from typing import Iterator
+from typing import Literal
+from typing import overload
+
 from sqlglot import parse_one
 
 from giql.dialect import GIQLDialect
@@ -12,41 +17,35 @@ from giql.table import Table
 from giql.table import Tables
 from giql.transformer import ClusterTransformer
 from giql.transformer import IntersectsBinnedJoinTransformer
+from giql.transformer import IntersectsDuckDBIEJoinTransformer
 from giql.transformer import MergeTransformer
 
 
-def _build_tables(tables: list[str | Table] | None) -> Tables:
-    """Build a Tables container from table specifications.
+@overload
+def transpile(
+    giql: str,
+    tables: list[str | Table] | None = None,
+    *,
+    dialect: None = None,
+    intersects_bin_size: int | None = None,
+) -> str: ...
 
-    Parameters
-    ----------
-    tables : list[str | Table] | None
-        Table specifications. Strings use default column mappings.
-        Table objects provide custom column mappings.
 
-    Returns
-    -------
-    Tables
-        Container with all tables registered.
-    """
-    container = Tables()
-
-    if tables is None:
-        return container
-
-    for item in tables:
-        if isinstance(item, str):
-            container.register(item, Table(item))
-        else:
-            container.register(item.name, item)
-
-    return container
+@overload
+def transpile(
+    giql: str,
+    tables: list[str | Table] | None = None,
+    *,
+    dialect: Literal["duckdb"],
+    intersects_bin_size: None = None,
+) -> str: ...
 
 
 def transpile(
     giql: str,
     tables: list[str | Table] | None = None,
     *,
+    dialect: Literal["duckdb"] | None = None,
     intersects_bin_size: int | None = None,
 ) -> str:
     """Transpile a GIQL query to SQL.
@@ -59,15 +58,26 @@ def transpile(
     giql : str
         The GIQL query string containing genomic extensions like
         INTERSECTS, CONTAINS, WITHIN, CLUSTER, MERGE, NEAREST, or DISJOIN.
-    tables : list[str | Table] | None
+    tables : list[str | :class:`Table`] | None
         Table configurations. Strings use default column mappings
-        (chrom, start, end, strand). Table objects provide custom
-        column name mappings.
+        (chrom, start, end, strand). :class:`Table` objects provide
+        custom column name mappings.
+    dialect : Literal["duckdb"] | None
+        Optional target dialect. When set to ``"duckdb"``, column-to-column
+        ``INTERSECTS`` joins (INNER, SEMI, or ANTI) are transpiled into a
+        per-chromosome dynamic-SQL pattern (``SET VARIABLE`` +
+        ``query(getvariable(...))``) that DuckDB plans through its
+        range-join family (``IE_JOIN`` / ``PIECEWISE_MERGE_JOIN``).
+        Mutually exclusive with ``intersects_bin_size``. Defaults to
+        ``None`` (the generic binned equi-join path). Hard-error projection
+        shapes raise ``ValueError`` at transpile time; see the performance
+        guide for the full enumeration.
     intersects_bin_size : int | None
         Bin size for INTERSECTS equi-join optimization. When a query
         contains a full-table column-to-column INTERSECTS join, the
         transpiler rewrites it as a binned equi-join for performance.
-        Defaults to 10,000 if not specified.
+        Defaults to 10,000 if not specified. Cannot be combined with
+        ``dialect="duckdb"``.
 
     Returns
     -------
@@ -77,7 +87,9 @@ def transpile(
     Raises
     ------
     ValueError
-        If the query cannot be parsed or transpiled.
+        If the query cannot be parsed or transpiled, if ``dialect`` is
+        unknown, or if ``dialect="duckdb"`` and ``intersects_bin_size``
+        are both set.
 
     Examples
     --------
@@ -88,7 +100,7 @@ def transpile(
             tables=["peaks"],
         )
 
-    Custom table configuration::
+    Custom :class:`Table` configuration::
 
         sql = transpile(
             "SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1000-2000'",
@@ -111,41 +123,105 @@ def transpile(
             tables=["peaks", "genes"],
             intersects_bin_size=100000,
         )
+
+    DuckDB IEJoin dialect (column-to-column INNER/SEMI/ANTI JOIN only;
+    projections must be qualified)::
+
+        sql = transpile(
+            "SELECT a.chrom, a.start, b.start "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
     """
-    # Build tables container
+    if dialect is not None and dialect != "duckdb":
+        raise ValueError(f"Unknown dialect: {dialect!r}. Supported: 'duckdb' or None.")
+    if dialect == "duckdb" and intersects_bin_size is not None:
+        raise ValueError(
+            "intersects_bin_size has no effect with dialect='duckdb'; "
+            "the DuckDB dialect uses an IEJoin per-partition plan instead "
+            "of the binned equi-join. Pass one or the other, not both."
+        )
+
     tables_container = _build_tables(tables)
 
-    # Initialize transformers with table configurations
+    with _reraise_as_value_error("Parse error", query=giql):
+        ast = parse_one(giql, dialect=GIQLDialect)
+
+    # Falls back to the binned plan for unsupported shapes — see
+    # IntersectsDuckDBIEJoinTransformer.transform_to_sql for the complete
+    # fallback set.
+    if dialect == "duckdb":
+        duckdb_transformer = IntersectsDuckDBIEJoinTransformer(tables_container)
+        with _reraise_as_value_error("Transformation error"):
+            duckdb_sql = duckdb_transformer.transform_to_sql(ast)
+        if duckdb_sql is not None:
+            return duckdb_sql
+
     intersects_transformer = IntersectsBinnedJoinTransformer(
         tables_container,
         bin_size=intersects_bin_size,
     )
     merge_transformer = MergeTransformer(tables_container)
     cluster_transformer = ClusterTransformer(tables_container)
-
-    # Initialize generator with table configurations
     generator = BaseGIQLGenerator(tables=tables_container)
 
-    # Parse GIQL query
-    try:
-        ast = parse_one(giql, dialect=GIQLDialect)
-    except Exception as e:
-        raise ValueError(f"Parse error: {e}\nQuery: {giql}") from e
-
-    # Apply transformations
-    try:
+    with _reraise_as_value_error("Transformation error"):
         ast = intersects_transformer.transform(ast)
-        # MERGE transformation (which may internally use CLUSTER)
         ast = merge_transformer.transform(ast)
-        # CLUSTER transformation for any standalone CLUSTER expressions
         ast = cluster_transformer.transform(ast)
-    except Exception as e:
-        raise ValueError(f"Transformation error: {e}") from e
 
-    # Generate SQL
-    try:
+    with _reraise_as_value_error("Transpilation error"):
         sql = generator.generate(ast)
-    except Exception as e:
-        raise ValueError(f"Transpilation error: {e}") from e
 
     return sql
+
+
+def _build_tables(tables: list[str | Table] | None) -> Tables:
+    """Build a :class:`Tables` container from table specifications.
+
+    Parameters
+    ----------
+    tables : list[str | :class:`Table`] | None
+        Table specifications. Strings use default column mappings.
+        :class:`Table` objects provide custom column mappings.
+
+    Returns
+    -------
+    Tables
+        Container with all tables registered.
+    """
+    container = Tables()
+
+    if tables is None:
+        return container
+
+    for item in tables:
+        if isinstance(item, str):
+            container.register(item, Table(item))
+        else:
+            container.register(item.name, item)
+
+    return container
+
+
+@contextmanager
+def _reraise_as_value_error(prefix: str, query: str | None = None) -> Iterator[None]:
+    """Re-raise non-:class:`ValueError` exceptions as :class:`ValueError` with *prefix*.
+
+    Lets user-facing :class:`ValueError`\\s from the parser, transformer chain,
+    and generator propagate verbatim (so the dialect's targeted error messages
+    survive the boundary) while wrapping unexpected exceptions in a uniform
+    :class:`ValueError` prefixed with the stage name. When *query* is supplied,
+    the original input is appended to the message so parse errors retain the
+    offending text.
+    """
+    try:
+        yield
+    except ValueError:
+        raise
+    except Exception as e:
+        msg = f"{prefix}: {e}"
+        if query is not None:
+            msg += f"\nQuery: {query}"
+        raise ValueError(msg) from e

--- a/tests/test_canonical.py
+++ b/tests/test_canonical.py
@@ -1,0 +1,512 @@
+"""Unit tests for ``giql.canonical`` coordinate canonicalization helpers.
+
+These tests pin down the externally observable contract of
+:func:`giql.canonical.canonical_start` / :func:`giql.canonical.canonical_end`
+and their inverses :func:`giql.canonical.decanonical_start` /
+:func:`giql.canonical.decanonical_end` — pure functions that wrap a raw
+column reference with the offset required to convert between a source
+:class:`giql.table.Table`'s declared encoding and the canonical 0-based
+half-open form the transpiler emits.
+"""
+
+import pytest
+
+from giql.canonical import canonical_end
+from giql.canonical import canonical_start
+from giql.canonical import decanonical_end
+from giql.canonical import decanonical_start
+from giql.table import Table
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given  # noqa: E402
+from hypothesis import settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+def test_canonical_start_should_return_input_unchanged_when_table_is_none():
+    """Test that a missing table leaves the start expression untouched.
+
+    Given:
+        A raw start expression and ``table=None``.
+    When:
+        ``canonical_start(raw, None)`` is called.
+    Then:
+        It should return the original raw expression unchanged.
+    """
+    # Arrange
+    raw = "a.start"
+
+    # Act
+    result = canonical_start(raw, None)
+
+    # Assert
+    assert result == raw
+
+
+def test_canonical_start_should_return_input_unchanged_when_table_is_zero_based():
+    """Test that a 0-based table leaves the start expression untouched.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="0based"``.
+    When:
+        ``canonical_start(raw, table)`` is called.
+    Then:
+        It should return ``raw`` unchanged because the source already
+        uses the canonical 0-based start convention.
+    """
+    # Arrange
+    raw = "a.start"
+    table = Table(name="features", coordinate_system="0based")
+
+    # Act
+    result = canonical_start(raw, table)
+
+    # Assert
+    assert result == raw
+
+
+def test_canonical_start_should_subtract_one_when_table_is_one_based():
+    """Test that a 1-based table subtracts one from the start expression.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="1based"``.
+    When:
+        ``canonical_start(raw, table)`` is called.
+    Then:
+        It should return ``f"({raw} - 1)"`` so the canonical 0-based
+        half-open form is emitted downstream.
+    """
+    # Arrange
+    raw = "a.start"
+    table = Table(name="features", coordinate_system="1based")
+
+    # Act
+    result = canonical_start(raw, table)
+
+    # Assert
+    assert result == f"({raw} - 1)"
+
+
+def test_canonical_end_should_return_input_unchanged_when_table_is_none():
+    """Test that a missing table leaves the end expression untouched.
+
+    Given:
+        A raw end expression and ``table=None``.
+    When:
+        ``canonical_end(raw, None)`` is called.
+    Then:
+        It should return the original raw expression unchanged.
+    """
+    # Arrange
+    raw = "a.end"
+
+    # Act
+    result = canonical_end(raw, None)
+
+    # Assert
+    assert result == raw
+
+
+def test_canonical_end_should_return_input_unchanged_when_table_is_zero_based_half_open():
+    """Test that 0-based half-open tables leave the end expression untouched.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="0based"``
+        and ``interval_type="half_open"``.
+    When:
+        ``canonical_end(raw, table)`` is called.
+    Then:
+        It should return ``raw`` unchanged because the source already
+        matches the canonical convention.
+    """
+    # Arrange
+    raw = "a.end"
+    table = Table(
+        name="features",
+        coordinate_system="0based",
+        interval_type="half_open",
+    )
+
+    # Act
+    result = canonical_end(raw, table)
+
+    # Assert
+    assert result == raw
+
+
+def test_canonical_end_should_add_one_when_table_is_zero_based_closed():
+    """Test that 0-based closed tables add one to the end expression.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="0based"``
+        and ``interval_type="closed"``.
+    When:
+        ``canonical_end(raw, table)`` is called.
+    Then:
+        It should return ``f"({raw} + 1)"`` to convert closed to
+        half-open.
+    """
+    # Arrange
+    raw = "a.end"
+    table = Table(
+        name="features",
+        coordinate_system="0based",
+        interval_type="closed",
+    )
+
+    # Act
+    result = canonical_end(raw, table)
+
+    # Assert
+    assert result == f"({raw} + 1)"
+
+
+def test_canonical_end_should_subtract_one_when_table_is_one_based_half_open():
+    """Test that 1-based half-open tables subtract one from the end expression.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="1based"``
+        and ``interval_type="half_open"``.
+    When:
+        ``canonical_end(raw, table)`` is called.
+    Then:
+        It should return ``f"({raw} - 1)"`` to convert 1-based
+        half-open to canonical 0-based half-open.
+    """
+    # Arrange
+    raw = "a.end"
+    table = Table(
+        name="features",
+        coordinate_system="1based",
+        interval_type="half_open",
+    )
+
+    # Act
+    result = canonical_end(raw, table)
+
+    # Assert
+    assert result == f"({raw} - 1)"
+
+
+def test_canonical_end_should_return_input_unchanged_when_table_is_one_based_closed():
+    """Test that 1-based closed tables leave the end expression untouched.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="1based"``
+        and ``interval_type="closed"``.
+    When:
+        ``canonical_end(raw, table)`` is called.
+    Then:
+        It should return ``raw`` unchanged because a 1-based closed
+        end equals a 0-based half-open end numerically.
+    """
+    # Arrange
+    raw = "a.end"
+    table = Table(
+        name="features",
+        coordinate_system="1based",
+        interval_type="closed",
+    )
+
+    # Act
+    result = canonical_end(raw, table)
+
+    # Assert
+    assert result == raw
+
+
+@settings(max_examples=100, deadline=None)
+@given(
+    raw=st.text(
+        alphabet=st.characters(min_codepoint=0x20, max_codepoint=0x7E),
+        min_size=1,
+        max_size=20,
+    ),
+    coord_system=st.sampled_from(["0based", "1based"]),
+    interval_type=st.sampled_from(["half_open", "closed"]),
+)
+def test_canonical_end_should_return_one_of_three_documented_forms(
+    raw, coord_system, interval_type
+):
+    """Test that canonical_end output matches one of three documented shapes.
+
+    Given:
+        A Hypothesis-generated raw column reference (ASCII-printable
+        text of length 1..20) and a sampled
+        ``(coordinate_system, interval_type)`` enum pair drawn from
+        the four allowed combinations.
+    When:
+        ``canonical_end(raw, Table(...))`` is called.
+    Then:
+        It should return exactly one of ``raw``, ``f"({raw} + 1)"``,
+        or ``f"({raw} - 1)"`` — no other shape is ever produced.
+    """
+    # Arrange
+    table = Table(
+        name="features",
+        coordinate_system=coord_system,
+        interval_type=interval_type,
+    )
+    allowed = {raw, f"({raw} + 1)", f"({raw} - 1)"}
+
+    # Act
+    result = canonical_end(raw, table)
+
+    # Assert
+    assert result in allowed
+
+
+def test_decanonical_start_should_return_input_unchanged_when_table_is_none():
+    """Test that a missing table leaves the canonical start untouched.
+
+    Given:
+        A canonical 0-based start expression and ``table=None``.
+    When:
+        ``decanonical_start(canon, None)`` is called.
+    Then:
+        It should return the canonical expression unchanged.
+    """
+    # Arrange
+    canon = "a.start"
+
+    # Act
+    result = decanonical_start(canon, None)
+
+    # Assert
+    assert result == canon
+
+
+def test_decanonical_start_should_return_input_unchanged_when_table_is_zero_based():
+    """Test that a 0-based table leaves the canonical start untouched.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="0based"``.
+    When:
+        ``decanonical_start(canon, table)`` is called.
+    Then:
+        It should return ``canon`` unchanged because the canonical
+        form already matches the source convention.
+    """
+    # Arrange
+    canon = "a.start"
+    table = Table(name="features", coordinate_system="0based")
+
+    # Act
+    result = decanonical_start(canon, table)
+
+    # Assert
+    assert result == canon
+
+
+def test_decanonical_start_should_add_one_when_table_is_one_based():
+    """Test that a 1-based table adds one to the canonical start.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="1based"``.
+    When:
+        ``decanonical_start(canon, table)`` is called.
+    Then:
+        It should return ``f"({canon} + 1)"`` so the value lands back
+        in the table's 1-based encoding.
+    """
+    # Arrange
+    canon = "(a.start - 1)"
+    table = Table(name="features", coordinate_system="1based")
+
+    # Act
+    result = decanonical_start(canon, table)
+
+    # Assert
+    assert result == f"({canon} + 1)"
+
+
+@settings(max_examples=100, deadline=None)
+@given(
+    x=st.integers(min_value=0, max_value=10**9),
+    coord_system=st.sampled_from(["0based", "1based"]),
+)
+def test_decanonical_start_should_invert_canonical_start_numerically(x, coord_system):
+    """Test that decanonical_start is the numeric inverse of canonical_start.
+
+    Given:
+        A Hypothesis-generated integer start coordinate and a sampled
+        ``coordinate_system``.
+    When:
+        ``decanonical_start(canonical_start(str(x), table), table)`` is
+        evaluated as a Python expression.
+    Then:
+        It should evaluate back to ``x`` — the two helpers are exact
+        inverses across the full coordinate-system enum.
+    """
+    # Arrange
+    table = Table(name="features", coordinate_system=coord_system)
+
+    # Act
+    composed = decanonical_start(canonical_start(str(x), table), table)
+
+    # Assert
+    assert eval(composed) == x
+
+
+def test_decanonical_end_should_return_input_unchanged_when_table_is_none():
+    """Test that a missing table leaves the canonical end untouched.
+
+    Given:
+        A canonical 0-based half-open end expression and ``table=None``.
+    When:
+        ``decanonical_end(canon, None)`` is called.
+    Then:
+        It should return the canonical expression unchanged.
+    """
+    # Arrange
+    canon = "a.end"
+
+    # Act
+    result = decanonical_end(canon, None)
+
+    # Assert
+    assert result == canon
+
+
+def test_decanonical_end_should_return_input_unchanged_when_table_is_zero_based_half_open():
+    """Test that 0-based half-open tables leave the canonical end untouched.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="0based"``
+        and ``interval_type="half_open"``.
+    When:
+        ``decanonical_end(canon, table)`` is called.
+    Then:
+        It should return ``canon`` unchanged because the canonical
+        form already matches the source convention.
+    """
+    # Arrange
+    canon = "a.end"
+    table = Table(
+        name="features",
+        coordinate_system="0based",
+        interval_type="half_open",
+    )
+
+    # Act
+    result = decanonical_end(canon, table)
+
+    # Assert
+    assert result == canon
+
+
+def test_decanonical_end_should_subtract_one_when_table_is_zero_based_closed():
+    """Test that 0-based closed tables subtract one from the canonical end.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="0based"``
+        and ``interval_type="closed"``.
+    When:
+        ``decanonical_end(canon, table)`` is called.
+    Then:
+        It should return ``f"({canon} - 1)"`` to convert canonical
+        half-open back to the source's closed form.
+    """
+    # Arrange
+    canon = "(a.end + 1)"
+    table = Table(
+        name="features",
+        coordinate_system="0based",
+        interval_type="closed",
+    )
+
+    # Act
+    result = decanonical_end(canon, table)
+
+    # Assert
+    assert result == f"({canon} - 1)"
+
+
+def test_decanonical_end_should_add_one_when_table_is_one_based_half_open():
+    """Test that 1-based half-open tables add one to the canonical end.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="1based"``
+        and ``interval_type="half_open"``.
+    When:
+        ``decanonical_end(canon, table)`` is called.
+    Then:
+        It should return ``f"({canon} + 1)"`` to convert canonical
+        half-open back to the source's 1-based half-open form.
+    """
+    # Arrange
+    canon = "(a.end - 1)"
+    table = Table(
+        name="features",
+        coordinate_system="1based",
+        interval_type="half_open",
+    )
+
+    # Act
+    result = decanonical_end(canon, table)
+
+    # Assert
+    assert result == f"({canon} + 1)"
+
+
+def test_decanonical_end_should_return_input_unchanged_when_table_is_one_based_closed():
+    """Test that 1-based closed tables leave the canonical end untouched.
+
+    Given:
+        A :class:`giql.table.Table` with ``coordinate_system="1based"``
+        and ``interval_type="closed"``.
+    When:
+        ``decanonical_end(canon, table)`` is called.
+    Then:
+        It should return ``canon`` unchanged because a 1-based closed
+        end equals a canonical 0-based half-open end numerically.
+    """
+    # Arrange
+    canon = "a.end"
+    table = Table(
+        name="features",
+        coordinate_system="1based",
+        interval_type="closed",
+    )
+
+    # Act
+    result = decanonical_end(canon, table)
+
+    # Assert
+    assert result == canon
+
+
+@settings(max_examples=100, deadline=None)
+@given(
+    x=st.integers(min_value=1, max_value=10**9),
+    coord_system=st.sampled_from(["0based", "1based"]),
+    interval_type=st.sampled_from(["half_open", "closed"]),
+)
+def test_decanonical_end_should_invert_canonical_end_numerically(
+    x, coord_system, interval_type
+):
+    """Test that decanonical_end is the numeric inverse of canonical_end.
+
+    Given:
+        A Hypothesis-generated integer end coordinate and a sampled
+        ``(coordinate_system, interval_type)`` pair drawn from the
+        four allowed combinations.
+    When:
+        ``decanonical_end(canonical_end(str(x), table), table)`` is
+        evaluated as a Python expression.
+    Then:
+        It should evaluate back to ``x`` — the two helpers are exact
+        inverses across the full enum cross-product.
+    """
+    # Arrange
+    table = Table(
+        name="features",
+        coordinate_system=coord_system,
+        interval_type=interval_type,
+    )
+
+    # Act
+    composed = decanonical_end(canonical_end(str(x), table), table)
+
+    # Assert
+    assert eval(composed) == x

--- a/tests/test_duckdb_iejoin.py
+++ b/tests/test_duckdb_iejoin.py
@@ -1,0 +1,5580 @@
+"""Tests for the DuckDB IEJoin dialect path on column-to-column INTERSECTS joins."""
+
+import re
+
+import pytest
+
+from giql import Table
+from giql import transpile
+
+duckdb = pytest.importorskip("duckdb")
+hypothesis = pytest.importorskip("hypothesis")
+
+from hypothesis import HealthCheck  # noqa: E402
+from hypothesis import given  # noqa: E402
+from hypothesis import settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+def _make_table(conn, name: str, rows: list[tuple]) -> None:
+    conn.execute(f"""
+        CREATE TABLE {name} (
+            chrom VARCHAR,
+            "start" INTEGER,
+            "end" INTEGER,
+            name VARCHAR,
+            score INTEGER,
+            strand VARCHAR
+        )
+    """)
+    if rows:
+        conn.executemany(f"INSERT INTO {name} VALUES (?, ?, ?, ?, ?, ?)", rows)
+
+
+def _python_overlap(peaks: list[tuple], genes: list[tuple]) -> list[tuple]:
+    """Reference half-open overlap on (chrom, start, end) triples.
+
+    Returns a *sorted multiset* (list) so the caller can assert exact row
+    multiplicity — a `set` would collapse duplicate input rows and hide
+    multiplicity bugs in the dialect's rewrite.
+    """
+    out: list[tuple] = []
+    for pc, ps, pe in peaks:
+        for gc, gs, ge in genes:
+            if pc == gc and pe > gs and ge > ps:
+                out.append((pc, ps, pe, gc, gs, ge))
+    return sorted(out)
+
+
+def _python_semi_overlap(peaks: list[tuple], genes: list[tuple]) -> list[tuple]:
+    """Reference SEMI-join overlap: distinct left rows with any match."""
+    matched: set[tuple] = set()
+    for pc, ps, pe in peaks:
+        for gc, gs, ge in genes:
+            if pc == gc and pe > gs and ge > ps:
+                matched.add((pc, ps, pe))
+                break
+    return sorted(matched)
+
+
+def _python_anti_overlap(peaks: list[tuple], genes: list[tuple]) -> list[tuple]:
+    """Reference ANTI-join overlap: distinct left rows with no match."""
+    matched = set(_python_semi_overlap(peaks, genes))
+    return sorted({(pc, ps, pe) for (pc, ps, pe) in peaks} - matched)
+
+
+@pytest.fixture
+def conn():
+    c = duckdb.connect(":memory:")
+    yield c
+    c.close()
+
+
+@pytest.fixture
+def peaks_genes(conn):
+    _make_table(
+        conn,
+        "peaks",
+        [
+            ("chr1", 100, 200, "p1", 10, "+"),
+            ("chr1", 300, 400, "p2", 20, "+"),
+            ("chr1", 500, 600, "p3", 25, "+"),
+            ("chr2", 100, 200, "p4", 30, "-"),
+            ("chr2", 800, 900, "p5", 35, "-"),
+        ],
+    )
+    _make_table(
+        conn,
+        "genes",
+        [
+            ("chr1", 150, 250, "g1", 1, "+"),
+            ("chr1", 500, 600, "g2", 2, "-"),
+            ("chr1", 700, 800, "g3", 3, "+"),
+            ("chr2", 50, 150, "g4", 4, "-"),
+            ("chr2", 250, 350, "g5", 5, "+"),
+        ],
+    )
+    return conn
+
+
+# Truth table for peaks_genes overlapping pairs (half-open):
+# - chr1: peaks[100,200) vs genes[150,250) -> overlap
+# - chr1: peaks[500,600) vs genes[500,600) -> overlap
+# - chr2: peaks[100,200) vs genes[50,150)  -> overlap
+_EXPECTED_OVERLAPS_PEAKS_GENES = [
+    ("chr1", 100, 200, "chr1", 150, 250),
+    ("chr1", 500, 600, "chr1", 500, 600),
+    ("chr2", 100, 200, "chr2", 50, 150),
+]
+
+
+class TestTranspileDuckDBIEJoinSQLStructure:
+    """SQL-shape and routing assertions for the DuckDB IEJoin dialect path."""
+
+    def test_transpile_should_keep_binned_path_when_dialect_is_none(self):
+        """Test that omitting ``dialect`` keeps the generic binned plan.
+
+        Given:
+            A column-to-column INTERSECTS JOIN.
+        When:
+            ``transpile`` is called without specifying ``dialect``.
+        Then:
+            It should emit SQL that contains no ``SET VARIABLE`` /
+            ``getvariable`` scaffolding (the IEJoin path is opt-in).
+        """
+        # Arrange
+        query = """
+            SELECT a.*, b.*
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"])
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    def test_transpile_should_route_outer_join_intersects_to_binned_plan_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that LEFT JOIN INTERSECTS falls back to the binned plan.
+
+        Given:
+            A LEFT JOIN INTERSECTS query and a peak with no overlapping
+            gene on the join chromosome.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            It should preserve LEFT JOIN semantics by returning the
+            unmatched peak with NULL gene columns (which the IEJoin path
+            cannot do, so the binned fallback fires).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 0, "+"),
+                ("chr1", 5000, 6000, "p_lonely", 0, "+"),
+            ],
+        )
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.start AS a_start, b.start AS b_start
+            FROM peaks a
+            LEFT JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall(), key=lambda r: r[0])
+
+        # Assert
+        assert rows == [(100, 150), (5000, None)]
+
+    def test_query_should_honor_extra_join_on_predicate_alongside_where_intersects_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that an extra non-INTERSECTS join predicate is honored.
+
+        Given:
+            A query whose JOIN ON carries a non-INTERSECTS predicate
+            (``a.score > b.score``) alongside a WHERE INTERSECTS, and
+            input rows where one pair overlaps but violates the score
+            predicate.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The dialect path should inline the extra predicate into each
+            per-chromosome subquery's join ON, excluding the pair that
+            violates the predicate and including the pair that satisfies
+            it. (Note: the binned plan still drops this predicate per
+            bug #94; the dialect now sidesteps that bug entirely by
+            handling extras directly.)
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p_high", 100, "+"),
+                ("chr1", 300, 400, "p_low", 1, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g_low", 5, "+"),
+                ("chr1", 350, 450, "g_high", 50, "+"),
+            ],
+        )
+        sql = transpile(
+            """
+            SELECT a.start AS a_start, b.start AS b_start
+            FROM peaks a JOIN genes b ON a.score > b.score
+            WHERE a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        # Only ``p_high`` (score 100) overlaps ``g_low`` (score 5) AND beats
+        # its score; ``p_low`` (score 1) overlaps ``g_high`` (score 50) but
+        # fails the score predicate.
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(100, 150)]
+
+    def test_transpile_should_inline_extra_join_on_predicate_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that an extra ON predicate appears inside each per-chromosome subquery.
+
+        Given:
+            A column-to-column INTERSECTS INNER join whose ON also
+            carries ``a.score > 20`` (a single-side predicate).
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            The emitted SQL should engage the dialect path (no fallback)
+            and inline the extra predicate into the per-chromosome
+            subquery's ON, rewritten against the inner ``a``/``b`` scope.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval AND a.score > 20",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # The score predicate must show up inside the dynamic SQL literal so
+        # DuckDB evaluates it inside each per-chromosome IEJoin candidate set.
+        assert "a.score > 20" in sql
+
+    def test_query_should_filter_by_extra_where_predicate_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that a WHERE predicate alongside an ON-INTERSECTS filters rows.
+
+        Given:
+            Two overlap rows on the same chromosome and an extra
+            ``WHERE b.score < 30`` predicate that should exclude one
+            of them.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            Only the row whose ``b.score`` satisfies the predicate is
+            returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 300, 400, "p2", 2, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g_low", 5, "+"),
+                ("chr1", 350, 450, "g_high", 50, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE b.score < 30",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(100,)]
+
+    def test_query_should_combine_multiple_extra_predicates_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that two extra predicates AND together correctly under the dialect.
+
+        Given:
+            Three peaks/genes with varying scores, and ``ON ... AND a.score > 20``
+            plus ``WHERE b.score < 40`` — only one pair satisfies both.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            Only the pair satisfying both extras is returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 10, "+"),  # score too low for ON
+                ("chr1", 300, 400, "p2", 25, "+"),  # score passes ON
+                ("chr1", 500, 600, "p3", 30, "+"),  # score passes ON
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 5, "+"),
+                ("chr1", 350, 450, "g2", 5, "+"),  # b.score passes WHERE
+                ("chr1", 550, 650, "g3", 50, "+"),  # b.score fails WHERE
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval AND a.score > 20 "
+            "WHERE b.score < 40",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(300,)]
+
+    def test_transpile_should_route_to_binned_plan_when_extra_predicate_uses_or(
+        self,
+    ):
+        """Test that an OR-wrapped extra predicate falls back to the binned plan.
+
+        Given:
+            A column-to-column INTERSECTS INNER join whose JOIN ON wraps
+            the INTERSECTS and a sibling predicate in an OR.
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            The dialect cannot peel the INTERSECTS out of the OR tree
+            (only AND-conjunctions are decomposable safely) and routes
+            to the binned plan.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval OR a.score > 0",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_raise_when_extra_predicate_is_unqualified(
+        self,
+    ):
+        """Test that an unqualified-column extra predicate raises a ValueError.
+
+        Given:
+            A column-to-column INTERSECTS INNER join carrying
+            ``WHERE strand = '+'`` (the column reference has no table
+            qualifier).
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            The dialect cannot safely scope the predicate to either
+            ``a`` or ``b`` inside the inner subquery, and the binned
+            plan can't handle it correctly either (issue #94), so the
+            dialect raises with an actionable message naming the join's
+            valid aliases instead of silently routing to a broken plan.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="qualified with 'a' or 'b'"):
+            transpile(
+                "SELECT a.start AS s FROM peaks a "
+                "JOIN genes b ON a.interval INTERSECTS b.interval "
+                "WHERE strand = '+'",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+
+    def test_transpile_should_rewrite_residual_aliases_to_inner_a_b_when_user_uses_other_aliases(
+        self,
+    ):
+        """Test that residuals are rewritten when the user picks aliases other than a/b.
+
+        Given:
+            A column-to-column INTERSECTS INNER join whose user aliases
+            are ``p`` and ``g`` (instead of the dialect's hardcoded inner
+            ``a`` / ``b``) and an extra ON predicate ``p.score > g.score``.
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            The emitted inner SQL should reference ``a`` and ``b`` rather
+            than ``p`` and ``g`` in the extra predicate (otherwise the
+            inner subquery would fail to resolve the column refs).
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT p.start AS s FROM peaks p "
+            "JOIN genes g ON p.interval INTERSECTS g.interval AND p.score > g.score",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert "a.score > b.score" in sql
+        assert "p.score" not in sql
+        assert "g.score" not in sql
+
+    def test_transpile_should_handle_custom_chrom_col_when_dialect_is_duckdb(self, conn):
+        """Test that custom column names round-trip through the IEJoin path.
+
+        Given:
+            Two DuckDB tables defined with ``chromosome`` / ``start_pos`` /
+            ``end_pos`` instead of the default column names, and a
+            qualified-projection query referring to those columns.
+        When:
+            The query is transpiled with the matching ``Table`` configs and
+            ``dialect='duckdb'`` and executed against the connection.
+        Then:
+            It should return the overlap rows correctly using the custom
+            column names on both sides of the join.
+        """
+        # Arrange
+        conn.execute(
+            "CREATE TABLE peaks (chromosome VARCHAR, start_pos INTEGER, end_pos INTEGER)"
+        )
+        conn.execute("INSERT INTO peaks VALUES ('chr1', 100, 200), ('chr1', 1000, 1100)")
+        conn.execute(
+            "CREATE TABLE genes (chromosome VARCHAR, start_pos INTEGER, end_pos INTEGER)"
+        )
+        conn.execute("INSERT INTO genes VALUES ('chr1', 150, 250), ('chr1', 5000, 6000)")
+        sql = transpile(
+            """
+            SELECT a.chromosome AS a_chrom, a.start_pos AS a_start,
+                   b.start_pos AS b_start
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table(
+                    "peaks",
+                    chrom_col="chromosome",
+                    start_col="start_pos",
+                    end_col="end_pos",
+                ),
+                Table(
+                    "genes",
+                    chrom_col="chromosome",
+                    start_col="start_pos",
+                    end_col="end_pos",
+                ),
+            ],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert rows == [("chr1", 100, 150)]
+
+    def test_transpile_should_passthrough_literal_intersects_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that literal-range INTERSECTS bypasses the IEJoin scaffolding.
+
+        Given:
+            A WHERE literal-range INTERSECTS query (not column-to-column).
+        When:
+            The query is transpiled with ``dialect=None`` and with
+            ``dialect='duckdb'`` and both are executed.
+        Then:
+            It should produce the same SQL and the same result rows under
+            both dialects (the IEJoin path is a no-op for literal ranges).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 0, "+"),
+                ("chr1", 1500, 1700, "p2", 0, "+"),
+                ("chr1", 5000, 6000, "p3", 0, "+"),
+            ],
+        )
+        query = "SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1000-2000'"
+
+        # Act
+        sql_default = transpile(query, tables=["peaks"])
+        sql_duckdb = transpile(query, tables=["peaks"], dialect="duckdb")
+        rows_default = sorted(conn.execute(sql_default).fetchall())
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+
+        # Assert
+        assert "SET VARIABLE" not in sql_duckdb.upper()
+        assert "getvariable" not in sql_duckdb
+        assert rows_default == rows_duckdb
+        assert rows_duckdb == [("chr1", 1500, 1700, "p2", 0, "+")]
+
+    def test_transpile_should_raise_when_dialect_is_unknown(self):
+        """Test that an unknown dialect string raises ``ValueError``.
+
+        Given:
+            A dialect name other than ``'duckdb'`` or ``None``.
+        When:
+            ``transpile`` is called.
+        Then:
+            It should raise ``ValueError`` with a message that names the
+            unknown dialect.
+        """
+        # Arrange
+        query = "SELECT * FROM peaks"
+
+        # Act & assert — message must name both the failure mode and the
+        # offending value so the user can recover without guessing.
+        with pytest.raises(ValueError, match=r"[Uu]nknown dialect.*'postgres'"):
+            transpile(query, tables=["peaks"], dialect="postgres")
+
+    def test_transpile_should_raise_when_select_has_unqualified_wildcard(self):
+        """Test that bare ``SELECT *`` is rejected under the DuckDB dialect.
+
+        Given:
+            A column-to-column INTERSECTS JOIN whose projection is a bare
+            ``*``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` whose message mentions
+            "qualified" projections.
+        """
+        # Arrange
+        query = """
+            SELECT *
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act & assert
+        with pytest.raises(ValueError, match="qualified"):
+            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+    def test_transpile_should_raise_when_dialect_duckdb_and_intersects_bin_size_are_both_set(
+        self,
+    ):
+        """Test that ``dialect='duckdb'`` and ``intersects_bin_size`` are mutually exclusive.
+
+        Given:
+            ``dialect='duckdb'`` together with a non-None
+            ``intersects_bin_size``.
+        When:
+            ``transpile`` is called.
+        Then:
+            It should raise ``ValueError`` whose message names
+            ``intersects_bin_size``.
+        """
+        # Arrange
+        query = """
+            SELECT a.chrom, a.start, b.start
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act & assert
+        with pytest.raises(ValueError, match="intersects_bin_size"):
+            transpile(
+                query,
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+                intersects_bin_size=50000,
+            )
+
+    # --- DI-001..DI-009: new SQL-structure / contract tests --------------
+
+    def test_transpile_should_be_round_trip_executable_when_dialect_is_duckdb(
+        self, peaks_genes
+    ):
+        """Test end-to-end execution of an INNER JOIN INTERSECTS under DuckDB.
+
+        Given:
+            A column-to-column INTERSECTS INNER JOIN with default column
+            names against a multi-chromosome fixture with a known truth
+            table of overlapping pairs.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed
+            against an in-memory DuckDB connection.
+        Then:
+            It should return exactly the expected set of overlapping
+            (peak, gene) tuples.
+        """
+        # Arrange
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(peaks_genes.execute(sql).fetchall())
+
+        # Assert
+        assert rows == sorted(_EXPECTED_OVERLAPS_PEAKS_GENES)
+
+    def test_transpile_should_route_to_binned_plan_when_query_has_two_intersects_predicates(
+        self, conn
+    ):
+        """Test that two INTERSECTS predicates fall back to the binned plan.
+
+        Given:
+            A three-table chained INTERSECTS query (peaks JOIN genes
+            JOIN genes2) with ON-INTERSECTS predicates on each join.
+        When:
+            The query is transpiled both with ``dialect='duckdb'`` and
+            with ``dialect=None`` and both are executed.
+        Then:
+            The DuckDB-dialect path should fall back to the binned plan
+            and return the same multiset of triply-overlapping rows as the
+            default ``dialect=None`` path.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g", 0, "+")])
+        conn.execute(
+            "CREATE TABLE genes2 ("
+            'chrom VARCHAR, "start" INTEGER, "end" INTEGER, '
+            "name VARCHAR, score INTEGER, strand VARCHAR)"
+        )
+        conn.execute("INSERT INTO genes2 VALUES ('chr1', 175, 350, 'g2', 0, '+')")
+        query = """
+            SELECT a.start AS a_s, b.start AS b_s, c.start AS c_s
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            JOIN genes2 c ON b.interval INTERSECTS c.interval
+            """
+        sql_dd = transpile(
+            query,
+            tables=["peaks", "genes", "genes2"],
+            dialect="duckdb",
+        )
+        sql_default = transpile(query, tables=["peaks", "genes", "genes2"])
+
+        # Act
+        rows_dd = sorted(conn.execute(sql_dd).fetchall())
+        rows_default = sorted(conn.execute(sql_default).fetchall())
+
+        # Assert
+        assert rows_dd == rows_default
+        assert rows_dd == [(100, 150, 175)]
+
+    def test_transpile_should_route_self_join_to_fallback_plan_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that a self-join INTERSECTS falls back and still executes.
+
+        Given:
+            A query joining ``peaks`` against itself on INTERSECTS.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            It should fall back to the binned plan and return the
+            self-overlap pairs without raising.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 0, "+"),
+                ("chr1", 150, 300, "p2", 0, "+"),
+                ("chr1", 1000, 1100, "p3", 0, "+"),
+            ],
+        )
+        sql = transpile(
+            """
+            SELECT a.start AS a_s, b.start AS b_s
+            FROM peaks a JOIN peaks b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        # Each peak overlaps itself; p1[100,200) and p2[150,300) overlap each
+        # other; p3 only overlaps itself.
+        assert rows == [
+            (100, 100),
+            (100, 150),
+            (150, 100),
+            (150, 150),
+            (1000, 1000),
+        ]
+
+    def test_transpile_should_emit_order_by_and_limit_on_outer_select_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that ORDER BY and LIMIT survive on the dialect's outer SELECT.
+
+        Given:
+            A column-to-column INTERSECTS INNER join carrying a top-level
+            ``ORDER BY a.start LIMIT 1``.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            It should engage the dialect path (``SET VARIABLE
+            __giql_iejoin_`` is emitted), append the user's ``ORDER BY``
+            / ``LIMIT`` to the outer SELECT, and return exactly the
+            first row by ascending ``a.start``.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 300, 400, "p2", 2, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 350, 450, "g2", 2, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY a.start LIMIT 1",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # Structural check: ORDER BY must sit on the outer wrapper (after
+        # ``query(getvariable(...)``) and before ``LIMIT`` — pins the clause
+        # ordering contract of ``_build_sql``.
+        wrapper_idx = sql.index("query(getvariable(")
+        order_idx = sql.index("ORDER BY", wrapper_idx)
+        limit_idx = sql.index("LIMIT 1", wrapper_idx)
+        assert wrapper_idx < order_idx < limit_idx
+        assert rows == [(100,)]
+
+    def test_transpile_should_emit_distinct_on_outer_select_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that SELECT DISTINCT survives on the dialect's outer SELECT.
+
+        Given:
+            A column-to-column INTERSECTS INNER join projecting
+            ``DISTINCT a.chrom`` over fixture data with two overlapping
+            peaks sharing the same chromosome.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            It should engage the dialect path (``SET VARIABLE
+            __giql_iejoin_`` is emitted), prepend ``DISTINCT`` to the
+            outer SELECT, and return exactly one distinct chromosome row.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 300, 400, "p2", 2, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 350, 450, "g2", 2, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT DISTINCT a.chrom AS c FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert "SELECT DISTINCT" in sql
+        assert rows == [("chr1",)]
+
+    def test_query_should_return_rows_in_order_by_order_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that ORDER BY DESC over multiple chromosomes orders rows.
+
+        Given:
+            A column-to-column INTERSECTS INNER join with two overlap
+            rows on different chromosomes and a top-level
+            ``ORDER BY a.start DESC``.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The returned rows should be sorted by ``a.start`` descending.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr2", 500, 600, "p2", 2, "-"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr2", 550, 650, "g2", 2, "-"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s, a.chrom AS c FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY a.start DESC",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(500, "chr2"), (100, "chr1")]
+
+    def test_query_should_respect_offset_when_dialect_is_duckdb(self, conn):
+        """Test that LIMIT N OFFSET M skips the first M rows.
+
+        Given:
+            Two overlap rows after sorting by ``a.start``.
+        When:
+            The query is transpiled with ``dialect='duckdb'``, a
+            ``LIMIT 1 OFFSET 1`` is included, and the SQL is executed.
+        Then:
+            The second-by-order row is returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 300, 400, "p2", 2, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 350, 450, "g2", 2, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY a.start LIMIT 1 OFFSET 1",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(300,)]
+
+    def test_query_should_resolve_order_by_user_alias_when_dialect_is_duckdb(self, conn):
+        """Test that ORDER BY can reference a SELECT-list user alias directly.
+
+        Given:
+            A column-to-column INTERSECTS INNER join with
+            ``SELECT a.start AS s ... ORDER BY s``.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The order-by reference to the bare user alias should resolve
+            against the outer wrapper and return rows in ascending order
+            by ``a.start``.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 300, 400, "p2", 2, "+"),
+                ("chr1", 100, 200, "p1", 1, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 350, 450, "g2", 2, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY s",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(100,), (300,)]
+
+    def test_query_should_auto_project_order_by_column_when_not_in_select_under_dialect(
+        self, conn
+    ):
+        """Test that an ORDER BY column not in the SELECT is auto-projected internally.
+
+        Given:
+            Two overlap rows sortable by ``b.score`` (which is not in
+            the user's SELECT list).
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            ``ORDER BY b.score``, and the SQL is executed.
+        Then:
+            The dialect should silently project ``b.score`` into the
+            inner subquery so the outer ORDER BY can resolve it; the
+            user's SELECT list remains unchanged, and rows return in
+            ``b.score`` order.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 300, 400, "p2", 2, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g_high", 99, "+"),
+                ("chr1", 350, 450, "g_low", 1, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY b.score",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert: ordered by g_low (b.score=1) first then g_high (b.score=99)
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert [r[0] for r in rows] == [300, 100]
+        # The user's projection is still single-column ``s``.
+        assert all(len(r) == 1 for r in rows)
+
+    def test_query_should_allow_order_by_when_outer_name_is_shared_under_dialect(
+        self, conn
+    ):
+        """Test that ORDER BY on a shared outer name resolves unambiguously.
+
+        Given:
+            A column-to-column INTERSECTS INNER join projecting both
+            ``a.start`` and ``b.start`` (both would otherwise surface
+            under the outer name ``"start"``) and ``ORDER BY a.start``.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            The rewriter resolves the reference to the inner alias for
+            ``a.start`` rather than to a colliding outer name, so the
+            query succeeds and orders by ``a.start``.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 300, 400, "p2", 2, "+"),
+                ("chr1", 100, 200, "p1", 1, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 350, 450, "g2", 2, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start, b.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY a.start",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(100, 150), (300, 350)]
+
+    def test_query_should_group_overlap_pairs_by_chrom_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that an outer GROUP BY with COUNT(*) under the dialect groups rows.
+
+        Given:
+            A column-to-column INTERSECTS INNER join with a top-level
+            ``GROUP BY a.chrom`` and a ``COUNT(*)`` aggregate over two
+            chromosomes each having a single overlap.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The dialect path should engage and return one row per
+            chromosome with the matching count.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr2", 100, 200, "p2", 2, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr2", 150, 250, "g2", 2, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, COUNT(*) AS n FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert "GROUP BY" in sql
+        assert rows == [("chr1", 1), ("chr2", 1)]
+
+    def test_query_should_filter_groups_via_having_when_dialect_is_duckdb(self, conn):
+        """Test that an outer HAVING filter survives under the dialect.
+
+        Given:
+            A column-to-column INTERSECTS INNER join with a
+            ``GROUP BY ... HAVING COUNT(*) > 1`` over data where exactly
+            one chromosome has more than one overlap.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The dialect path should engage and return only the
+            chromosome whose overlap count exceeds the threshold.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 110, 210, "p2", 2, "+"),
+                ("chr2", 100, 200, "p3", 3, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr2", 150, 250, "g2", 2, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, COUNT(*) AS n FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom HAVING COUNT(*) > 1",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert "HAVING" in sql
+        assert rows == [("chr1", 2)]
+
+    def test_query_should_compute_sum_aggregate_with_group_by_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that SUM(a.score) over GROUP BY a.chrom works under the dialect.
+
+        Given:
+            A column-to-column INTERSECTS INNER join over two chromosomes
+            with multiple overlaps per side, plus a ``GROUP BY a.chrom``
+            and ``SUM(a.score)`` aggregate.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The dialect path should engage and return one row per
+            chromosome with the per-chromosome sum.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 10, "+"),
+                ("chr1", 300, 400, "p2", 5, "+"),
+                ("chr2", 100, 200, "p3", 7, "-"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 0, "+"),
+                ("chr1", 350, 450, "g2", 0, "+"),
+                ("chr2", 150, 250, "g3", 0, "-"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, SUM(a.score) AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [("chr1", 15), ("chr2", 7)]
+
+    def test_query_should_handle_count_distinct_aggregate_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that COUNT(DISTINCT a.x) preserves DISTINCT through the rewrite.
+
+        Given:
+            Overlap data where the same ``a.name`` appears twice on the
+            same chromosome and a ``COUNT(DISTINCT a.name)`` aggregate.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The dialect path should engage and the count should reflect
+            the number of distinct names (not the total row count).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p_dup", 1, "+"),
+                ("chr1", 110, 210, "p_dup", 2, "+"),
+                ("chr1", 300, 400, "p_other", 3, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 0, "+"),
+                ("chr1", 350, 450, "g2", 0, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, COUNT(DISTINCT a.name) AS n FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        # The two p_dup peaks both overlap g1 — under DISTINCT they
+        # collapse to 1; p_other overlaps g2; total distinct = 2.
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert "DISTINCT" in sql.upper()
+        assert rows == [("chr1", 2)]
+
+    def test_query_should_match_binned_plan_avg_aggregate_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that AVG aggregate matches the binned plan executing-side.
+
+        Given:
+            Two chromosomes with multiple overlap pairs and varied
+            ``a.score`` values that produce a non-integer per-chrom
+            average.
+        When:
+            A ``SELECT a.chrom, AVG(a.score) ... GROUP BY a.chrom`` is
+            transpiled under both ``dialect=None`` (binned plan) and
+            ``dialect='duckdb'`` and executed.
+        Then:
+            Both plans return the same per-chrom averages (compared via
+            ``pytest.approx`` since AVG yields floats). This is the
+            execution-side AVG-equivalence check that the aggregate PBT
+            intentionally skips (PBT excludes AVG to keep its equality
+            assertion strict).
+        """
+        # Arrange — scores chosen so chr1's mean is 31.0 (integer) and
+        # chr2's mean is 12.5 (genuinely non-integer), forcing
+        # ``pytest.approx`` to actually do float comparison.
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 10, "+"),
+                ("chr1", 110, 210, "p2", 32, "+"),
+                ("chr1", 120, 220, "p3", 51, "+"),
+                ("chr2", 100, 200, "p4", 7, "-"),
+                ("chr2", 110, 210, "p5", 18, "-"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 0, "+"),
+                ("chr2", 150, 250, "g2", 0, "-"),
+            ],
+        )
+        query = (
+            "SELECT a.chrom AS c, AVG(a.score) AS v FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom ORDER BY a.chrom"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = conn.execute(sql_default).fetchall()
+        rows_duckdb = conn.execute(sql_duckdb).fetchall()
+
+        # Assert — value-equivalence with float tolerance.
+        assert len(rows_default) == len(rows_duckdb)
+        for (c_d, v_d), (c_q, v_q) in zip(rows_default, rows_duckdb):
+            assert c_d == c_q
+            assert v_d == pytest.approx(v_q)
+
+    def test_query_should_combine_count_star_and_sum_when_dialect_is_duckdb(self, conn):
+        """Test that multiple aggregates coexist correctly under the dialect.
+
+        Given:
+            Two chromosomes with multiple overlaps and a SELECT list that
+            mixes ``COUNT(*)`` and ``SUM(b.score)``.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The dialect should engage, project the underlying column for
+            ``SUM(b.score)`` into the inner subquery, and emit both
+            aggregates against the wrapper relation.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 110, 210, "p2", 2, "+"),
+                ("chr2", 100, 200, "p3", 3, "-"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 10, "+"),
+                ("chr2", 150, 250, "g2", 20, "-"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, COUNT(*) AS n, SUM(b.score) AS bs "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # chr1: two overlaps, each with g1 (score 10) -> sum 20; chr2: 1 with g2 (20)
+        assert rows == [("chr1", 2, 20), ("chr2", 1, 20)]
+
+    def test_transpile_should_raise_when_aggregate_argument_is_unqualified(self):
+        """Test that an aggregate with an unqualified-column argument raises.
+
+        Given:
+            A SELECT-list aggregate ``SUM(score)`` whose argument is not
+            table-qualified.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            A ``ValueError`` should be raised that names the offending
+            projection and asks for a qualified reference.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match=r"qualified"):
+            transpile(
+                "SELECT a.chrom AS c, SUM(score) AS s FROM peaks a "
+                "JOIN genes b ON a.interval INTERSECTS b.interval "
+                "GROUP BY a.chrom",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+
+    def test_transpile_should_route_to_binned_plan_when_outer_join_intersects_lives_in_where(
+        self,
+    ):
+        """Test that LEFT JOIN ON TRUE WHERE INTERSECTS falls back.
+
+        Given:
+            A ``LEFT JOIN ... ON TRUE WHERE a.interval INTERSECTS
+            b.interval`` query — the INTERSECTS lives in WHERE while
+            the join keeps its LEFT side modifier.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect must NOT engage (rewriting as an inner IEJoin
+            would silently drop LEFT JOIN's unmatched-row guarantee).
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "LEFT JOIN genes b ON TRUE "
+            "WHERE a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_route_to_binned_plan_when_full_outer_join_intersects_lives_in_where(
+        self,
+    ):
+        """Test that FULL OUTER JOIN ... WHERE INTERSECTS falls back.
+
+        Given:
+            A ``FULL OUTER JOIN ... ON TRUE WHERE a.interval INTERSECTS
+            b.interval`` — same shape as LEFT, but FULL.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect must not engage; the binned plan handles the
+            outer-join semantics.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "FULL OUTER JOIN genes b ON TRUE "
+            "WHERE a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_route_to_binned_plan_when_extra_predicate_contains_window_function(
+        self,
+    ):
+        """Test that window functions inside extras force a fallback.
+
+        Given:
+            An INTERSECTS join carrying ``WHERE a.score > (ROW_NUMBER()
+            OVER (PARTITION BY a.chrom))`` — a window function in an
+            extra predicate. DuckDB forbids window functions in JOIN ON
+            clauses, so the dialect cannot inline this residual.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect must reject the residual and route to the
+            binned plan (rather than emit SQL that DuckDB rejects at
+            runtime).
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.score > (ROW_NUMBER() OVER (PARTITION BY a.chrom))",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_raise_with_window_specific_message_when_window_aggregate_in_select(
+        self,
+    ):
+        """Test that a window-aggregate projection raises with a targeted message.
+
+        Given:
+            A SELECT list containing ``SUM(a.score) OVER (PARTITION BY
+            a.chrom)`` — a window aggregate, which the dispatcher does
+            not classify as ``exp.AggFunc``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            A ``ValueError`` is raised whose message names "window
+            aggregates" (rather than the generic "qualified
+            projections" message).
+        """
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                "SELECT a.chrom AS c, "
+                "SUM(a.score) OVER (PARTITION BY a.chrom) AS s "
+                "FROM peaks a JOIN genes b "
+                "ON a.interval INTERSECTS b.interval",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+        assert "window" in str(excinfo.value).lower()
+
+    def test_transpile_should_raise_with_window_message_when_paren_wrapped_window_aggregate(
+        self,
+    ):
+        """Test that ``(SUM(a.score) OVER (...))`` gets the targeted window message.
+
+        Given:
+            A paren-wrapped window aggregate in the SELECT list. The
+            Paren wrapper hides the inner ``exp.Window`` from the
+            non-peeled type check that the diagnostic branches used to
+            rely on.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dispatcher peels the Paren and routes to the window
+            diagnostic branch, raising the dedicated window-aggregate
+            message rather than the generic
+            arithmetic-over-aggregate one.
+        """
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                "SELECT a.chrom AS c, "
+                "(SUM(a.score) OVER (PARTITION BY a.chrom)) AS s "
+                "FROM peaks a JOIN genes b "
+                "ON a.interval INTERSECTS b.interval",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+        assert "window" in str(excinfo.value).lower()
+
+    def test_transpile_should_raise_with_aggregate_in_expression_message_when_count_in_arithmetic(
+        self,
+    ):
+        """Test that arithmetic over an aggregate raises with a targeted message.
+
+        Given:
+            A SELECT list containing ``COUNT(*) * 2`` — arithmetic over
+            an aggregate, which the dispatcher does not classify as
+            ``exp.AggFunc``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            A ``ValueError`` is raised whose message names aggregates
+            inside expressions (rather than the generic "qualified
+            projections" message).
+        """
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                "SELECT a.chrom AS c, COUNT(*) * 2 AS doubled "
+                "FROM peaks a JOIN genes b "
+                "ON a.interval INTERSECTS b.interval "
+                "GROUP BY a.chrom",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+        message = str(excinfo.value).lower()
+        assert "aggregate" in message and (
+            "expression" in message or "arithmetic" in message
+        )
+
+    def test_transpile_should_route_to_binned_plan_when_modifier_contains_subquery(
+        self,
+    ):
+        """Test that a subquery inside ORDER BY routes to the binned plan.
+
+        Given:
+            A query whose ``ORDER BY`` clause embeds a scalar subquery
+            (``(SELECT MAX(score) FROM peaks)``). The modifier rewriter
+            is not scope-aware, so the dialect should fall back to the
+            binned plan rather than rewrite column refs inside the
+            nested scope.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect must not engage; the binned plan handles the
+            subquery natively.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY (SELECT MAX(score) FROM peaks)",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_route_to_binned_plan_when_modifier_contains_exists(
+        self,
+    ):
+        """Test that EXISTS inside ORDER BY routes to the binned plan.
+
+        Given:
+            A query whose ``ORDER BY`` clause embeds an ``EXISTS
+            (SELECT ...)`` clause. sqlglot parses EXISTS as
+            ``Exists(Select(...))`` without an ``exp.Subquery``
+            wrapper, so the gate must also check for ``exp.Select`` —
+            otherwise EXISTS slips past and the non-scope-aware
+            modifier rewriter corrupts the EXISTS scope.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect must not engage.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY EXISTS (SELECT 1 FROM peaks p WHERE p.score > 0)",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_route_to_binned_plan_when_having_contains_subquery(
+        self,
+    ):
+        """Test that a subquery inside HAVING routes to the binned plan.
+
+        Given:
+            A query whose HAVING compares against a scalar subquery
+            (``HAVING SUM(a.score) > (SELECT AVG(score) FROM peaks)``).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect must not engage.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.chrom AS c, SUM(a.score) AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom "
+            "HAVING SUM(a.score) > (SELECT AVG(score) FROM peaks)",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_accept_paren_wrapped_aggregate_in_select(
+        self,
+    ):
+        """Test that ``(SUM(a.score)) AS s`` is accepted, not rejected.
+
+        Given:
+            A SELECT-list projection that wraps an aggregate in an
+            otherwise-redundant ``exp.Paren`` (``(SUM(a.score)) AS s``).
+            Previously this hit the arithmetic-over-aggregate raise
+            with misleading guidance, because ``exp.Paren`` is not an
+            ``exp.AggFunc``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect should peel the paren and route the projection
+            through the aggregate branch, emitting valid SQL with the
+            inner-alias rewrite.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.chrom AS c, (SUM(a.score)) AS s "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # The aggregate's argument should be rewritten to an inner alias
+        # rather than left as ``a.score`` on the outer SELECT.
+        outer_select = sql.split(";\n", 1)[-1]
+        assert "a.score" not in outer_select
+        assert re.search(r"SUM\(__giql_p\d+\)", outer_select) is not None
+
+    def test_transpile_should_raise_with_subquery_specific_message_when_scalar_subquery_in_select(
+        self,
+    ):
+        """Test that a scalar subquery in SELECT gets a targeted error.
+
+        Given:
+            A SELECT list containing a scalar subquery that itself
+            contains an aggregate (``(SELECT SUM(score) FROM
+            other_table)``). Previously this hit the
+            arithmetic-over-aggregate message with misleading guidance.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            A ``ValueError`` whose message names the scalar-subquery
+            shape (rather than steering the user toward "do the
+            arithmetic in a wrapping query").
+        """
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                "SELECT a.chrom AS c, "
+                "(SELECT SUM(score) FROM peaks) AS s "
+                "FROM peaks a JOIN genes b "
+                "ON a.interval INTERSECTS b.interval",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+        assert "subquer" in str(excinfo.value).lower()
+
+    def test_transpile_should_route_to_binned_plan_when_query_has_distinct_on(self):
+        """Test that DISTINCT ON (...) falls back to the binned plan.
+
+        Given:
+            A column-to-column INTERSECTS INNER join with a
+            ``SELECT DISTINCT ON (a.chrom) ...`` projection.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect should not engage; the SQL should not contain
+            the ``SET VARIABLE __giql_iejoin_`` marker.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT DISTINCT ON (a.chrom) a.chrom, a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_route_to_binned_plan_and_execute_correctly_when_query_has_top_level_with_clause(
+        self, conn
+    ):
+        """Test that a top-level WITH clause falls back to the binned plan.
+
+        Given:
+            A query whose INTERSECTS join is wrapped in a top-level
+            ``WITH big AS (SELECT * FROM genes)`` whose CTE is then used
+            as one of the joined operands.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            It should fall back to the binned plan, preserve the CTE
+            definition, and execute against the materialized CTE. The
+            dialect path would otherwise emit a `FROM big` referencing
+            a missing table.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [("chr1", 100, 200, "p1", 1, "+")],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [("chr1", 150, 250, "g1", 1, "+")],
+        )
+        sql = transpile(
+            "WITH big AS (SELECT * FROM genes) "
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN big b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+        assert rows == [(100,)]
+
+    def test_transpile_should_route_to_binned_plan_when_query_has_three_table_cross_join(
+        self, conn
+    ):
+        """Test that a 3-table implicit cross-join falls back to the binned plan.
+
+        Given:
+            A 3-table comma-style FROM clause where the INTERSECTS
+            predicate only connects two of the three tables. The third
+            table contributes a real cross-product factor to the result.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            It should fall back to the binned plan and return a row
+            count consistent with the full 3-way join — the dialect
+            path would silently drop the third table.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [("chr1", 100, 200, "p1", 1, "+")],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [("chr1", 150, 250, "g1", 1, "+")],
+        )
+        _make_table(
+            conn,
+            "extra",
+            [
+                ("chr1", 0, 10, "e1", 0, "+"),
+                ("chr1", 0, 10, "e2", 0, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a, genes b, extra c "
+            "WHERE a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes", "extra"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+        # One (peaks, genes) overlap pair cross-joined with 2 extra rows
+        # = 2 result rows. The dialect path would emit only 1 (extra dropped).
+        assert len(rows) == 2
+
+    def test_transpile_should_route_to_binned_plan_when_join_target_is_a_giql_operator(
+        self, conn
+    ):
+        """Test that a GIQL table-function in JOIN position falls back.
+
+        Given:
+            A query whose INTERSECTS join uses ``DISJOIN(genes)`` as the
+            right-hand operand. ``DISJOIN(...)`` parses as an
+            ``exp.Table`` with an empty ``name``; the pre-fix dialect
+            path would interpolate that empty name into broken SQL.
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            The dialect path should return ``None`` (fall back) and the
+            emitted SQL should contain no ``SET VARIABLE`` block and no
+            empty ``FROM `` interpolation. (Execution is the binned
+            path's domain and is covered by DISJOIN's own tests.)
+        """
+        # Arrange & Act
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN DISJOIN(genes) b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+        # No empty-name table interpolation leaked into the output.
+        assert "FROM  " not in sql
+        assert "FROM (SELECT * FROM  " not in sql
+
+    def test_transpile_should_double_quote_table_name_and_execute_correctly_when_table_name_is_a_reserved_word(
+        self, conn
+    ):
+        """Test that the dialect double-quotes a reserved-word table name.
+
+        Given:
+            A column-to-column INTERSECTS INNER join whose left table is
+            named ``select`` — a SQL reserved word that must be quoted
+            wherever the dialect interpolates it.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and the
+            generated SQL is executed against a real DuckDB table named
+            ``select``.
+        Then:
+            The dialect should engage (this *is* the supported shape),
+            the emitted SQL should reference ``"select"`` (quoted) and
+            never bare ``FROM select``, and the query should execute to
+            the expected overlap row.
+        """
+        # Arrange
+        conn.execute(
+            'CREATE TABLE "select" '
+            '(chrom VARCHAR, "start" BIGINT, "end" BIGINT, name VARCHAR, '
+            "score INTEGER, strand VARCHAR)"
+        )
+        conn.execute(
+            'INSERT INTO "select" VALUES (?, ?, ?, ?, ?, ?)',
+            ("chr1", 100, 200, "p", 1, "+"),
+        )
+        conn.execute(
+            "CREATE TABLE genes "
+            '(chrom VARCHAR, "start" BIGINT, "end" BIGINT, name VARCHAR, '
+            "score INTEGER, strand VARCHAR)"
+        )
+        conn.execute(
+            "INSERT INTO genes VALUES (?, ?, ?, ?, ?, ?)",
+            ("chr1", 150, 250, "g", 1, "+"),
+        )
+        sql = transpile(
+            'SELECT a.start AS s FROM "select" a '
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=[Table("select"), "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert '"select"' in sql
+        # Bare unquoted identifier in a FROM position would have broken DuckDB.
+        assert "FROM select " not in sql
+        assert "FROM select," not in sql
+        assert rows == [(100,)]
+
+    def test_transpile_should_emit_iejoin_block_and_return_overlap_when_implicit_cross_join_has_swapped_alias_order(
+        self, conn
+    ):
+        """Test that an implicit cross-join with swapped FROM order works.
+
+        Given:
+            An implicit cross-join where the FROM clause lists ``genes``
+            first and ``peaks`` second, while the INTERSECTS predicate
+            references ``a.interval`` (peaks) before ``b.interval``
+            (genes).
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            It should emit the dialect's ``SET VARIABLE`` IEJoin block
+            and return the correct overlap pair (the IEJoin path must
+            not depend on FROM order matching INTERSECTS argument order).
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.start AS a_s, b.start AS b_s
+            FROM genes b, peaks a
+            WHERE a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE" in sql.upper()
+        assert rows == [(100, 150)]
+
+    def test_transpile_should_raise_when_select_list_has_only_unqualified_columns(
+        self,
+    ):
+        """Test that unqualified column projections are rejected under DuckDB.
+
+        Given:
+            A query whose SELECT list contains bare column names (no
+            table qualifier).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` whose message mentions
+            "qualified".
+        """
+        # Arrange
+        query = """
+            SELECT chrom, start
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act & assert — message should name the offending column and the
+        # ``a.col``/``b.col`` form so the user can fix the query directly.
+        with pytest.raises(ValueError) as excinfo:
+            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        message = str(excinfo.value)
+        assert "qualified" in message
+        assert "chrom" in message
+        assert "a.col" in message or "b.col" in message
+
+    def test_transpile_should_raise_when_projection_references_unknown_table_alias(
+        self,
+    ):
+        """Test that a projection referring to an out-of-scope alias is rejected.
+
+        Given:
+            A SELECT list that qualifies a column with a table alias
+            (``c``) not present in the FROM/JOIN clauses.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` whose message names the
+            unknown qualifier.
+        """
+        # Arrange
+        query = """
+            SELECT c.col
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act & assert
+        with pytest.raises(ValueError, match="[Uu]nknown.*qualifier|'c'"):
+            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+    def test_transpile_should_raise_when_projection_uses_expression_form(self):
+        """Test that an arithmetic projection expression is rejected.
+
+        Given:
+            A SELECT list containing an expression
+            (``a.start + 1``) rather than a bare qualified column.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` whose message mentions
+            "qualified".
+        """
+        # Arrange
+        query = """
+            SELECT a.start + 1
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act & assert — message should echo the offending expression so
+        # the user can spot which projection to rewrite.
+        with pytest.raises(ValueError) as excinfo:
+            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        message = str(excinfo.value)
+        assert "qualified" in message
+        assert "a.start + 1" in message or "a.start" in message
+
+    def test_transpile_should_raise_when_star_qualifier_references_unknown_table(
+        self,
+    ):
+        """Test that ``c.*`` against an out-of-scope alias is rejected.
+
+        Given:
+            A SELECT list with a qualified-star projection ``c.*`` whose
+            qualifier ``c`` is not present in the FROM/JOIN clauses.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` whose message names the
+            unknown qualifier.
+        """
+        # Arrange
+        query = """
+            SELECT c.*
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act & assert
+        with pytest.raises(ValueError, match="[Uu]nknown.*qualifier|'c'"):
+            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+    def test_transpile_should_use_unique_variable_names_across_interleaved_calls(
+        self, conn
+    ):
+        """Test that two interleaved transpile outputs do not collide.
+
+        Given:
+            Two ``transpile(..., dialect='duckdb')`` outputs whose
+            ``SET VARIABLE`` and ``SELECT`` statements are interleaved
+            (both ``SET``, then both ``SELECT``) in a single DuckDB
+            session, with the two queries projecting different columns
+            so that a fixed-name collision would surface one query's
+            result in the other's slot.
+        When:
+            The interleaved statements are executed.
+        Then:
+            Each ``SELECT`` should return the result of its own query —
+            proving the dialect emits a per-call unique variable name.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g", 0, "+")])
+        sql_a = transpile(
+            "SELECT a.chrom AS v FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+        sql_b = transpile(
+            "SELECT a.start AS v FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+        # The dialect emits exactly one `;\n` between the SET and the
+        # SELECT, so split each output on that to interleave the four
+        # statements deliberately. Under a single fixed variable name
+        # the second `SET` would overwrite the first before either
+        # `SELECT` ran, surfacing query B's row in query A's slot.
+        set_a, sep_a, select_a = sql_a.partition(";\n")
+        set_b, sep_b, select_b = sql_b.partition(";\n")
+        assert sep_a and sep_b
+        assert set_a.startswith("SET VARIABLE")
+        assert set_b.startswith("SET VARIABLE")
+        assert select_a.startswith("SELECT")
+        assert select_b.startswith("SELECT")
+
+        # Act
+        conn.execute(set_a)
+        conn.execute(set_b)
+        row_a = conn.execute(select_a).fetchall()
+        row_b = conn.execute(select_b).fetchall()
+
+        # Assert
+        assert row_a == [("chr1",)]
+        assert row_b == [(100,)]
+
+    def test_transpile_should_preserve_order_by_modifiers_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that DESC and NULLS FIRST modifiers survive the rewrite.
+
+        Given:
+            A column-to-column INTERSECTS join with
+            ``ORDER BY a.start DESC NULLS FIRST``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The emitted outer SELECT should preserve both ``DESC`` and
+            ``NULLS FIRST`` in the rewritten ORDER BY clause. (sqlglot
+            strips its own defaults like ``ASC NULLS FIRST``, so the
+            test uses the non-default-for-DESC variant to assert that
+            both modifiers round-trip through the rewriter.)
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY a.start DESC NULLS FIRST",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        outer_select = sql.split(";\n", 1)[-1]
+        order_idx = outer_select.index("ORDER BY")
+        assert "DESC" in outer_select[order_idx:]
+        assert "NULLS FIRST" in outer_select[order_idx:]
+
+    def test_transpile_should_preserve_multiple_order_by_expressions_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that multi-column ORDER BY survives, with per-term modifiers.
+
+        Given:
+            A column-to-column INTERSECTS join with
+            ``ORDER BY a.start, b.end DESC``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The outer ORDER BY clause should carry two comma-separated
+            terms, ``DESC`` should attach to the second term only, and
+            neither the user's ``a.``/``b.`` qualifiers should remain on
+            the outer ORDER BY (they get rewritten to inner aliases).
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start AS s, b.end AS e FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY a.start, b.end DESC",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        wrapper_idx = sql.index("query(getvariable(")
+        order_clause = sql[sql.index("ORDER BY", wrapper_idx) :]
+        # Pin the DESC attachment positionally so a regression that
+        # accidentally moved DESC to the first term (or attached it to
+        # both) would fail. Two inner-alias placeholders, comma-separated,
+        # with DESC on the second.
+        assert (
+            re.search(
+                r"ORDER BY\s+__giql_p\d+(?:\s+NULLS\s+(?:FIRST|LAST))?\s*,"
+                r"\s*__giql_p\d+\s+DESC",
+                order_clause,
+            )
+            is not None
+        )
+        # The rewriter binds user-qualified refs to inner aliases on the
+        # outer SELECT, so ``a.start`` / ``b.end`` should not appear in
+        # the outer ORDER BY.
+        assert "a.start" not in order_clause
+        assert "b.end" not in order_clause
+
+    def test_transpile_should_inline_cross_side_on_predicate_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that a cross-side ON predicate is inlined into each subquery.
+
+        Given:
+            A join ``ON a.interval INTERSECTS b.interval AND a.score > b.score``
+            referencing both sides of the inner subquery.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The cross-side predicate ``a.score > b.score`` should appear
+            in the dynamic SQL literal (inside the per-chromosome
+            subquery template), proving both ``a`` and ``b`` are in
+            scope inside the inlined extra predicate.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "AND a.score > b.score",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert "a.score > b.score" in sql
+
+    def test_transpile_should_inline_between_predicate_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that a ``BETWEEN`` extra predicate is inlined.
+
+        Given:
+            A join carrying an extra ``BETWEEN`` predicate on a
+            qualified column.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The ``BETWEEN 10 AND 50`` substring should appear in the
+            dynamic SQL literal.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "AND a.score BETWEEN 10 AND 50",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert — the predicate must land inside the per-chromosome
+        # template (SET VARIABLE half), not on the outer wrapper SELECT.
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        set_part, outer_part = sql.split(";\n", 1)
+        assert "BETWEEN 10 AND 50" in set_part
+        assert "BETWEEN" not in outer_part
+
+    def test_transpile_should_inline_is_null_predicate_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that an ``IS NULL`` extra predicate is inlined.
+
+        Given:
+            A join carrying ``AND a.strand IS NULL`` as an extra
+            predicate.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The ``IS NULL`` substring should appear in the dynamic SQL
+            literal.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "AND a.strand IS NULL",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert — the predicate must land inside the per-chromosome
+        # template (SET VARIABLE half), not on the outer wrapper SELECT.
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        set_part, outer_part = sql.split(";\n", 1)
+        assert "IS NULL" in set_part
+        assert "IS NULL" not in outer_part
+
+    def test_transpile_should_route_to_binned_plan_when_paren_wraps_intersects(
+        self,
+    ):
+        """Test that a Paren-wrapped INTERSECTS routes to the binned plan.
+
+        Given:
+            A join ``ON (a.interval INTERSECTS b.interval) AND a.score > 0``
+            where the INTERSECTS is wrapped in explicit parentheses.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect only decomposes AND-conjunctions when stripping
+            the INTERSECTS out of a join clause; a paren wrapper leaves
+            the INTERSECTS embedded in the residual and the dialect
+            must fall back to the binned plan.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON (a.interval INTERSECTS b.interval) "
+            "AND a.score > 0",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_route_to_binned_plan_when_residual_contains_subquery(
+        self,
+    ):
+        """Test that a subquery in the residual predicate forces a fallback.
+
+        Given:
+            A join INTERSECTS plus
+            ``WHERE a.score > (SELECT MAX(score) FROM peaks)``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect's residual-safety check rejects predicates
+            containing a subquery, so the query falls back to the
+            binned plan.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.score > (SELECT MAX(score) FROM peaks)",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_rewrite_group_by_multiple_columns_to_inner_aliases_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that multi-column GROUP BY rewrites every key to an inner alias.
+
+        Given:
+            A query ``SELECT a.chrom, a.score, COUNT(*) ... GROUP BY a.chrom, a.score``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The outer GROUP BY clause should reference two distinct
+            ``__giql_p<n>`` placeholders (one per key) and the user's
+            ``a.chrom``/``a.score`` should not appear in the outer
+            GROUP BY.
+        """
+
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.chrom AS c, a.score AS s, COUNT(*) AS n FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom, a.score",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        wrapper_idx = sql.index("query(getvariable(")
+        outer = sql[wrapper_idx:]
+        group_clause = outer[outer.index("GROUP BY") :]
+        # Two distinct inner-alias placeholders should appear in GROUP BY.
+        placeholders = set(
+            re.findall(r"__giql_p\d+", group_clause.split("HAVING")[0].split("ORDER")[0])
+        )
+        assert len(placeholders) >= 2
+        assert "a.chrom" not in group_clause.split("ORDER")[0].split("HAVING")[0]
+        assert "a.score" not in group_clause.split("ORDER")[0].split("HAVING")[0]
+
+    def test_transpile_should_emit_sum_min_max_avg_aggregates_with_inner_alias_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that four aggregates over the same column reuse one inner alias.
+
+        Given:
+            A query ``SELECT SUM(a.score), MIN(a.score), MAX(a.score),
+            AVG(a.score) ... GROUP BY a.chrom``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The inner SELECT should project ``a."score"`` exactly once,
+            and all four outer aggregates should reference the same
+            ``__giql_p<n>`` placeholder.
+        """
+
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.chrom AS c, "
+            "SUM(a.score) AS s, MIN(a.score) AS mn, "
+            "MAX(a.score) AS mx, AVG(a.score) AS av FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # Behavior-level dedup check: ``a."score"`` should be allocated to
+        # exactly one inner alias across the whole SQL string, regardless
+        # of which ``__giql_p<n>`` index that alias happens to get
+        # (allocation order depends on sqlglot's traversal of the SELECT
+        # list and is not part of the dialect's public contract).
+        score_inner_allocs = re.findall(r'a\."score"\s+AS\s+(__giql_p\d+)', sql)
+        assert len(set(score_inner_allocs)) == 1
+        outer_select = sql.split(";\n", 1)[-1]
+        # Each of the four aggregates appears once with an inner-alias arg,
+        # and all four reference the same alias (dedup propagated to the
+        # outer SELECT).
+        agg_refs = re.findall(r"(SUM|MIN|MAX|AVG)\((__giql_p\d+)\)", outer_select)
+        assert len(agg_refs) == 4
+        assert len({alias for _, alias in agg_refs}) == 1
+        # User aliases preserved on the outer SELECT.
+        for label in ('"s"', '"mn"', '"mx"', '"av"'):
+            assert label in outer_select
+
+    def test_transpile_should_auto_project_group_by_column_into_inner_select_when_not_in_outer_select_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that a GROUP BY column absent from SELECT is auto-projected.
+
+        Given:
+            A query ``SELECT COUNT(*) AS n FROM peaks a JOIN genes b ON
+            ... GROUP BY a.chrom`` where ``a.chrom`` only appears in
+            GROUP BY.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The inner subquery should project ``a."chrom"`` (so the
+            wrapper relation has it available); the outer SELECT list
+            should be ``COUNT(*)`` only; and GROUP BY should reference
+            the inner alias rather than ``a.chrom``.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT COUNT(*) AS n FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert 'a."chrom"' in sql  # inner projection auto-added
+        outer_select = sql.split(";\n", 1)[-1]
+        select_clause = outer_select[: outer_select.index("FROM query(")]
+        # Only COUNT(*) — no qualified column projection.
+        assert "COUNT(*)" in select_clause
+        assert "a.chrom" not in select_clause
+        # GROUP BY references inner alias.
+        group_clause = outer_select[outer_select.index("GROUP BY") :]
+        assert "a.chrom" not in group_clause
+        assert "__giql_p" in group_clause
+
+    def test_transpile_should_emit_aggregate_of_expression_with_rewritten_inner_aliases_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that ``SUM(a.start + a.end)`` rewrites both inner columns.
+
+        Given:
+            A query whose aggregate argument is an expression over two
+            qualified columns: ``SUM(a.start + a.end)``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The inner subquery should project both ``a."start"`` and
+            ``a."end"`` under distinct inner aliases, the outer
+            aggregate should reference both inner aliases inside the
+            arithmetic expression, and the original ``a.start`` /
+            ``a.end`` should not survive in the outer SELECT.
+        """
+
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.chrom AS c, SUM(a.start + a.end) AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # Both genomic columns projected into the inner subquery.
+        assert 'a."start"' in sql
+        assert 'a."end"' in sql
+        outer_select = sql.split(";\n", 1)[-1]
+        # Outer SUM references two inner aliases under arithmetic.
+        sum_match = re.search(r"SUM\(__giql_p\d+\s*\+\s*__giql_p\d+\)", outer_select)
+        assert sum_match is not None
+        # The two operand aliases must be distinct.
+        operand_aliases = set(re.findall(r"__giql_p\d+", sum_match.group(0)))
+        assert len(operand_aliases) == 2
+        # No raw a.start / a.end in the outer SELECT.
+        assert "a.start" not in outer_select
+        assert "a.end" not in outer_select
+
+    def test_transpile_should_route_right_outer_join_intersects_to_binned_plan_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that ``RIGHT JOIN ... INTERSECTS`` falls back to the binned plan.
+
+        Given:
+            A query with a ``RIGHT JOIN`` whose ON contains a
+            column-to-column INTERSECTS.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            ``_has_outer_join_intersects`` should detect the
+            outer-join side and route to the binned plan.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "RIGHT JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_route_to_binned_plan_when_join_target_is_subquery(
+        self,
+    ):
+        """Test that a subquery JOIN target routes to the binned plan.
+
+        Given:
+            A query whose JOIN target is a parenthesised subquery,
+            ``JOIN (SELECT * FROM genes) b ON a.interval INTERSECTS
+            b.interval``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dialect's "must be a base table" gate should fire and
+            route to the binned plan.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "JOIN (SELECT * FROM genes) b "
+            "ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_raise_when_select_projects_a_literal(self):
+        """Test that a literal-only SELECT-list entry raises ``ValueError``.
+
+        Given:
+            A query whose SELECT list contains a bare integer literal
+            (``SELECT 100 FROM peaks a JOIN ...``).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            A ``ValueError`` matching ``qualified`` should be raised
+            and the offending literal text should appear in the message.
+        """
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                "SELECT 100 FROM peaks a "
+                "JOIN genes b ON a.interval INTERSECTS b.interval",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+        message = str(excinfo.value)
+        assert "qualified" in message
+        assert "100" in message
+
+    def test_transpile_should_raise_when_star_projection_carries_a_user_alias(
+        self,
+    ):
+        """Test that ``SELECT a.* AS x`` is rejected rather than silently stripped.
+
+        Given:
+            A query with a star projection that also has a user alias
+            (``SELECT a.* AS x``).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            A ``ValueError`` should be raised mentioning the
+            unsupported alias and pointing at concrete alternatives
+            (drop the alias, or list columns explicitly).
+        """
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                "SELECT a.* AS x FROM peaks a "
+                "JOIN genes b ON a.interval INTERSECTS b.interval",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+        message = str(excinfo.value).lower()
+        assert "star" in message or "alias" in message
+
+    def test_transpile_should_surface_value_error_for_unqualified_projection_under_dialect(
+        self,
+    ):
+        """Test that the dialect surfaces a plain ``ValueError`` on bare ``*``.
+
+        Given:
+            A query that triggers the dialect's unqualified-projection
+            rejection (bare ``SELECT *``).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The exception surfaced to the caller should be a
+            ``ValueError`` and the docs-promised behavior holds: the
+            ``"qualified"`` keyword appears in the message, and the
+            class is reachable via ``isinstance(..., ValueError)`` (no
+            internal subclass leaks across that contract).
+        """
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                "SELECT * FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+        assert isinstance(excinfo.value, ValueError)
+        assert "qualified" in str(excinfo.value)
+
+    def test_transpile_should_fall_back_to_binned_plan_when_join_is_natural(self):
+        """Test that NATURAL JOIN falls back to the binned plan.
+
+        Given:
+            A query joining two tables with ``NATURAL JOIN`` and an
+            INTERSECTS predicate in WHERE.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should emit SQL with no ``SET VARIABLE`` scaffolding
+            (the dialect cannot enumerate NATURAL's implicit shared
+            columns at transpile time, so it falls back).
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a "
+            "NATURAL JOIN genes b "
+            "WHERE a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_engage_dialect_when_using_join_targets_chrom_only(self):
+        """Test that ``USING(chrom)`` engages the dialect path.
+
+        Given:
+            A query joining two tables with ``USING(chrom)`` and an
+            INTERSECTS predicate in WHERE — the per-chromosome partition
+            IS the equi-join that USING(chrom) requests.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should emit a ``SET VARIABLE __giql_iejoin_`` block.
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a JOIN genes b USING (chrom) "
+            "WHERE a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+
+    def test_transpile_should_fall_back_when_using_join_targets_non_chrom_column(self):
+        """Test that ``USING(<non-chrom>)`` falls back to the binned plan.
+
+        Given:
+            A query with ``USING(strand)`` plus INTERSECTS — the partition
+            cannot satisfy a strand equi-join.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should fall back to the binned plan (no
+            ``SET VARIABLE __giql_iejoin_`` block).
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a JOIN genes b USING (strand) "
+            "WHERE a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_fall_back_when_using_join_targets_multiple_columns(self):
+        """Test that multi-column ``USING(chrom, strand)`` falls back.
+
+        Given:
+            A query with ``USING(chrom, strand)`` plus INTERSECTS.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should fall back to the binned plan (multi-column USING
+            inline support is a documented follow-up).
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b USING (chrom, strand) "
+            "WHERE a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_engage_dialect_when_join_is_implicit_cross_join(self):
+        """Test that CROSS JOIN + WHERE INTERSECTS continues to engage the dialect.
+
+        Given:
+            A query joining two tables with ``CROSS JOIN`` and an
+            INTERSECTS predicate in WHERE — equivalent to the implicit
+            cross-join shape the dialect was designed for.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should emit a ``SET VARIABLE __giql_iejoin_`` block
+            (regression guard so the new gate doesn't reject the
+            legitimate cross-join shape).
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a CROSS JOIN genes b "
+            "WHERE a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+
+    def test_transpile_should_fall_back_when_aggregate_argument_contains_subquery(
+        self,
+    ):
+        """Test that a subquery inside an aggregate argument falls back.
+
+        Given:
+            A query whose SELECT list contains ``SUM((SELECT a.start
+            FROM peaks))`` — the wrapper-relation rewriter would walk
+            into the subquery and substitute wrapper aliases for refs
+            that only resolve in the subquery's own scope.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should fall back to the binned plan.
+        """
+        # Arrange
+        query = (
+            "SELECT SUM((SELECT a.start FROM peaks)) "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_fall_back_when_select_aggregate_contains_correlated_subquery(
+        self,
+    ):
+        """Test that a correlated subquery inside an aggregate argument falls back.
+
+        Given:
+            ``SUM((SELECT a.start FROM genes WHERE genes.chrom = a.chrom))``
+            in the SELECT list — same scope hazard as the uncorrelated
+            case.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should fall back to the binned plan.
+        """
+        # Arrange
+        query = (
+            "SELECT SUM((SELECT a.start FROM genes "
+            "WHERE genes.chrom = a.chrom)) "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" not in sql
+
+    def test_transpile_should_resolve_projections_when_aliases_differ_in_case(
+        self,
+    ):
+        """Test that mixed-case aliases are normalized to match references.
+
+        Given:
+            A query with ``peaks A`` / ``genes B`` (uppercase aliases)
+            and references via ``A.start`` / ``B.interval``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should emit a ``SET VARIABLE __giql_iejoin_`` block
+            (case-folded alias matching aligns with DuckDB's identifier
+            semantics, not Python's strict equality).
+        """
+        # Arrange
+        query = (
+            "SELECT A.start FROM peaks A "
+            "JOIN genes B ON A.interval INTERSECTS B.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+
+    def test_transpile_should_reject_extra_predicate_with_catalog_or_schema_qualified_column_when_dialect_is_duckdb(  # noqa: E501
+        self,
+    ):
+        """Test that a catalog/schema-qualified column in an extra predicate raises.
+
+        Given:
+            A query whose extra predicate uses
+            ``mycat.myschema.a.score > 0`` — the alias-only rewriter
+            would leave the catalog/schema qualifier intact in the
+            inner subquery where it addresses a different relation
+            than intended.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` with a message naming the
+            catalog/schema qualifier.
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "AND mycat.myschema.a.score > 0"
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        assert "catalog/schema qualifier" in str(excinfo.value)
+
+    def test_transpile_should_engage_dialect_for_semi_join_with_intersects(self):
+        """Test that SEMI JOIN with INTERSECTS engages the dialect path.
+
+        Given:
+            A query joining two tables with ``SEMI JOIN`` and an
+            INTERSECTS predicate.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should emit a ``SET VARIABLE __giql_iejoin_`` block.
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a "
+            "SEMI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+
+    def test_transpile_should_emit_semi_keyword_when_join_is_semi(self):
+        """Test that SEMI JOIN's per-chromosome template uses the SEMI keyword.
+
+        Given:
+            A SEMI JOIN + INTERSECTS query.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The emitted SQL should contain a ``SEMI JOIN`` substring
+            inside the per-chromosome template (not just ``JOIN``).
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a "
+            "SEMI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SEMI JOIN" in sql
+
+    def test_transpile_should_reject_right_side_projection_when_join_is_semi(self):
+        """Test that SEMI JOIN raises on ``b.col`` in the outer SELECT.
+
+        Given:
+            A SEMI JOIN + INTERSECTS query whose outer SELECT projects
+            ``b.start`` — but SEMI returns left-side rows only.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` naming the left-only
+            constraint.
+        """
+        # Arrange
+        query = (
+            "SELECT b.start FROM peaks a "
+            "SEMI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        assert "left-side" in str(excinfo.value)
+
+    def test_transpile_should_engage_dialect_for_anti_join_with_intersects(self):
+        """Test that ANTI JOIN with INTERSECTS engages the dialect path.
+
+        Given:
+            A query joining two tables with ``ANTI JOIN`` and an
+            INTERSECTS predicate.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should emit a ``SET VARIABLE __giql_iejoin_`` block.
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+
+    def test_transpile_should_use_left_only_chrom_partition_when_join_is_anti(self):
+        """Test that ANTI JOIN's partition source is left-distinct only.
+
+        Given:
+            An ANTI JOIN + INTERSECTS query.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The emitted SET VARIABLE block should NOT contain
+            ``INTERSECT`` (the partition source is left-distinct only,
+            not the chromosome-INTERSECT used by INNER / SEMI).
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        set_var_stmt = sql.split(";\n", 1)[0]
+
+        # Assert
+        assert "INTERSECT" not in set_var_stmt
+
+    def test_transpile_should_reject_right_side_projection_when_join_is_anti(self):
+        """Test that ANTI JOIN raises on ``b.col`` in the outer SELECT.
+
+        Given:
+            An ANTI JOIN + INTERSECTS query whose outer SELECT projects
+            ``b.start``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` naming the left-only
+            constraint.
+        """
+        # Arrange
+        query = (
+            "SELECT b.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        assert "left-side" in str(excinfo.value)
+
+
+class TestTranspileDuckDBIEJoinExecution:
+    """End-to-end execution tests against in-memory DuckDB."""
+
+    def test_query_should_return_overlapping_pairs_when_executed_on_duckdb(
+        self, peaks_genes
+    ):
+        """Test the multi-chromosome inner-join overlap truth table.
+
+        Given:
+            A peaks/genes fixture with a non-trivial truth table of
+            overlapping pairs across multiple chromosomes.
+        When:
+            The DuckDB-dialect SQL is executed against the connection.
+        Then:
+            It should return exactly the expected sorted set of
+            overlapping pairs.
+        """
+        # Arrange
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(peaks_genes.execute(sql).fetchall())
+
+        # Assert
+        assert rows == sorted(_EXPECTED_OVERLAPS_PEAKS_GENES)
+
+    def test_query_should_return_empty_set_when_no_chromosomes_intersect(self, conn):
+        """Test the empty-schema fallback when no chromosomes intersect.
+
+        Given:
+            Two tables with disjoint chromosome sets.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should return an empty result without raising (the
+            COALESCE empty-schema fallback fires).
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 0, "+")])
+        _make_table(conn, "genes", [("chr2", 100, 200, "g1", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == []
+
+    def test_query_should_match_binned_plan_results_when_executed_on_duckdb(
+        self, peaks_genes
+    ):
+        """Test that the binned plan and the IEJoin path agree on results.
+
+        Given:
+            The ``peaks_genes`` fixture and a column-to-column
+            INTERSECTS INNER JOIN.
+        When:
+            The query is transpiled both with ``dialect=None`` (binned
+            plan) and with ``dialect='duckdb'`` (IEJoin path) and both
+            are executed.
+        Then:
+            Both should produce the same sorted set of overlapping
+            (peak, gene) rows.
+        """
+        # Arrange
+        query = """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+        binned_sql = transpile(query, tables=["peaks", "genes"])
+        duckdb_sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        binned_rows = sorted(peaks_genes.execute(binned_sql).fetchall())
+        duckdb_rows = sorted(peaks_genes.execute(duckdb_sql).fetchall())
+
+        # Assert
+        assert binned_rows == duckdb_rows
+        assert duckdb_rows == sorted(_EXPECTED_OVERLAPS_PEAKS_GENES)
+
+    def test_query_should_handle_chrom_with_single_quote_in_name(self, conn):
+        """Test that single quotes in chrom names are escaped correctly.
+
+        Given:
+            Intervals on a chromosome whose name contains a single
+            quote.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should escape the quote inside the dynamic SQL builder
+            and return the matching pair byte-for-byte.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr'1", 100, 200, "p1", 0, "+")])
+        _make_table(conn, "genes", [("chr'1", 150, 250, "g1", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [("chr'1", 100, 200, "chr'1", 150, 250)]
+
+    def test_query_should_handle_one_based_closed_intervals(self, conn):
+        """Test that 1-based closed intervals report touching endpoints as overlapping.
+
+        Given:
+            Tables declared as 1-based closed-closed intervals where
+            ``peaks[100, 200]`` and ``genes[200, 300]`` share endpoint
+            200.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should report the pair as overlapping (closed-closed
+            shares endpoint 200).
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 200, 300, "g1", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table("peaks", coordinate_system="1based", interval_type="closed"),
+                Table("genes", coordinate_system="1based", interval_type="closed"),
+            ],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert ("chr1", 100, 200, "chr1", 200, 300) in rows
+
+    def test_query_should_not_report_non_touching_one_based_closed_as_overlapping(
+        self, conn
+    ):
+        """Test that strictly disjoint 1-based closed intervals do not match.
+
+        Given:
+            Tables declared as 1-based closed-closed with non-touching
+            intervals (``peaks[100, 199]`` and ``genes[200, 300]``).
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should report no overlap.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 199, "p1", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 200, 300, "g1", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table("peaks", coordinate_system="1based", interval_type="closed"),
+                Table("genes", coordinate_system="1based", interval_type="closed"),
+            ],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == []
+
+    def test_query_should_handle_zero_based_closed_intervals(self, conn):
+        """Test that 0-based closed intervals match abutting endpoints.
+
+        Given:
+            Tables declared as 0-based closed-closed intervals where
+            ``peaks[100, 200]`` abuts ``genes[200, 300]``.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should report the pair as overlapping (closed-closed
+            shares endpoint 200).
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 200, 300, "g1", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table("peaks", coordinate_system="0based", interval_type="closed"),
+                Table("genes", coordinate_system="0based", interval_type="closed"),
+            ],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert ("chr1", 100, 200, "chr1", 200, 300) in rows
+
+    def test_query_should_handle_implicit_cross_join_when_dialect_is_duckdb(
+        self, peaks_genes
+    ):
+        """Test that an implicit cross-join INTERSECTS produces the truth table.
+
+        Given:
+            An implicit cross-join (``FROM peaks a, genes b WHERE
+            a.interval INTERSECTS b.interval``) over the multi-chromosome
+            ``peaks_genes`` fixture.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should return exactly the expected sorted truth table of
+            overlapping pairs.
+        """
+        # Arrange
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a, genes b
+            WHERE a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(peaks_genes.execute(sql).fetchall())
+
+        # Assert
+        assert rows == sorted(_EXPECTED_OVERLAPS_PEAKS_GENES)
+
+    # --- DX-001..DX-011: behavioral truth tables -------------------------
+
+    def test_query_should_expand_qualified_star_when_dialect_is_duckdb(self, conn):
+        """Test that ``a.*, b.*`` expands to the genomic columns plus strand of each side.
+
+        Given:
+            A ``SELECT a.*, b.*`` projection over an INTERSECTS join.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            Each row should carry chrom / start / end plus strand from
+            both sides (the default Table config declares strand_col),
+            and the result should contain the expected overlap pair.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        sql = transpile(
+            """
+            SELECT a.*, b.*
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        result = conn.execute(sql)
+        rows = result.fetchall()
+
+        # Assert
+        assert rows == [("chr1", 100, 200, "+", "chr1", 150, 250, "-")]
+
+    def test_query_should_propagate_user_alias_on_qualified_column(self, conn):
+        """Test that a ``a.start AS s`` alias survives the IEJoin rewrite.
+
+        Given:
+            A ``SELECT a.start AS s`` projection over an INTERSECTS
+            join.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The result column should be named ``s`` and carry the value
+            of ``a.start`` for the matching pair.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.start AS s
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        result = conn.execute(sql)
+        column_names = [d[0] for d in result.description]
+        rows = result.fetchall()
+
+        # Assert
+        assert column_names == ["s"]
+        assert rows == [(100,)]
+
+    def test_query_should_treat_touching_half_open_intervals_as_non_overlapping(
+        self, conn
+    ):
+        """Test that half-open intervals that share an endpoint do not overlap.
+
+        Given:
+            Two half-open tables where ``peaks[100, 200)`` ends exactly
+            where ``genes[200, 300)`` begins.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should return an empty result (touching half-open
+            intervals do not overlap).
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 200, 300, "g", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.start AS a_s, b.start AS b_s
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table("peaks", coordinate_system="0based", interval_type="half_open"),
+                Table("genes", coordinate_system="0based", interval_type="half_open"),
+            ],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == []
+
+    def test_query_should_handle_mixed_coordinate_systems(self, conn):
+        """Test semantic equivalence across mixed coordinate systems.
+
+        Given:
+            ``peaks`` declared as 1-based closed (``[100, 200]``) and
+            ``genes`` declared as 0-based half-open (``[99, 200)``)
+            describing the same genomic span.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should report the pair as overlapping (both canonicalize
+            to the same 0-based half-open span).
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 99, 200, "g", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.start AS a_s, b.start AS b_s
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table("peaks", coordinate_system="1based", interval_type="closed"),
+                Table("genes", coordinate_system="0based", interval_type="half_open"),
+            ],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [(100, 99)]
+
+    def test_query_should_apply_one_based_offset_when_only_left_table_is_one_based(
+        self, conn
+    ):
+        """Test that the 1-based offset is applied per side, not globally.
+
+        Given:
+            ``peaks`` declared as 1-based half-open and ``genes`` declared
+            as 0-based half-open, with values that overlap iff the offset
+            is applied to the peaks side
+            (``peaks[100, 101)`` and ``genes[99, 100)``).
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should report the overlap; if the offset were skipped no
+            overlap would be reported.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 101, "p", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 99, 100, "g", 0, "+")])
+        sql_offset = transpile(
+            """
+            SELECT a.start AS a_s, b.start AS b_s
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table(
+                    "peaks",
+                    coordinate_system="1based",
+                    interval_type="half_open",
+                ),
+                Table(
+                    "genes",
+                    coordinate_system="0based",
+                    interval_type="half_open",
+                ),
+            ],
+            dialect="duckdb",
+        )
+        sql_no_offset = transpile(
+            """
+            SELECT a.start AS a_s, b.start AS b_s
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table(
+                    "peaks",
+                    coordinate_system="0based",
+                    interval_type="half_open",
+                ),
+                Table(
+                    "genes",
+                    coordinate_system="0based",
+                    interval_type="half_open",
+                ),
+            ],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows_offset = conn.execute(sql_offset).fetchall()
+        rows_no_offset = conn.execute(sql_no_offset).fetchall()
+
+        # Assert
+        assert rows_offset == [(100, 99)]
+        assert rows_no_offset == []
+
+    def test_query_should_return_empty_when_left_table_is_empty(self, conn):
+        """Test the empty-left input case for the IEJoin path.
+
+        Given:
+            ``peaks`` empty and ``genes`` populated with one row.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should return an empty result without raising.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.start AS a_s, b.start AS b_s
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == []
+
+    def test_query_should_return_empty_when_right_table_is_empty(self, conn):
+        """Test the empty-right input case for the IEJoin path.
+
+        Given:
+            ``peaks`` populated with one row and ``genes`` empty.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should return an empty result without raising.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 0, "+")])
+        _make_table(conn, "genes", [])
+        sql = transpile(
+            """
+            SELECT a.start AS a_s, b.start AS b_s
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == []
+
+    def test_query_should_return_typed_empty_result_when_chromosome_intersection_is_empty(
+        self, conn
+    ):
+        """Test that the empty-schema fallback exposes correctly typed columns.
+
+        Given:
+            Two tables whose chromosome sets are disjoint so the
+            chromosome-intersection ``string_agg`` is NULL.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should fetch an empty result whose column descriptions
+            match the source-table schema declared by ``_make_table``
+            (chrom as VARCHAR, start/end as INTEGER).
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chrA", 100, 200, "p", 0, "+")])
+        _make_table(conn, "genes", [("chrB", 100, 200, "g", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        result = conn.execute(sql)
+        rows = result.fetchall()
+        type_by_name = {d[0]: str(d[1]) for d in result.description}
+
+        # Assert
+        assert rows == []
+        assert type_by_name["a_chrom"] == "VARCHAR"
+        assert type_by_name["b_chrom"] == "VARCHAR"
+        assert type_by_name["a_start"] == "INTEGER"
+        assert type_by_name["a_end"] == "INTEGER"
+        assert type_by_name["b_start"] == "INTEGER"
+        assert type_by_name["b_end"] == "INTEGER"
+
+    def test_query_should_type_non_genomic_columns_in_empty_schema_fallback(self, conn):
+        """Test that non-genomic projected columns retain their real types when empty.
+
+        Given:
+            Two tables whose chromosome sets are disjoint, projecting a
+            non-genomic column whose declared type is INTEGER (not VARCHAR
+            or BIGINT).
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            It should fetch an empty result whose ``score`` column is typed
+            as INTEGER, matching the source table schema.
+        """
+        # Arrange
+        conn.execute(
+            "CREATE TABLE peaks (chrom VARCHAR, start BIGINT, "
+            '"end" BIGINT, score INTEGER)'
+        )
+        conn.execute(
+            "CREATE TABLE genes (chrom VARCHAR, start BIGINT, "
+            '"end" BIGINT, score INTEGER)'
+        )
+        conn.execute("INSERT INTO peaks VALUES ('chrA', 100, 200, 7)")
+        conn.execute("INSERT INTO genes VALUES ('chrB', 100, 200, 9)")
+        sql = transpile(
+            """
+            SELECT a.score AS a_score, b.score AS b_score
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        result = conn.execute(sql)
+        rows = result.fetchall()
+        type_by_name = {d[0]: str(d[1]) for d in result.description}
+
+        # Assert
+        assert rows == []
+        assert type_by_name["a_score"] == "INTEGER"
+        assert type_by_name["b_score"] == "INTEGER"
+
+    def test_query_should_preserve_outer_join_semantics_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that LEFT JOIN INTERSECTS preserves unmatched left rows.
+
+        Given:
+            A LEFT JOIN of ``peaks`` against ``genes`` on INTERSECTS,
+            with one peak that has no matching gene.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            The unmatched peak should appear in the result with NULL
+            gene columns (the IEJoin path falls back to the binned plan
+            for outer joins).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p_match", 0, "+"),
+                ("chr1", 5000, 6000, "p_lonely", 0, "+"),
+            ],
+        )
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.start AS a_start, b.start AS b_start
+            FROM peaks a
+            LEFT JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall(), key=lambda r: r[0])
+
+        # Assert
+        assert rows == [(100, 150), (5000, None)]
+
+    def test_query_should_preserve_extra_join_predicate_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that an extra non-INTERSECTS predicate is honored end-to-end.
+
+        Given:
+            A query whose JOIN ON carries
+            ``a.interval INTERSECTS b.interval AND a.score > b.score``,
+            with input rows where one pair overlaps and satisfies the
+            score predicate and another overlaps but violates it.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            Only the pair that overlaps and satisfies the extra
+            predicate should be returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p_high", 100, "+"),
+                ("chr1", 300, 400, "p_low", 1, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g_low", 5, "+"),
+                ("chr1", 350, 450, "g_high", 50, "+"),
+            ],
+        )
+        sql = transpile(
+            """
+            SELECT a.start AS a_start, b.start AS b_start
+            FROM peaks a
+            JOIN genes b
+              ON a.interval INTERSECTS b.interval
+             AND a.score > b.score
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert rows == [(100, 150)]
+
+    def test_query_should_return_correct_rows_for_literal_intersects_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that literal-range INTERSECTS produces the same rows as default.
+
+        Given:
+            A WHERE literal-range INTERSECTS query over ``peaks``.
+        When:
+            The query is transpiled with ``dialect=None`` and with
+            ``dialect='duckdb'`` and both are executed.
+        Then:
+            Both should return the same sorted rows.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 0, "+"),
+                ("chr1", 1500, 1700, "p2", 0, "+"),
+                ("chr1", 5000, 6000, "p3", 0, "+"),
+            ],
+        )
+        query = "SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1000-2000'"
+
+        # Act
+        rows_default = sorted(
+            conn.execute(transpile(query, tables=["peaks"])).fetchall()
+        )
+        rows_duckdb = sorted(
+            conn.execute(transpile(query, tables=["peaks"], dialect="duckdb")).fetchall()
+        )
+
+        # Assert
+        assert rows_default == rows_duckdb
+        assert rows_duckdb == [("chr1", 1500, 1700, "p2", 0, "+")]
+
+    def test_query_should_partition_on_custom_chrom_col_when_table_uses_custom_columns(
+        self, conn
+    ):
+        """Test that the IEJoin partition uses the configured chrom column.
+
+        Given:
+            DuckDB tables with ``chromosome``/``start_pos``/``end_pos``
+            custom column names and rows on multiple chromosomes (only
+            one of which has overlapping intervals).
+        When:
+            The query is transpiled with the matching ``Table`` configs
+            and ``dialect='duckdb'`` and executed.
+        Then:
+            It should return only the rows where the custom-named
+            chromosome column matches and the ranges overlap.
+        """
+        # Arrange
+        conn.execute(
+            "CREATE TABLE peaks (chromosome VARCHAR, start_pos INTEGER, end_pos INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO peaks VALUES "
+            "('chr1', 100, 200), "
+            "('chr2', 100, 200), "
+            "('chr3', 100, 200)"
+        )
+        conn.execute(
+            "CREATE TABLE genes (chromosome VARCHAR, start_pos INTEGER, end_pos INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO genes VALUES "
+            "('chr1', 150, 250), "
+            "('chr2', 1000, 2000), "
+            "('chr3', 5000, 6000)"
+        )
+        sql = transpile(
+            """
+            SELECT a.chromosome AS a_chrom, a.start_pos AS a_start,
+                   b.start_pos AS b_start
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=[
+                Table(
+                    "peaks",
+                    chrom_col="chromosome",
+                    start_col="start_pos",
+                    end_col="end_pos",
+                ),
+                Table(
+                    "genes",
+                    chrom_col="chromosome",
+                    start_col="start_pos",
+                    end_col="end_pos",
+                ),
+            ],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert rows == [("chr1", 100, 150)]
+
+    def test_query_should_preserve_row_multiplicity_for_duplicate_input_rows(self, conn):
+        """Test that duplicate input rows surface as duplicate output rows.
+
+        Given:
+            Two identical ``peaks`` rows that each overlap the same single
+            ``genes`` row, projecting genomic columns from both sides.
+        When:
+            The DuckDB-dialect SQL is executed.
+        Then:
+            The result should contain *two* identical overlap rows, not
+            one — a regression detector for a rewrite that silently
+            collapses duplicates via an unintended ``DISTINCT``. (The
+            property-based oracle below sorts a multiset, so this is the
+            canonical-example pin for the same invariant.)
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p_dup", 1, "+"),
+                ("chr1", 100, 200, "p_dup", 1, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [("chr1", 150, 250, "g1", 10, "-")],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, a.start AS s, a.end AS e "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert rows == [("chr1", 100, 200), ("chr1", 100, 200)]
+
+    def test_query_should_order_lexicographically_when_order_by_has_two_columns(
+        self, conn
+    ):
+        """Test that ORDER BY on two keys orders lexicographically.
+
+        Given:
+            Multiple overlap rows where the first ORDER BY key has ties
+            and the second key discriminates among them.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            Rows should come back in lexicographic order on the two
+            keys.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 100, 200, "p2", 2, "+"),
+                ("chr1", 300, 400, "p3", 3, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g_a", 10, "+"),
+                ("chr1", 350, 450, "g_b", 20, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s, b.score AS gs FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY a.start ASC, b.score DESC",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # Two chr1 peaks at start=100 overlap g_a (score 10); chr1 peak at
+        # start=300 overlaps g_b (score 20). Within the start=100 ties,
+        # b.score DESC is a no-op (only one matching gene), so the keyed
+        # order is: (100, 10), (100, 10), then (300, 20).
+        assert rows == [(100, 10), (100, 10), (300, 20)]
+
+    def test_query_should_skip_first_m_and_return_remainder_when_offset_only(self, conn):
+        """Test that OFFSET past the first ordered row returns the rest.
+
+        Given:
+            Three ordered overlap rows on chr1.
+        When:
+            The query is transpiled with ``LIMIT 5 OFFSET 1`` and
+            executed.
+        Then:
+            The trailing two rows (after skipping the first) are
+            returned, in order.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 300, 400, "p2", 2, "+"),
+                ("chr1", 500, 600, "p3", 3, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 350, 450, "g2", 2, "+"),
+                ("chr1", 550, 650, "g3", 3, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "ORDER BY a.start LIMIT 5 OFFSET 1",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(300,), (500,)]
+
+    def test_query_should_dedup_on_tuple_when_select_distinct_has_multiple_columns(
+        self, conn
+    ):
+        """Test that ``SELECT DISTINCT`` over a multi-column list dedups on tuples.
+
+        Given:
+            Multiple overlap rows that produce duplicate
+            ``(a.chrom, b.chrom)`` tuples but distinct ``a.start``
+            values.
+        When:
+            The query is transpiled with ``SELECT DISTINCT a.chrom AS
+            ca, b.chrom AS cb`` and executed.
+        Then:
+            The result should collapse to the set of distinct tuples,
+            not deduplicate on either column alone.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 300, 400, "p2", 2, "+"),
+                ("chr2", 100, 200, "p3", 3, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 350, 450, "g2", 2, "+"),
+                ("chr2", 150, 250, "g3", 3, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT DISTINCT a.chrom AS ca, b.chrom AS cb FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = set(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # Two chr1 join rows collapse to one ('chr1','chr1') tuple; chr2
+        # contributes one ('chr2','chr2') tuple. Total: 2 distinct tuples.
+        assert rows == {("chr1", "chr1"), ("chr2", "chr2")}
+
+    def test_query_should_filter_cross_side_predicate_in_where_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that a cross-side predicate in WHERE filters rows correctly.
+
+        Given:
+            Three overlapping pairs on chr1 where only those whose
+            peak's ``start`` is strictly less than the gene's ``start``
+            satisfy the cross-side WHERE predicate. (Variant of the
+            ON-side cross-predicate test — exercises the WHERE-extras
+            extraction path rather than the JOIN-ON extras path.)
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            Only the pair satisfying the cross-side WHERE predicate is
+            returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                (
+                    "chr1",
+                    100,
+                    200,
+                    "p_lt",
+                    1,
+                    "+",
+                ),  # a.start (100) < b.start (150) → keep
+                (
+                    "chr1",
+                    300,
+                    400,
+                    "p_eq",
+                    2,
+                    "+",
+                ),  # a.start (300) < b.start (350) → keep
+                (
+                    "chr1",
+                    500,
+                    600,
+                    "p_gt",
+                    3,
+                    "+",
+                ),  # a.start (500) > b.start (490) → drop
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 0, "+"),
+                ("chr1", 350, 450, "g2", 0, "+"),
+                ("chr1", 490, 590, "g3", 0, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS a_s, b.start AS b_s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.start < b.start",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(100, 150), (300, 350)]
+
+    def test_query_should_filter_by_between_predicate_when_dialect_is_duckdb(self, conn):
+        """Test that ``BETWEEN`` filters overlap rows.
+
+        Given:
+            Three overlap pairs with varied ``a.score``; the predicate
+            ``a.score BETWEEN 10 AND 50`` excludes the row at score=1
+            and the row at score=99.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            Only the score=20 row should be returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p_low", 1, "+"),
+                ("chr1", 300, 400, "p_mid", 20, "+"),
+                ("chr1", 500, 600, "p_high", 99, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 0, "+"),
+                ("chr1", 350, 450, "g2", 0, "+"),
+                ("chr1", 550, 650, "g3", 0, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "AND a.score BETWEEN 10 AND 50",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(300,)]
+
+    def test_query_should_honor_is_null_predicate_when_dialect_is_duckdb(self, conn):
+        """Test that ``WHERE a.score IS NULL`` filters overlap rows.
+
+        Given:
+            Two overlap pairs on chr1 — one with NULL ``a.score`` and
+            one with a non-NULL score.
+        When:
+            The query is transpiled with ``WHERE a.score IS NULL`` and
+            executed.
+        Then:
+            Only the NULL-score row should be returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p_null", None, "+"),
+                ("chr1", 300, 400, "p_set", 99, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 0, "+"),
+                ("chr1", 350, 450, "g2", 0, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.start AS s FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.score IS NULL",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(100,)]
+
+    def test_query_should_rewrite_user_aliases_p_g_to_inner_a_b_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that user aliases other than ``a``/``b`` get rewritten at runtime.
+
+        Given:
+            A join written as ``FROM peaks p JOIN genes g`` (user
+            aliases ``p`` and ``g``, not ``a`` and ``b``) with an extra
+            cross-side ON predicate ``p.score > g.score``.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            DuckDB should not raise an alias-resolution error — the
+            dialect rewrote ``p`` / ``g`` to the inner subquery's
+            hardcoded ``a`` / ``b`` aliases — and the filter should
+            return only the pair satisfying the cross-side predicate.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 100, "+"),
+                ("chr1", 300, 400, "p2", 5, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g_low", 10, "+"),
+                ("chr1", 350, 450, "g_high", 50, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT p.start AS p_s, g.start AS g_s FROM peaks p "
+            "JOIN genes g ON p.interval INTERSECTS g.interval "
+            "AND p.score > g.score",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [(100, 150)]
+
+    def test_query_should_count_non_null_column_values_per_group_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that ``COUNT(a.name)`` counts only non-NULL names per group.
+
+        Given:
+            Three overlap rows on chr1 — two with non-NULL ``a.name``
+            and one with NULL — plus one overlap on chr2 with non-NULL
+            ``a.name``.
+        When:
+            The query is transpiled with ``COUNT(a.name) GROUP BY
+            a.chrom`` and executed.
+        Then:
+            The chr1 count should be 2 (excluding the NULL), and the
+            chr2 count should be 1.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 110, 210, None, 2, "+"),
+                ("chr1", 120, 220, "p3", 3, "+"),
+                ("chr2", 100, 200, "p4", 4, "-"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr2", 150, 250, "g2", 2, "-"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, COUNT(a.name) AS n FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [("chr1", 2), ("chr2", 1)]
+
+    def test_query_should_group_by_multiple_columns_when_dialect_is_duckdb(self, conn):
+        """Test that multi-column GROUP BY groups by tuple.
+
+        Given:
+            Overlap rows whose ``(a.chrom, a.strand)`` tuples are
+            heterogeneous: two ``(chr1, +)`` overlaps, one ``(chr1, -)``
+            overlap.
+        When:
+            The query is transpiled with ``GROUP BY a.chrom, a.strand``
+            and executed.
+        Then:
+            One row per distinct ``(chrom, strand)`` tuple should be
+            returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 110, 210, "p2", 2, "+"),
+                ("chr1", 300, 400, "p3", 3, "-"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 350, 450, "g2", 2, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, a.strand AS s, COUNT(*) AS n FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom, a.strand",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [("chr1", "+", 2), ("chr1", "-", 1)]
+
+    def test_query_should_filter_groups_when_having_combines_two_conditions(self, conn):
+        """Test that ``HAVING`` with two AND-ed aggregate conditions filters groups.
+
+        Given:
+            Three chromosomes; chr1 has many low-score overlaps, chr2
+            has one high-score overlap, chr3 has many high-score
+            overlaps. Only chr3 satisfies both
+            ``COUNT(*) > 1 AND SUM(a.score) > 100``.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            Only chr3 should be returned.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                # chr1: 3 overlaps, all score 1 → COUNT > 1, SUM = 3
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 110, 210, "p2", 1, "+"),
+                ("chr1", 120, 220, "p3", 1, "+"),
+                # chr2: 1 overlap, score 99 → COUNT == 1 (fails)
+                ("chr2", 100, 200, "p4", 99, "+"),
+                # chr3: 2 overlaps, scores 60 each → COUNT > 1, SUM = 120
+                ("chr3", 100, 200, "p5", 60, "+"),
+                ("chr3", 110, 210, "p6", 60, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 0, "+"),
+                ("chr2", 150, 250, "g2", 0, "+"),
+                ("chr3", 150, 250, "g3", 0, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, COUNT(*) AS n, SUM(a.score) AS s "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom HAVING COUNT(*) > 1 AND SUM(a.score) > 100",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert rows == [("chr3", 2, 120)]
+
+    def test_query_should_compose_all_tier1_features_in_single_pipeline_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test the kitchen-sink composition of every Tier 1 feature.
+
+        Given:
+            A query combining an extra ON predicate (``a.score > 20``),
+            an extra WHERE predicate (``b.score < 50``), multi-column
+            ``GROUP BY``, a non-trivial ``HAVING`` (``SUM(a.score) >
+            40`` — actually filters one of the groups out), ``ORDER BY
+            n DESC``, and ``LIMIT 10`` — over data crafted so the
+            counts after both filters are 2/1/0 on chr1/chr2/chr3 but
+            chr2's surviving sum is below the HAVING threshold.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            Only chr1 survives — its 2-overlap SUM(a.score) of 70 beats
+            the threshold; chr2's single 30 fails it; chr3 was already
+            dropped by the ON predicate. LIMIT 10 has no effect (one
+            group survives). Aggregates SUM and COUNT(*) coexist and
+            the ORDER BY references the user-aliased COUNT alias.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                # chr1: two peaks both pass a.score > 20; sum = 70
+                ("chr1", 100, 200, "p1", 30, "+"),
+                ("chr1", 110, 210, "p2", 40, "+"),
+                # chr2: one peak passes a.score > 20; sum = 30 (fails HAVING)
+                ("chr2", 100, 200, "p3", 30, "-"),
+                # chr3: peak fails a.score > 20
+                ("chr3", 100, 200, "p4", 10, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                # chr1 gene passes b.score < 50 (=10)
+                ("chr1", 150, 250, "g1", 10, "+"),
+                # chr2 gene passes b.score < 50 (=20)
+                ("chr2", 150, 250, "g2", 20, "-"),
+                # chr3 gene would pass but no overlap-survivor exists
+                ("chr3", 150, 250, "g3", 5, "+"),
+            ],
+        )
+        sql = transpile(
+            "SELECT a.chrom AS c, COUNT(*) AS n, SUM(a.score) AS s "
+            "FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "AND a.score > 20 "
+            "WHERE b.score < 50 "
+            "GROUP BY a.chrom HAVING SUM(a.score) > 40 "
+            "ORDER BY n DESC LIMIT 10",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        # chr1: 2 overlaps, sum(a.score)=70 → passes HAVING
+        # chr2: 1 overlap, sum(a.score)=30 → fails HAVING
+        # chr3: 0 overlaps (peak filtered by ON) → no group
+        assert rows == [("chr1", 2, 70)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        [
+            ("0based", "half_open"),
+            ("0based", "closed"),
+            ("1based", "half_open"),
+            ("1based", "closed"),
+        ],
+    )
+    def test_query_should_match_binned_plan_for_coordinate_system_combinations(
+        self, conn, coordinate_system, interval_type
+    ):
+        """Test cross-plan equivalence across all 4 coord-system × interval-type combos.
+
+        Given:
+            A fixed 6-row truth table of peaks/genes with overlaps that
+            depend on how endpoints are interpreted.
+        When:
+            The same logical query is transpiled twice — once with
+            ``dialect=None`` (binned plan) and once with
+            ``dialect="duckdb"`` — under each of the 4
+            ``(coordinate_system, interval_type)`` combinations.
+        Then:
+            Both plans should return the same sorted multiset for every
+            combination, proving canonicalization composes with the
+            dialect rewrite consistently.
+        """
+        # Arrange — fixture uses strict (non-touching) overlaps so the
+        # overlap set is identical across all 4 coord-system × interval
+        # combos. The test then asserts that canonicalization composes
+        # with the dialect rewrite without changing which pairs match.
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 0, "+"),
+                ("chr1", 300, 400, "p2", 0, "+"),
+                ("chr1", 700, 800, "p3", 0, "+"),
+                ("chr2", 100, 200, "p4", 0, "-"),
+                ("chr2", 500, 600, "p5", 0, "-"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 0, "+"),
+                ("chr1", 350, 450, "g2", 0, "+"),
+                ("chr2", 50, 180, "g3", 0, "-"),
+                ("chr2", 550, 700, "g4", 0, "-"),
+            ],
+        )
+        tables = [
+            Table(
+                "peaks",
+                coordinate_system=coordinate_system,
+                interval_type=interval_type,
+            ),
+            Table(
+                "genes",
+                coordinate_system=coordinate_system,
+                interval_type=interval_type,
+            ),
+        ]
+        query = (
+            "SELECT a.chrom AS c, a.start AS s "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval"
+        )
+        sql_default = transpile(query, tables=tables)
+        sql_duckdb = transpile(query, tables=tables, dialect="duckdb")
+        # Python-native ground truth. The fixture uses strict (non-
+        # touching) overlaps, so the matching set is identical across
+        # all 4 coord-system × interval combos — that's the property
+        # the test is pinning. Asserting against this expected list
+        # (not just `rows_default == rows_duckdb`) catches a regression
+        # in which both plans share the same bug.
+        expected = [
+            ("chr1", 100),  # peaks[100,200) ∩ genes[150,250)
+            ("chr1", 300),  # peaks[300,400) ∩ genes[350,450)
+            ("chr2", 100),  # peaks[100,200) ∩ genes[50,180)
+            ("chr2", 500),  # peaks[500,600) ∩ genes[550,700)
+        ]
+
+        # Act
+        rows_default = sorted(conn.execute(sql_default).fetchall())
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+
+        # Assert
+        assert rows_duckdb == expected
+        assert rows_default == rows_duckdb
+
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2", "chr3"]),
+                st.integers(min_value=0, max_value=200),
+                st.integers(min_value=1, max_value=50),
+            ),
+            min_size=0,
+            max_size=8,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2", "chr3"]),
+                st.integers(min_value=0, max_value=200),
+                st.integers(min_value=1, max_value=50),
+            ),
+            min_size=0,
+            max_size=8,
+        ),
+    )
+    def test_query_should_match_python_native_overlap_for_random_inputs(
+        self, conn, peaks, genes
+    ):
+        """Test the IEJoin path against a Python-native overlap reference.
+
+        Given:
+            A Hypothesis-generated pair of small interval lists drawn
+            from a tiny chromosome alphabet and small int starts/lengths
+            (half-open coordinates on both sides).
+        When:
+            The DuckDB-dialect SQL is executed and compared against a
+            Python-native overlap reference
+            (``a.end > b.start AND b.end > a.start AND a.chrom == b.chrom``).
+        Then:
+            The set of overlapping ``(chrom, start, end, chrom, start,
+            end)`` tuples should be identical between the two methods.
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length) for (c, s, length) in peaks]
+        gene_rows = [(c, s, s + length) for (c, s, length) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if peak_rows:
+            conn.executemany("INSERT INTO peaks VALUES (?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if gene_rows:
+            conn.executemany("INSERT INTO genes VALUES (?, ?, ?)", gene_rows)
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        sql_rows = sorted(conn.execute(sql).fetchall())
+        expected = _python_overlap(peak_rows, gene_rows)
+
+        # Assert: sorted-multiset equality — a `set` here would collapse
+        # duplicate input rows and silently hide multiplicity bugs.
+        assert sql_rows == expected
+
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+    )
+    def test_query_should_match_binned_plan_for_random_inputs(self, conn, peaks, genes):
+        """Test that the binned plan and the IEJoin path agree on random inputs.
+
+        Given:
+            A Hypothesis-generated pair of small interval lists.
+        When:
+            The same logical query is transpiled both with
+            ``dialect=None`` and with ``dialect='duckdb'`` and executed.
+        Then:
+            Both plans should return the same multiset of overlapping
+            rows.
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length) for (c, s, length) in peaks]
+        gene_rows = [(c, s, s + length) for (c, s, length) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if peak_rows:
+            conn.executemany("INSERT INTO peaks VALUES (?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if gene_rows:
+            conn.executemany("INSERT INTO genes VALUES (?, ?, ?)", gene_rows)
+        query = """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, a.end AS a_end,
+                   b.chrom AS b_chrom, b.start AS b_start, b.end AS b_end
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = sorted(conn.execute(sql_default).fetchall())
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+
+        # Assert
+        assert rows_default == rows_duckdb
+
+    @settings(
+        max_examples=30,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+                st.integers(min_value=0, max_value=50),
+            ),
+            min_size=1,
+            max_size=6,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+                st.integers(min_value=0, max_value=50),
+            ),
+            min_size=1,
+            max_size=6,
+        ),
+        score_threshold=st.integers(min_value=0, max_value=50),
+    )
+    def test_query_should_match_binned_plan_when_where_group_count_order_combined(
+        self, conn, peaks, genes, score_threshold
+    ):
+        """Test cross-plan equivalence with extras, GROUP BY, and ORDER BY.
+
+        Given:
+            Hypothesis-generated peak / gene interval lists carrying
+            scores, and a random ``score_threshold``.
+        When:
+            The same logical query — combining a WHERE extra predicate,
+            a GROUP BY, a COUNT(*) aggregate, and ORDER BY — is
+            transpiled both with ``dialect=None`` and ``dialect='duckdb'``
+            and executed.
+        Then:
+            Both plans should return the same multiset of grouped rows.
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length, score) for (c, s, length, score) in peaks]
+        gene_rows = [(c, s, s + length, score) for (c, s, length, score) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, '
+            '"end" INTEGER, score INTEGER)'
+        )
+        conn.executemany("INSERT INTO peaks VALUES (?, ?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, '
+            '"end" INTEGER, score INTEGER)'
+        )
+        conn.executemany("INSERT INTO genes VALUES (?, ?, ?, ?)", gene_rows)
+        query = (
+            "SELECT a.chrom AS c, COUNT(*) AS n "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval "
+            f"WHERE a.score >= {score_threshold} "
+            "GROUP BY a.chrom "
+            "ORDER BY a.chrom"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = conn.execute(sql_default).fetchall()
+        rows_duckdb = conn.execute(sql_duckdb).fetchall()
+
+        # Assert
+        assert rows_default == rows_duckdb
+
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        chrom_name=st.text(
+            alphabet=st.characters(
+                min_codepoint=0x20,
+                max_codepoint=0x7E,
+                blacklist_characters=["\x00", "%", "?"],
+            ),
+            min_size=1,
+            max_size=10,
+        ),
+    )
+    def test_query_should_round_trip_arbitrary_chrom_names_under_dialect(
+        self, conn, chrom_name
+    ):
+        """Test that arbitrary printable chrom names round-trip the IEJoin path.
+
+        Given:
+            A Hypothesis-drawn printable-ASCII chromosome name (length
+            1..10, excluding NUL, ``%``, ``?``) that may include single
+            quotes, double quotes, or backslashes, seeded as the chrom
+            value of a single overlapping pair.
+        When:
+            The DuckDB-dialect SQL is generated and executed.
+        Then:
+            The pair should be returned exactly once and the chrom value
+            should round-trip byte-for-byte.
+        """
+        # Arrange
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.execute("INSERT INTO peaks VALUES (?, ?, ?)", (chrom_name, 100, 200))
+        conn.execute("INSERT INTO genes VALUES (?, ?, ?)", (chrom_name, 150, 250))
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [(chrom_name, 100)]
+
+    @settings(
+        max_examples=30,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+                # Nullable score so IS NULL / IS NOT NULL aren't
+                # tautological against an always-populated column.
+                st.one_of(st.none(), st.integers(min_value=0, max_value=50)),
+            ),
+            min_size=1,
+            max_size=5,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+                st.one_of(st.none(), st.integers(min_value=0, max_value=50)),
+            ),
+            min_size=1,
+            max_size=5,
+        ),
+        predicate_kind=st.sampled_from(
+            ["cmp", "between", "in_list", "cross_side", "is_null"]
+        ),
+        threshold=st.integers(min_value=0, max_value=50),
+    )
+    def test_query_should_match_binned_plan_for_random_extra_where_predicates(
+        self, conn, peaks, genes, predicate_kind, threshold
+    ):
+        """Test cross-plan equivalence under random WHERE extras.
+
+        Given:
+            Hypothesis-generated peak / gene interval lists with
+            (possibly NULL) score columns, plus a sampled predicate
+            kind from ``{cmp, between, in_list, cross_side, is_null}``.
+        When:
+            The composed query is transpiled under both ``dialect=None``
+            and ``dialect="duckdb"`` and executed.
+        Then:
+            Both plans should return the same sorted multiset.
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length, score) for (c, s, length, score) in peaks]
+        gene_rows = [(c, s, s + length, score) for (c, s, length, score) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, '
+            '"end" INTEGER, score INTEGER)'
+        )
+        conn.executemany("INSERT INTO peaks VALUES (?, ?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, '
+            '"end" INTEGER, score INTEGER)'
+        )
+        conn.executemany("INSERT INTO genes VALUES (?, ?, ?, ?)", gene_rows)
+        where_clauses = {
+            "cmp": f"WHERE a.score >= {threshold}",
+            "between": f"WHERE a.score BETWEEN {threshold} AND {threshold + 20}",
+            "in_list": "WHERE a.score IN (0, 10, 20, 30, 40, 50)",
+            "cross_side": "WHERE a.score >= b.score",
+            "is_null": "WHERE a.score IS NOT NULL",
+        }
+        where = where_clauses[predicate_kind]
+        query = (
+            "SELECT a.chrom AS c, a.start AS s "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval "
+            f"{where}"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = sorted(conn.execute(sql_default).fetchall())
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+
+        # Assert
+        assert rows_default == rows_duckdb
+
+    @settings(
+        max_examples=30,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+                st.integers(min_value=0, max_value=50),
+            ),
+            min_size=1,
+            max_size=5,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+                st.integers(min_value=0, max_value=50),
+            ),
+            min_size=1,
+            max_size=5,
+        ),
+        aggregate_kind=st.sampled_from(
+            [
+                "count_star",
+                "sum_a_score",
+                "min_b_start",
+                "max_b_end",
+                "count_distinct_b_chrom",
+            ]
+        ),
+    )
+    def test_query_should_match_binned_plan_for_random_group_by_aggregates(
+        self, conn, peaks, genes, aggregate_kind
+    ):
+        """Test cross-plan equivalence for GROUP BY + random aggregate.
+
+        Given:
+            Hypothesis-generated peak / gene interval lists with score
+            columns, plus a sampled aggregate from a small whitelist.
+        When:
+            A query with ``GROUP BY a.chrom`` and the chosen aggregate
+            is transpiled under both ``dialect=None`` and
+            ``dialect="duckdb"`` and executed.
+        Then:
+            Both plans should return the same row list (sorted by chrom
+            for stable comparison; ``AVG`` excluded from this PBT to
+            keep equality strict — covered by an example test instead).
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length, score) for (c, s, length, score) in peaks]
+        gene_rows = [(c, s, s + length, score) for (c, s, length, score) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, '
+            '"end" INTEGER, score INTEGER)'
+        )
+        conn.executemany("INSERT INTO peaks VALUES (?, ?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, '
+            '"end" INTEGER, score INTEGER)'
+        )
+        conn.executemany("INSERT INTO genes VALUES (?, ?, ?, ?)", gene_rows)
+        aggregates = {
+            "count_star": "COUNT(*)",
+            "sum_a_score": "SUM(a.score)",
+            "min_b_start": "MIN(b.start)",
+            "max_b_end": "MAX(b.end)",
+            "count_distinct_b_chrom": "COUNT(DISTINCT b.chrom)",
+        }
+        agg = aggregates[aggregate_kind]
+        query = (
+            f"SELECT a.chrom AS c, {agg} AS v "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom ORDER BY a.chrom"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = conn.execute(sql_default).fetchall()
+        rows_duckdb = conn.execute(sql_duckdb).fetchall()
+
+        # Assert — ORDER BY makes positional comparison meaningful.
+        assert rows_default == rows_duckdb
+
+    @settings(
+        # Full-composite has the largest input space (extras + GROUP BY
+        # + HAVING + ORDER BY + LIMIT + OFFSET), so we run more examples.
+        max_examples=60,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        # Allow ``min_size=0`` on peaks so empty-input cross-plan
+        # equivalence is exercised in combination with the full Tier 1
+        # stack (the simpler PBTs use min_size=1).
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+                st.integers(min_value=0, max_value=50),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+                st.integers(min_value=0, max_value=50),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+        score_threshold=st.integers(min_value=0, max_value=50),
+        having_min=st.integers(min_value=0, max_value=5),
+        # Include LIMIT 0 so the trivial-truncation edge case is
+        # exercised against both plans.
+        limit=st.integers(min_value=0, max_value=10),
+    )
+    def test_query_should_match_binned_plan_for_full_composite_query(
+        self, conn, peaks, genes, score_threshold, having_min, limit
+    ):
+        """Test cross-plan equivalence under the full Tier 1 composition.
+
+        Given:
+            Hypothesis-generated peaks/genes with random thresholds for
+            an extra WHERE predicate, a HAVING minimum count, and a
+            LIMIT.
+        When:
+            A query exercising extra ON + extra WHERE + GROUP BY +
+            HAVING + ORDER BY + LIMIT is transpiled under both
+            ``dialect=None`` and ``dialect="duckdb"`` and executed.
+        Then:
+            Both plans should return the same ordered row list (``==``,
+            because ``ORDER BY`` makes order part of the contract).
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length, score) for (c, s, length, score) in peaks]
+        gene_rows = [(c, s, s + length, score) for (c, s, length, score) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, '
+            '"end" INTEGER, score INTEGER)'
+        )
+        # DuckDB's executemany rejects empty parameter lists; skip the
+        # INSERT step when the strategy generates no rows.
+        if peak_rows:
+            conn.executemany("INSERT INTO peaks VALUES (?, ?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, '
+            '"end" INTEGER, score INTEGER)'
+        )
+        if gene_rows:
+            conn.executemany("INSERT INTO genes VALUES (?, ?, ?, ?)", gene_rows)
+        query = (
+            "SELECT a.chrom AS c, COUNT(*) AS n "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval AND a.score >= b.score "
+            f"WHERE a.score >= {score_threshold} "
+            "GROUP BY a.chrom "
+            f"HAVING COUNT(*) >= {having_min} "
+            "ORDER BY a.chrom "
+            f"LIMIT {limit}"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = conn.execute(sql_default).fetchall()
+        rows_duckdb = conn.execute(sql_duckdb).fetchall()
+
+        # Assert
+        assert rows_default == rows_duckdb
+
+    def test_query_should_match_inner_join_result_when_using_join_targets_chrom_only(
+        self, peaks_genes
+    ):
+        """Test that USING(chrom) returns the same rows as plain INNER JOIN.
+
+        Given:
+            The shared peaks_genes fixture and two queries — one using
+            ``JOIN ... ON a.interval INTERSECTS b.interval`` and another
+            using ``JOIN ... USING (chrom) WHERE a.interval INTERSECTS
+            b.interval`` — both with ``dialect='duckdb'``.
+        When:
+            Both are executed.
+        Then:
+            They should return identical sorted row sets, because
+            USING(chrom) is redundant with the dialect's per-chromosome
+            partition.
+        """
+        # Arrange
+        plain_sql = transpile(
+            "SELECT a.chrom, a.start, a.end "
+            "FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+        using_sql = transpile(
+            "SELECT a.chrom, a.start, a.end "
+            "FROM peaks a JOIN genes b USING (chrom) "
+            "WHERE a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        plain_rows = sorted(peaks_genes.execute(plain_sql).fetchall())
+        using_rows = sorted(peaks_genes.execute(using_sql).fetchall())
+
+        # Assert
+        assert plain_rows == using_rows
+
+    def test_query_should_match_binned_plan_for_mixed_case_aliases(self, conn):
+        """Test that mixed-case aliases under the dialect match the binned plan.
+
+        Given:
+            The shared peaks_genes fixture loaded onto ``conn`` and a
+            query using uppercase aliases (``peaks A`` / ``genes B``).
+        When:
+            The same logical query is transpiled both with
+            ``dialect=None`` and ``dialect='duckdb'`` and executed.
+        Then:
+            Both plans should return the same multiset of rows.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 10, "+"),
+                ("chr1", 500, 600, "p2", 20, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 500, 600, "g2", 2, "+"),
+            ],
+        )
+        query = (
+            "SELECT A.chrom, A.start, B.start "
+            "FROM peaks A JOIN genes B "
+            "ON A.interval INTERSECTS B.interval"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = sorted(conn.execute(sql_default).fetchall())
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+
+        # Assert
+        assert rows_default == rows_duckdb
+
+    def test_query_should_preserve_rows_from_left_only_chromosomes_when_join_is_anti(self, conn):
+        """Test that ANTI JOIN preserves left-only chromosomes (C1b regression).
+
+        Given:
+            Peaks on chr1 and chr3; genes on chr1 only. Under ANTI JOIN
+            with INTERSECTS, chr3 peaks must be returned (they have no
+            overlapping right-side row), and chr1 peaks that don't
+            overlap any gene must also be returned.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            executed.
+        Then:
+            It should return the chr3 peak and any chr1 peaks with no
+            overlap — the chrom-INTERSECT partition would have excluded
+            chr3 entirely, so this is the critical regression for
+            C1b's left-distinct partition swap.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 10, 20, "p1", 0, "+"),  # no overlap with chr1 gene
+                ("chr1", 100, 200, "p2", 0, "+"),  # overlaps chr1 gene
+                ("chr3", 1, 1000, "p3", 0, "+"),  # chr3 — no genes there
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [("chr1", 50, 150, "g1", 0, "+")],
+        )
+        sql = transpile(
+            "SELECT a.chrom, a.start, a.end "
+            "FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert rows == sorted([("chr1", 10, 20), ("chr3", 1, 1000)])
+
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2", "chr3"]),
+                st.integers(min_value=0, max_value=200),
+                st.integers(min_value=1, max_value=50),
+            ),
+            min_size=0,
+            max_size=8,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2", "chr3"]),
+                st.integers(min_value=0, max_value=200),
+                st.integers(min_value=1, max_value=50),
+            ),
+            min_size=0,
+            max_size=8,
+        ),
+    )
+    def test_query_should_match_python_native_semi_overlap_for_random_inputs(
+        self, conn, peaks, genes
+    ):
+        """Test SEMI JOIN against a Python-native semi-overlap reference.
+
+        Given:
+            A Hypothesis-generated pair of small interval lists drawn
+            from a tiny chromosome alphabet.
+        When:
+            A ``SEMI JOIN ... ON a.interval INTERSECTS b.interval`` is
+            transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The set of returned ``(chrom, start, end)`` tuples should
+            equal the Python reference (distinct left rows that have
+            at least one overlapping right row).
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length) for (c, s, length) in peaks]
+        gene_rows = [(c, s, s + length) for (c, s, length) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if peak_rows:
+            conn.executemany("INSERT INTO peaks VALUES (?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if gene_rows:
+            conn.executemany("INSERT INTO genes VALUES (?, ?, ?)", gene_rows)
+        sql = transpile(
+            "SELECT a.chrom, a.start, a.end "
+            "FROM peaks a "
+            "SEMI JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        sql_rows = sorted(set(conn.execute(sql).fetchall()))
+        expected = _python_semi_overlap(peak_rows, gene_rows)
+
+        # Assert
+        assert sql_rows == expected
+
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+    )
+    def test_query_should_match_binned_plan_for_semi_join_random_inputs(
+        self, conn, peaks, genes
+    ):
+        """Test that SEMI JOIN under the dialect matches the binned plan.
+
+        Given:
+            A Hypothesis-generated pair of small interval lists.
+        When:
+            The same SEMI JOIN INTERSECTS query is transpiled with
+            ``dialect=None`` (binned) and ``dialect='duckdb'`` and
+            executed.
+        Then:
+            Both plans should return the same multiset of distinct
+            left rows.
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length) for (c, s, length) in peaks]
+        gene_rows = [(c, s, s + length) for (c, s, length) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if peak_rows:
+            conn.executemany("INSERT INTO peaks VALUES (?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if gene_rows:
+            conn.executemany("INSERT INTO genes VALUES (?, ?, ?)", gene_rows)
+        query = (
+            "SELECT a.chrom, a.start, a.end "
+            "FROM peaks a "
+            "SEMI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = sorted(set(conn.execute(sql_default).fetchall()))
+        rows_duckdb = sorted(set(conn.execute(sql_duckdb).fetchall()))
+
+        # Assert
+        assert rows_default == rows_duckdb
+
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2", "chr3"]),
+                st.integers(min_value=0, max_value=200),
+                st.integers(min_value=1, max_value=50),
+            ),
+            min_size=0,
+            max_size=8,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2", "chr3"]),
+                st.integers(min_value=0, max_value=200),
+                st.integers(min_value=1, max_value=50),
+            ),
+            min_size=0,
+            max_size=8,
+        ),
+    )
+    def test_query_should_match_python_native_anti_overlap_for_random_inputs(
+        self, conn, peaks, genes
+    ):
+        """Test ANTI JOIN against a Python-native anti-overlap reference.
+
+        Given:
+            A Hypothesis-generated pair of small interval lists.
+        When:
+            An ``ANTI JOIN ... ON a.interval INTERSECTS b.interval`` is
+            transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The set of returned ``(chrom, start, end)`` tuples should
+            equal the Python reference (distinct left rows with no
+            overlapping right row, including rows on chromosomes
+            absent from the right table).
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length) for (c, s, length) in peaks]
+        gene_rows = [(c, s, s + length) for (c, s, length) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if peak_rows:
+            conn.executemany("INSERT INTO peaks VALUES (?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if gene_rows:
+            conn.executemany("INSERT INTO genes VALUES (?, ?, ?)", gene_rows)
+        sql = transpile(
+            "SELECT a.chrom, a.start, a.end "
+            "FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Act
+        sql_rows = sorted(set(conn.execute(sql).fetchall()))
+        expected = _python_anti_overlap(peak_rows, gene_rows)
+
+        # Assert
+        assert sql_rows == expected
+
+    # NOTE: a `test_query_should_match_binned_plan_for_anti_join_random_inputs`
+    # would also be desirable, but the binned plan currently returns the
+    # WRONG result for ANTI JOIN when the right table is empty (it drops
+    # all left rows, where ANTI semantics demands that every left row
+    # passes). The dialect IS correct for that case — covered by
+    # ``test_query_should_preserve_rows_from_left_only_chromosomes_when_join_is_anti`` and
+    # ``test_query_should_match_python_native_anti_overlap_for_random_inputs``
+    # — so cross-plan parity for ANTI is not a useful contract until the
+    # binned plan's ANTI handling is fixed in a follow-up.
+
+
+class TestTranspileDuckDBIEJoinKwargs:
+    """Tests for the ``dialect`` / ``intersects_bin_size`` kwarg surface.
+
+    Covers the ``@overload`` pair on :func:`giql.transpile.transpile`, the
+    mutual-exclusivity validation between ``dialect`` and
+    ``intersects_bin_size``, the unknown-dialect error, and one
+    behavioral regression — running ``intersects_bin_size`` with
+    ``dialect`` omitted — that verifies adding the dialect kwarg did not
+    perturb the binned plan.
+    """
+
+    def test_transpile_should_match_default_when_dialect_none_is_explicit(self):
+        """Test that ``dialect=None`` is equivalent to omitting the kwarg.
+
+        Given:
+            A column-to-column INTERSECTS JOIN.
+        When:
+            ``transpile`` is called once with ``dialect=None`` explicit
+            and once with the kwarg omitted entirely.
+        Then:
+            Both calls should produce byte-identical SQL output.
+        """
+        # Arrange
+        query = """
+            SELECT a.chrom, a.start, b.start
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act
+        sql_omitted = transpile(query, tables=["peaks", "genes"])
+        sql_explicit_none = transpile(query, tables=["peaks", "genes"], dialect=None)
+
+        # Assert
+        assert sql_omitted == sql_explicit_none
+
+    def test_transpile_should_accept_intersects_bin_size_when_dialect_is_omitted(
+        self, conn
+    ):
+        """Test that ``intersects_bin_size`` works when ``dialect`` is omitted.
+
+        Given:
+            A column-to-column INTERSECTS JOIN.
+        When:
+            ``transpile`` is called with ``intersects_bin_size=50000`` and
+            no ``dialect`` and the resulting SQL is executed.
+        Then:
+            It should return the correct overlapping rows.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p", 0, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g", 0, "+")])
+        sql = transpile(
+            """
+            SELECT a.chrom AS a_chrom, a.start AS a_start, b.start AS b_start
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """,
+            tables=["peaks", "genes"],
+            intersects_bin_size=50000,
+        )
+
+        # Act
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert rows == [("chr1", 100, 150)]
+
+    def test_transpile_should_echo_offending_value_in_unknown_dialect_error(self):
+        """Test that the unknown-dialect error names the offending value.
+
+        Given:
+            An unknown dialect string ``'postgres'``.
+        When:
+            ``transpile`` is called.
+        Then:
+            It should raise ``ValueError`` whose message contains both
+            ``Unknown dialect`` and the literal ``'postgres'``.
+        """
+        # Arrange
+        query = "SELECT * FROM peaks"
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(query, tables=["peaks"], dialect="postgres")
+        message = str(excinfo.value)
+        assert "Unknown dialect" in message
+        assert "'postgres'" in message
+
+    def test_transpile_should_mention_both_kwargs_in_mutex_error_message(self):
+        """Test that the mutex error names both ``intersects_bin_size`` and ``duckdb``.
+
+        Given:
+            ``dialect='duckdb'`` together with a non-None
+            ``intersects_bin_size``.
+        When:
+            ``transpile`` is called.
+        Then:
+            It should raise ``ValueError`` whose message mentions both
+            ``intersects_bin_size`` and ``duckdb``.
+        """
+        # Arrange
+        query = """
+            SELECT a.chrom, a.start, b.start
+            FROM peaks a
+            JOIN genes b ON a.interval INTERSECTS b.interval
+            """
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                query,
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+                intersects_bin_size=50000,
+            )
+        message = str(excinfo.value)
+        assert "intersects_bin_size" in message
+        assert "duckdb" in message


### PR DESCRIPTION
## Summary

Add an opt-in DuckDB-specific transpilation path for column-to-column `INTERSECTS` joins. Passing `dialect="duckdb"` to `transpile()` routes a query through a new `IntersectsDuckDBIEJoinTransformer` that emits a `SET VARIABLE` block whose value is a per-chromosome `UNION ALL` of pure inequality-predicate subqueries, then selects through `query(getvariable(...))`. Each per-chromosome subquery is planned by DuckDB's range-join family (`IE_JOIN` or `PIECEWISE_MERGE_JOIN`), avoiding the cross-chromosome candidate-pair materialization that hurts a global IEJoin and the `UNNEST` / `DISTINCT` overhead that hurts the generic binned equi-join.

The dialect is mutually exclusive with `intersects_bin_size`. Passing both raises `ValueError`, and `@overload` declarations make the combination a static type error as well. When `dialect` is `None`, the existing binned plan continues to run unchanged.

The dialect handles INNER, SEMI, and ANTI joins with exactly one column-to-column `INTERSECTS` predicate plus a broad set of common decorations layered on top: top-level `ORDER BY` / `LIMIT` / `OFFSET` / `DISTINCT` on the outer SELECT, `GROUP BY` / `HAVING` with aggregate functions (`COUNT`, `SUM`, `MIN`, `MAX`, `AVG`, `COUNT(DISTINCT a.col)`, and any other `exp.AggFunc` subclass), and extra non-`INTERSECTS` predicates ANDed onto the join `ON` or `WHERE` (both single-side and cross-side, including `BETWEEN`, `IN (literal-list)`, `LIKE`, `IS NULL`). Outer-join `INTERSECTS` (in `ON` or `WHERE`), self-joins, multi-`INTERSECTS` queries, three-or-more-table FROM clauses, top-level `WITH` / CTE clauses, `DISTINCT ON (...)`, OR / NOT / paren-wrapped extras, unqualified-column extras, extras containing subqueries / aggregates / window functions, and subqueries (including `EXISTS`) inside `GROUP BY` / `HAVING` / `ORDER BY` all fall back to the binned plan automatically — callers can opt in unconditionally without hitting silent correctness regressions on unsupported shapes. Bare `SELECT *`, unqualified projections, expression-form projections, unknown table qualifiers, aggregates with unqualified arguments, `a.* AS x` (star-with-user-alias), window aggregates in `SELECT`, `FILTER (WHERE ...)` clauses on aggregates, aggregates inside arithmetic or function expressions (`COUNT(*) * 2`), and scalar subqueries in the `SELECT` list each raise `ValueError` with a dedicated message naming the offending shape.

Coordinate-system canonicalization is performed via a new `giql.canonical` module exposing `canonical_start` / `canonical_end` plus their inverses `decanonical_start` / `decanonical_end`. The functions are lifted out of `BaseGIQLGenerator` so the dialect transformer and the existing generator share a single source of truth across all four `(coordinate_system, interval_type)` combinations.

Two implementation notes depart from the original issue text. The dialect uses `SELECT * FROM query(getvariable(...))` rather than `EXECUTE getvariable(...)` — the latter no longer works in current DuckDB, while the former lets `transpile()` keep returning a single SQL string. The performance documentation describes the speedup qualitatively as a range-join family approach rather than the original "~2× faster" framing, and the partition-explosion guard (issue concern #6) is documented as a follow-up rather than enforced statically.

By inlining extra `JOIN ON` / `WHERE` predicates into each per-chromosome subquery directly, the dialect also sidesteps the pre-existing binned-plan bug [#94](https://github.com/abdenlab/giql/issues/94) — the `WHERE-INTERSECTS-plus-separate-JOIN-ON-predicate` shape that previously dropped the user's `ON` predicate now executes correctly under `dialect="duckdb"`. The binned plan itself remains affected for `dialect=None` callers; that fix lands separately under #94.

Closes #85

## Proposed changes

### Extract coordinate canonicalization into `giql.canonical`

`canonical_start`, `canonical_end`, `decanonical_start`, and `decanonical_end` move out of `BaseGIQLGenerator` into a new `src/giql/canonical.py`. Each function takes a raw column expression plus a `Table` (or `None`) and wraps the expression with whatever offset the table's `(coordinate_system, interval_type)` pair requires to reach the canonical 0-based half-open form. The decanonical counterparts apply the inverse offset so emitted endpoints land back in the table's own encoding. `BaseGIQLGenerator` now imports and delegates to the module-level helpers; behavior is unchanged for every existing call site.

### Add `IntersectsDuckDBIEJoinTransformer`

The new transformer in `src/giql/transformer.py` walks the parsed AST and rewrites a single column-to-column `INTERSECTS` join into the dynamic-SQL pattern. It identifies the target join (explicit `JOIN ... ON` or implicit cross-join in `WHERE`), pulls partition column / coordinate system / interval type from the relevant `Table`, builds the dynamic SQL with `string_agg(...)` over `(SELECT DISTINCT chrom FROM left INTERSECT SELECT DISTINCT chrom FROM right)`, wraps it in `COALESCE(..., <empty schema>)`, stores it in `__giql_iejoin_<token>`, and emits `SELECT ... FROM query(getvariable('__giql_iejoin_<token>')) AS __giql_duckdb_iejoin_<token>` for the outer projection. Five INTERSECTS-walking helpers (`_is_column_intersects`, `_find_column_intersects_in`, `_has_outer_join_intersects`, `_strip_intersects`, `_count_column_intersects`) move from `IntersectsBinnedJoinTransformer` to module scope so both transformers reuse one definition; the binned transformer no longer carries duplicate copies.

`_resolve_projections` pre-allocates a unique `__giql_p<n>` inner alias for every column the query references anywhere (SELECT, GROUP BY, HAVING, ORDER BY, aggregate argument), so the wrapper relation exposes every needed column regardless of whether the user surfaces it in the outer SELECT list. The empty-schema fallback projects the same columns from the source tables under `WHERE FALSE` so DuckDB resolves each output column to its real declared type instead of a hand-rolled NULL cast. Chromosome literals are escaped manually because DuckDB has no `quote_literal`.

### Outer modifiers, extras, and aggregates absorbed into the dialect path

- **Outer modifiers (`ORDER BY` / `LIMIT` / `OFFSET` / plain `DISTINCT`).** Appended to the outer wrapper SELECT. `ORDER BY` column references are rewritten through `_rewrite_modifier_refs` to use the wrapper relation's `__giql_p<n>` column names. `DISTINCT ON (...)` is the one DISTINCT variant that still falls back.
- **Extra `JOIN ON` / `WHERE` predicates.** `_extract_extra_predicates` walks the AND tree under each join `ON` and the `WHERE`, strips the target `INTERSECTS`, and returns the residuals. Each residual is rewritten through `_rewrite_subquery_refs` so its column refs use the inner subquery's hardcoded `a` / `b` aliases, then ANDed onto each per-chromosome subquery's join ON. `_can_inline_extras` validates each residual is safe to inline; anything failing the safety check routes to the binned plan.
- **`GROUP BY` / `HAVING` with aggregates.** `_resolve_projections` recognizes `exp.AggFunc` targets in the SELECT list and rewrites the aggregate's argument to reference the inner alias. Modifier-only columns referenced solely in `GROUP BY` / `HAVING` / `ORDER BY` are auto-projected into the inner subquery so the wrapper relation surfaces them, even when they're absent from the user's SELECT list. Aggregate arguments must be table-qualified; `SUM(score)` raises while `SUM(a.score)` is fine. Paren-wrapped aggregates (`(SUM(a.score)) AS s`) are peeled and routed through the same path.

### Defensive fallback gates and targeted error messages

The dialect's outer gate in `transform_to_sql` declines several shapes that would otherwise either crash at runtime or silently rewrite the query into a different shape: outer-join `INTERSECTS` in either `ON` or `WHERE`, subqueries (including `EXISTS` / `NOT EXISTS`) inside `GROUP BY` / `HAVING` / `ORDER BY`, self-joins, multi-`INTERSECTS` queries, three-or-more-table FROM clauses, non-base-table operands, and top-level `WITH` clauses all fall back unconditionally.

When a query can engage the dialect path but the SELECT list contains a shape the dialect can't translate, `_resolve_projections` raises `_UnqualifiedProjectionError` (wrapped to `ValueError` at the public API boundary) with a dedicated message naming the offending form.

### Expose `dialect` kwarg on `transpile()`

`transpile()` now accepts `dialect: Literal["duckdb"] | None = None`. Two `@overload` signatures encode the surface: one for the binned path (`dialect: None, intersects_bin_size: int | None`) and one for the dialect path (`dialect: Literal["duckdb"], intersects_bin_size: None`). The implementation guards the mutual exclusivity at runtime with a `ValueError` whose message points the caller at the right knob to drop; an unknown `dialect` value echoes the offending value back. A `_reraise_as_value_error` context manager surrounds the parse, transformer chain, and generator stages so user-facing `ValueError`s propagate verbatim while unexpected exceptions wrap to `ValueError` with a stage-prefixed message.

### Documentation

`docs/transpilation/performance.rst` gains a "DuckDB IEJoin dialect" subsection covering the opt-in, the supported shapes (including the absorbed decorations), the automatic fallbacks (each shape enumerated), the mutual exclusivity with `intersects_bin_size`, the empty-schema typing caveat, and the full enumeration of rejection paths that raise rather than fall back. `README.md` gains a short pointer to the dialect opt-in.

### Drive-by source-style fixes

Two small commits at the base of the branch land Python Style Guide conformance on surfaces the dialect work happened to read while landing:

- `refactor: Move _extract_bool_param into private-methods region of BaseGIQLGenerator` — the private static helper sat before `__init__`, violating class-member ordering. Move it next to `_enclosing_cte_names`.
- `style: Adopt Python Style Guide conventions in IntersectsBinnedJoinTransformer` — switch the bare `DEFAULT_BIN_SIZE` reference in `__init__`'s docstring to `:data:`~giql.constants.DEFAULT_BIN_SIZE``, and drop five inline what-comments from `_build_pairs_replacement_joins` (replacing one with a single why-comment that captures the symmetry invariant).

### Refresh notebook kernel metadata

`demo.ipynb`'s recorded kernel display name and language version are bumped to Python 3.13.3 to match the interpreter the demo is now developed against. No code-cell content changes.

## Test cases

The PR ships 157 tests across `tests/test_canonical.py` (19) and `tests/test_duckdb_iejoin.py` (138). The tables below summarize the test surface by suite; each table row may correspond to multiple example-based or property-based tests in the same group.

### `test_canonical.py` — 19 module-level free-function tests

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `canonical_start` | A raw expression and a `Table` (or `None`) under each `coordinate_system` | `canonical_start(raw, table)` is called | Return the raw expression unchanged for `0based` / `None`, or `(raw - 1)` for `1based` | `canonical_start` |
| 2 | `canonical_end` | A raw expression and a `Table` under every `(coordinate_system, interval_type)` combination | `canonical_end(raw, table)` is called | Return one of `raw`, `(raw + 1)`, or `(raw - 1)` matching the documented offset for that combination | `canonical_end` (example + Hypothesis property test pinning the three-form invariant) |
| 3 | `decanonical_start` | A canonical 0-based start expression and a `Table` (or `None`) | `decanonical_start(canon, table)` is called | Round-trip `canonical_start` numerically across the full `coordinate_system` enum | `decanonical_start` (example + Hypothesis property test) |
| 4 | `decanonical_end` | A canonical 0-based half-open end expression and a `Table` under every `(coordinate_system, interval_type)` combination | `decanonical_end(canon, table)` is called | Round-trip `canonical_end` numerically across the full enum cross-product | `decanonical_end` (example + Hypothesis property test) |

### `test_duckdb_iejoin.py` — 138 tests in three classes

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 5 | `TestTranspileDuckDBIEJoinSQLStructure` (engagement) | A column-to-column INTERSECTS INNER / SEMI / ANTI join | `transpile(query, dialect="duckdb")` runs | Emit a `SET VARIABLE __giql_iejoin_<n>` block and a `query(getvariable(...))` outer SELECT | Dialect engagement and template emission |
| 6 | `TestTranspileDuckDBIEJoinSQLStructure` (decorations) | The engagement shape plus `ORDER BY` / `LIMIT` / `OFFSET` / `DISTINCT` / `GROUP BY` / `HAVING` / extra `ON` / `WHERE` predicates | The query is transpiled | Inline each decoration into the per-chromosome subquery or wrapper SELECT correctly | Decoration absorption (aggregates, modifier rewriting, extra-predicate inlining including `BETWEEN`, `IN`, `LIKE`, `IS NULL`) |
| 7 | `TestTranspileDuckDBIEJoinSQLStructure` (fallback) | A query carrying an unsupported shape (outer-join INTERSECTS in `ON` or `WHERE`, self-join, multi-INTERSECTS, three-table FROM, top-level `WITH`, `DISTINCT ON`, OR / NOT / paren-wrapped extras, unqualified extras, subqueries / aggregates / window functions in extras, subquery / `EXISTS` / scalar subquery inside `GROUP BY` / `HAVING` / `ORDER BY`, non-base-table operand) | `transpile(query, dialect="duckdb")` runs | Decline the dialect path and return SQL from the binned plan with no `SET VARIABLE __giql_iejoin_` block | Documented fallback set |
| 8 | `TestTranspileDuckDBIEJoinSQLStructure` (raise) | A query with an unsupported SELECT-list shape (bare `*`, unqualified columns, expression projections, unknown qualifier, `a.* AS x`, window aggregate, `FILTER` clause, arithmetic-over-aggregate, scalar subquery in `SELECT`, aggregate-of-unqualified) | `transpile(query, dialect="duckdb")` runs | Raise `ValueError` whose message names the offending form | Hard-error projection rejection set |
| 9 | `TestTranspileDuckDBIEJoinExecution` (correctness) | Multi-chromosome `peaks` / `genes` tables on in-memory DuckDB | The dialect SQL is executed | Return rows matching the Python-native overlap reference, the binned plan, and the parametrized canonical truth table across every `(coordinate_system, interval_type)` combination | End-to-end correctness of the dialect plan, cross-plan parity, canonical handling |
| 10 | `TestTranspileDuckDBIEJoinExecution` (edge cases) | Empty left or empty right tables, disjoint chromosome sets, custom column names, reserved-word table names, `a.*` / `b.*` expansion, NULL-aware predicates, user-aliased joins with cross-side predicates, ambiguous-outer-name resolution, paren-wrapped aggregates, kitchen-sink combined query | The dialect SQL is executed | Return the correct rows (or a typed empty result) without raising | Edge cases enumerated in the issue and discovered during implementation |
| 11 | `TestTranspileDuckDBIEJoinExecution` (Hypothesis) | Random `peaks` / `genes` tables (including empty inputs), random extra `WHERE` predicates with nullable scores, random `GROUP BY` aggregates, full Tier 1 composite queries, and arbitrary printable-ASCII chromosome names | Both the dialect and the binned plan execute | Match each other and match the Python-native overlap reference across `INTERSECTS` / SEMI / ANTI variants | Cross-plan equivalence across the input space, chromosome-literal escaping under arbitrary names |
| 12 | `TestTranspileDuckDBIEJoinKwargs` | The `@overload` pair, the `dialect` × `intersects_bin_size` mutex, an unknown dialect value, and `intersects_bin_size` with `dialect` omitted | `transpile(...)` runs | Produce byte-identical output for `dialect=None` vs omitted, raise `ValueError` whose message names both kwargs on mutex violation, echo the offending value on unknown dialect, and execute the binned plan correctly when only `intersects_bin_size` is set | Kwarg surface and cross-kwarg behavioral regression |
