### PR TITLE
Skip the redundant EXISTS containment clause in self-referencing DISJOIN — Closes #107

### DIFF
--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -306,7 +306,7 @@ class BaseGIQLGenerator(Generator):
             )
 
         # Resolve the reference relation (defaults to the target set).
-        ref_from, ref_chrom, ref_start, ref_end, ref_table = (
+        ref_from, ref_chrom, ref_start, ref_end, ref_table, is_self_reference = (
             self._resolve_disjoin_reference(
                 expression,
                 target_name,
@@ -364,15 +364,26 @@ class BaseGIQLGenerator(Generator):
             "LEAD(pos) OVER (PARTITION BY kc, ks, ke ORDER BY pos) AS seg_end "
             "FROM __giql_dj_cuts)"
         )
+        # In self-reference mode the coverage EXISTS is provably always true:
+        # every emitted segment lies inside its parent target row, and that
+        # row is itself a member of the reference set. Skip the clause so the
+        # planner does not waste work on a no-op semi-join.
+        exists_clause = (
+            ""
+            if is_self_reference
+            else (
+                " AND EXISTS (SELECT 1 FROM __giql_dj_ref AS r "
+                f'WHERE r."{ref_chrom}" = s.kc AND {r_start} <= s.seg_start '
+                f"AND {r_end} > s.seg_start)"
+            )
+        )
         final_select = (
             f"SELECT t.*, s.kc AS disjoin_chrom, {out_start} AS disjoin_start, "
             f"{out_end} AS disjoin_end FROM __giql_dj_tgt AS t "
             f'JOIN __giql_dj_segs AS s ON t."{target_chrom}" = s.kc '
             f'AND t."{target_start}" = s.ks AND t."{target_end}" = s.ke '
-            "WHERE s.seg_end IS NOT NULL AND s.seg_end > s.seg_start "
-            "AND EXISTS (SELECT 1 FROM __giql_dj_ref AS r "
-            f'WHERE r."{ref_chrom}" = s.kc AND {r_start} <= s.seg_start '
-            f"AND {r_end} > s.seg_start)"
+            "WHERE s.seg_end IS NOT NULL AND s.seg_end > s.seg_start"
+            f"{exists_clause}"
         )
         return (
             f"(WITH {ref_cte}, {tgt_cte}, {bp_cte}, "
@@ -739,9 +750,7 @@ class BaseGIQLGenerator(Generator):
         # (validation will catch missing reference errors later)
         return "correlated"
 
-    def _find_outer_table_in_lateral_join(
-        self, expression: GIQLNearest
-    ) -> str | None:
+    def _find_outer_table_in_lateral_join(self, expression: GIQLNearest) -> str | None:
         """Find the outer table name in a LATERAL join context.
 
         Walks up the AST to find the JOIN clause and extracts the outer table
@@ -911,7 +920,7 @@ class BaseGIQLGenerator(Generator):
         target_name: str,
         target_cols: tuple[str, str, str],
         target_table: Table | None,
-    ) -> tuple[str, str, str, str, Table | None]:
+    ) -> tuple[str, str, str, str, Table | None, bool]:
         """Resolve the reference relation for a DISJOIN query.
 
         The reference contributes the breakpoints at which target intervals are
@@ -933,11 +942,16 @@ class BaseGIQLGenerator(Generator):
         :param target_table:
             Table config of the target (the default reference config)
         :return:
-            Tuple of ``(from_clause, chrom_col, start_col, end_col, table)``
-            where ``from_clause`` is the text following ``FROM`` inside the
-            ``__giql_dj_ref`` CTE. A subquery or CTE reference is assumed to
-            expose canonical 0-based half-open ``chrom`` / ``start`` / ``end``
-            columns, so ``table`` is ``None`` for those.
+            Tuple of ``(from_clause, chrom_col, start_col, end_col, table,
+            is_self_reference)`` where ``from_clause`` is the text following
+            ``FROM`` inside the ``__giql_dj_ref`` CTE. A subquery or CTE
+            reference is assumed to expose canonical 0-based half-open
+            ``chrom`` / ``start`` / ``end`` columns, so ``table`` is ``None``
+            for those. ``is_self_reference`` is ``True`` only when the
+            reference provably resolves to the same registered relation as the
+            target (omitted reference, or a bare name equal to the target name
+            that is not shadowed by an enclosing CTE and maps to the same
+            registered table).
         :raises ValueError:
             If the reference is not a table name, a CTE, or a subquery, or if
             a bare name resolves to neither a registered table nor a CTE.
@@ -947,9 +961,11 @@ class BaseGIQLGenerator(Generator):
 
         # No reference: default to the target set (single-mode).
         if reference is None:
-            return target_name, tc, ts, te, target_table
+            return target_name, tc, ts, te, target_table, True
 
-        # Subquery reference: inline it as an aliased derived table.
+        # Subquery reference: inline it as an aliased derived table. The
+        # subquery may textually duplicate the target, but proving equivalence
+        # is out of scope, so treat it as a distinct relation.
         if isinstance(reference, (exp.Subquery, exp.Select, exp.Union)):
             from_clause = f"{self.sql(reference)} AS __giql_dj_rs"
             return (
@@ -958,6 +974,7 @@ class BaseGIQLGenerator(Generator):
                 DEFAULT_START_COL,
                 DEFAULT_END_COL,
                 None,
+                False,
             )
 
         # Anything that is not a bare table/CTE name is unsupported.
@@ -979,7 +996,9 @@ class BaseGIQLGenerator(Generator):
             )
 
         # A CTE from an enclosing WITH shadows a registered table of the same
-        # name; it is assumed to expose canonical default columns.
+        # name; it is assumed to expose canonical default columns. A CTE may
+        # contain rows distinct from any same-named registered table, so it is
+        # never treated as a self-reference.
         if ref_name in self._enclosing_cte_names(expression):
             return (
                 ref_name,
@@ -987,6 +1006,7 @@ class BaseGIQLGenerator(Generator):
                 DEFAULT_START_COL,
                 DEFAULT_END_COL,
                 None,
+                False,
             )
 
         ref_table = self.tables.get(ref_name)
@@ -997,6 +1017,7 @@ class BaseGIQLGenerator(Generator):
                 ref_table.start_col,
                 ref_table.end_col,
                 ref_table,
+                ref_name == target_name and ref_table is target_table,
             )
         raise ValueError(
             f"DISJOIN reference {ref_name!r} is neither a registered table "
@@ -1168,9 +1189,7 @@ class BaseGIQLGenerator(Generator):
             BaseGIQLGenerator._canonical_end(raw_end, table),
         )
 
-    def _resolve_table_name(
-        self, column_ref: str, table_name: str | None
-    ) -> str | None:
+    def _resolve_table_name(self, column_ref: str, table_name: str | None) -> str | None:
         """Resolve the underlying table name for a column reference.
 
         Precedence: explicit ``table_name`` (caller-provided context) > alias

--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -367,23 +367,22 @@ class BaseGIQLGenerator(Generator):
         # In self-reference mode the coverage EXISTS is provably always true:
         # every emitted segment lies inside its parent target row, and that
         # row is itself a member of the reference set. Skip the clause so the
-        # planner does not waste work on a no-op semi-join.
-        exists_clause = (
-            ""
-            if is_self_reference
-            else (
-                " AND EXISTS (SELECT 1 FROM __giql_dj_ref AS r "
-                f'WHERE r."{ref_chrom}" = s.kc AND {r_start} <= s.seg_start '
-                f"AND {r_end} > s.seg_start)"
+        # planner does not waste work on a no-op semi-join. The __giql_dj_ref
+        # CTE itself stays live because __giql_dj_bp still draws breakpoints
+        # from it.
+        where_clauses = ["s.seg_end IS NOT NULL", "s.seg_end > s.seg_start"]
+        if not is_self_reference:
+            where_clauses.append(
+                f'EXISTS (SELECT 1 FROM __giql_dj_ref AS r WHERE r."{ref_chrom}" = s.kc '
+                f"AND {r_start} <= s.seg_start AND {r_end} > s.seg_start)"
             )
-        )
+        where_sql = " AND ".join(where_clauses)
         final_select = (
             f"SELECT t.*, s.kc AS disjoin_chrom, {out_start} AS disjoin_start, "
             f"{out_end} AS disjoin_end FROM __giql_dj_tgt AS t "
             f'JOIN __giql_dj_segs AS s ON t."{target_chrom}" = s.kc '
             f'AND t."{target_start}" = s.ks AND t."{target_end}" = s.ke '
-            "WHERE s.seg_end IS NOT NULL AND s.seg_end > s.seg_start"
-            f"{exists_clause}"
+            f"WHERE {where_sql}"
         )
         return (
             f"(WITH {ref_cte}, {tgt_cte}, {bp_cte}, "
@@ -951,7 +950,9 @@ class BaseGIQLGenerator(Generator):
             reference provably resolves to the same registered relation as the
             target (omitted reference, or a bare name equal to the target name
             that is not shadowed by an enclosing CTE and maps to the same
-            registered table).
+            registered table). It is ``False`` in all other cases, including
+            subquery and CTE references that may textually duplicate the
+            target.
         :raises ValueError:
             If the reference is not a table name, a CTE, or a subquery, or if
             a bare name resolves to neither a registered table nor a CTE.

--- a/tests/integration/coordinate_space/test_disjoin_coordinate_space.py
+++ b/tests/integration/coordinate_space/test_disjoin_coordinate_space.py
@@ -112,3 +112,202 @@ class TestDisjoinCoordinateSpace:
             encode(10, 30, coordinate_system, interval_type),
         ]
         assert result == expected
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_disjoin_self_mode_and_explicit_self_reference_yield_identical_partitions(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test omitted-reference and explicit-self-reference produce identical rows.
+
+        Given:
+            Two overlapping intervals (canonical [0, 20) and [10, 30))
+            re-encoded under one convention.
+        When:
+            ``DISJOIN(features)`` and ``DISJOIN(features, reference := features)``
+            are unioned (tagged) in one query.
+        Then:
+            Both tag groups should return the same partition
+            {[0, 10), [10, 20), [20, 30)} re-encoded under the target
+            convention — proving the two self-reference paths take the same
+            optimized branch.
+        """
+        # Arrange
+        s_a, e_a = encode(0, 20, coordinate_system, interval_type)
+        s_b, e_b = encode(10, 30, coordinate_system, interval_type)
+        tables = [make_table("features", coordinate_system, interval_type)]
+        rows = [_row("chr1", s_a, e_a, "a"), _row("chr1", s_b, e_b, "b")]
+        expected_partition = [
+            ("chr1", *encode(0, 10, coordinate_system, interval_type)),
+            ("chr1", *encode(10, 20, coordinate_system, interval_type)),
+            ("chr1", *encode(20, 30, coordinate_system, interval_type)),
+        ]
+
+        # Act
+        result = giql_query(
+            "SELECT 'omitted' AS tag, disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(features) "
+            "UNION ALL "
+            "SELECT 'explicit' AS tag, disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(features, reference := features) "
+            "ORDER BY tag, disjoin_start",
+            tables=tables,
+            features=rows,
+        )
+
+        # Assert
+        omitted = sorted({row[1:] for row in result if row[0] == "omitted"})
+        explicit = sorted({row[1:] for row in result if row[0] == "explicit"})
+        assert omitted == expected_partition
+        assert explicit == expected_partition
+
+    def test_disjoin_drops_segments_outside_partial_reference_coverage(self, giql_query):
+        """Test DISJOIN drops sub-intervals not covered by the reference set.
+
+        Given:
+            A target interval [0, 100) and a reference set covering only
+            [0, 30) and [70, 100) (gap [30, 70)), canonical 0-based half-open.
+        When:
+            DISJOIN(features, reference := refs) runs.
+        Then:
+            The result should contain exactly {[0, 30), [70, 100)} and the
+            uncovered [30, 70) segment should be dropped — proving the EXISTS
+            coverage filter is preserved for distinct references.
+        """
+        # Arrange
+        tables = [
+            make_table("features", "0based", "half_open"),
+            make_table("refs", "0based", "half_open"),
+        ]
+
+        # Act
+        result = giql_query(
+            "SELECT DISTINCT disjoin_start, disjoin_end "
+            "FROM DISJOIN(features, reference := refs) ORDER BY disjoin_start",
+            tables=tables,
+            features=[_row("chr1", 0, 100, "t")],
+            refs=[_row("chr1", 0, 30, "r1"), _row("chr1", 70, 100, "r2")],
+        )
+
+        # Assert
+        assert result == [(0, 30), (70, 100)]
+
+    def test_disjoin_drops_segments_outside_partial_reference_coverage_when_target_and_reference_use_different_encodings(
+        self, giql_query
+    ):
+        """Test EXISTS canonicalization across mixed target/reference encodings.
+
+        Given:
+            A target interval canonical [0, 100) stored 0-based half-open and
+            a partial-coverage reference {[0, 30), [70, 100)} stored 1-based
+            closed.
+        When:
+            DISJOIN(features, reference := refs) runs.
+        Then:
+            The result should contain the same canonical surviving sub-intervals
+            {[0, 30), [70, 100)} re-encoded under the target convention — the
+            EXISTS body still canonicalizes the reference endpoints correctly.
+        """
+        # Arrange
+        target_system, target_type = "0based", "half_open"
+        ref_system, ref_type = "1based", "closed"
+        s_t, e_t = encode(0, 100, target_system, target_type)
+        r1s, r1e = encode(0, 30, ref_system, ref_type)
+        r2s, r2e = encode(70, 100, ref_system, ref_type)
+        tables = [
+            make_table("features", target_system, target_type),
+            make_table("refs", ref_system, ref_type),
+        ]
+
+        # Act
+        result = giql_query(
+            "SELECT DISTINCT disjoin_start, disjoin_end "
+            "FROM DISJOIN(features, reference := refs) ORDER BY disjoin_start",
+            tables=tables,
+            features=[_row("chr1", s_t, e_t, "t")],
+            refs=[_row("chr1", r1s, r1e, "r1"), _row("chr1", r2s, r2e, "r2")],
+        )
+
+        # Assert
+        expected = [
+            encode(0, 30, target_system, target_type),
+            encode(70, 100, target_system, target_type),
+        ]
+        assert result == expected
+
+    def test_disjoin_keeps_coverage_filter_when_cte_shadows_target_name(
+        self, giql_query
+    ):
+        """Test CTE-shadowed self-reference still applies the coverage filter.
+
+        Given:
+            A registered ``features`` table with two intervals and an outer
+            WITH clause defining a CTE ``features`` that is a strict subset
+            (one row).
+        When:
+            ``WITH features AS (SELECT * FROM features WHERE name = 'a')
+            SELECT ... FROM DISJOIN(features, reference := features)`` is
+            unioned (tagged) with the registered-table self-mode partition.
+        Then:
+            The CTE-shadowed result should be just {[0, 50)} (one segment),
+            strictly smaller than the registered-table partition
+            {[0, 30), [30, 50), [50, 100)} — the CTE shadows both target and
+            reference and EXISTS remains active.
+        """
+        # Arrange
+        tables = [make_table("features", "0based", "half_open")]
+        rows = [_row("chr1", 0, 50, "a"), _row("chr1", 30, 100, "b")]
+
+        # Act
+        result = giql_query(
+            "SELECT 'shadowed' AS tag, disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM (WITH features AS (SELECT * FROM features WHERE name = 'a') "
+            "SELECT * FROM DISJOIN(features, reference := features)) AS s "
+            "UNION ALL "
+            "SELECT 'unshadowed' AS tag, disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(features) "
+            "ORDER BY tag, disjoin_start",
+            tables=tables,
+            features=rows,
+        )
+
+        # Assert
+        shadowed = sorted({row[1:] for row in result if row[0] == "shadowed"})
+        unshadowed = sorted({row[1:] for row in result if row[0] == "unshadowed"})
+        assert shadowed == [("chr1", 0, 50)]
+        assert unshadowed == [("chr1", 0, 30), ("chr1", 30, 50), ("chr1", 50, 100)]
+
+    def test_disjoin_keeps_coverage_filter_when_reference_is_partial_coverage_subquery(
+        self, giql_query
+    ):
+        """Test a partial-coverage subquery reference still drops uncovered segments.
+
+        Given:
+            A target with one wide row [0, 100) and one narrow row [20, 50)
+            on chr1; a subquery reference selecting only rows with
+            ``"start" >= 20`` (which yields only the narrow row).
+        When:
+            ``DISJOIN(features, reference := (SELECT * FROM features WHERE
+            "start" >= 20))`` runs.
+        Then:
+            Only the [20, 50) sub-interval should survive — proving subquery
+            references retain the EXISTS coverage filter end-to-end.
+        """
+        # Arrange
+        tables = [make_table("features", "0based", "half_open")]
+
+        # Act
+        result = giql_query(
+            "SELECT DISTINCT disjoin_start, disjoin_end "
+            "FROM DISJOIN(features, reference := ("
+            'SELECT * FROM features WHERE "start" >= 20'
+            ")) ORDER BY disjoin_start",
+            tables=tables,
+            features=[_row("chr1", 0, 100, "wide"), _row("chr1", 20, 50, "partial")],
+        )
+
+        # Assert
+        assert result == [(20, 50)]

--- a/tests/integration/coordinate_space/test_disjoin_coordinate_space.py
+++ b/tests/integration/coordinate_space/test_disjoin_coordinate_space.py
@@ -30,7 +30,7 @@ class TestDisjoinCoordinateSpace:
         CONVENTIONS,
         ids=lambda v: str(v),
     )
-    def test_disjoin_should_yield_the_partition_in_the_target_encoding(
+    def test_disjoin_yields_the_partition_in_the_target_encoding(
         self, giql_query, coordinate_system, interval_type
     ):
         """Test DISJOIN self-mode yields the partition in the target's encoding.
@@ -71,7 +71,7 @@ class TestDisjoinCoordinateSpace:
         CONVENTIONS,
         ids=lambda v: str(v),
     )
-    def test_disjoin_should_yield_target_encoded_subintervals_when_reference_differs(
+    def test_disjoin_yields_target_encoded_subintervals_when_reference_differs(
         self, giql_query, coordinate_system, interval_type
     ):
         """Test DISJOIN emits target-encoded sub-intervals across mixed encodings.

--- a/tests/test_disjoin_transpilation.py
+++ b/tests/test_disjoin_transpilation.py
@@ -392,3 +392,143 @@ class TestDisjoinTranspilation:
 
         # Assert
         assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_skip_exists_clause_when_target_uses_one_based_closed_encoding(
+        self,
+    ):
+        """Test that self-mode skips EXISTS even with non-default coordinates.
+
+        Given:
+            A self-mode DISJOIN against a target registered as 1-based closed.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should omit the coverage EXISTS subquery and still emit the
+            canonical 0-based shift on the target endpoints.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT * FROM DISJOIN(features)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                )
+            ],
+        )
+
+        # Assert
+        assert "EXISTS (" not in sql
+        assert '(t."start" - 1)' in sql
+
+    def test_giqldisjoin_sql_should_skip_exists_clause_when_target_uses_custom_column_names(
+        self,
+    ):
+        """Test that self-mode skips EXISTS cleanly under custom column names.
+
+        Given:
+            A self-mode DISJOIN against a target with custom genomic column
+            names.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should omit the coverage EXISTS subquery and leave no dangling
+            reference-side qualifier (no ``r."seqid"`` / ``r."lo"`` /
+            ``r."hi"``).
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT * FROM DISJOIN(feats)",
+            tables=[Table("feats", chrom_col="seqid", start_col="lo", end_col="hi")],
+        )
+
+        # Assert
+        assert "EXISTS (" not in sql
+        assert 'r."seqid"' not in sql
+        assert 'r."lo"' not in sql
+        assert 'r."hi"' not in sql
+
+    def test_giqldisjoin_sql_should_skip_exists_clause_when_explicit_self_reference_uses_one_based_closed_encoding(
+        self,
+    ):
+        """Test that explicit self-reference skips EXISTS under non-default config.
+
+        Given:
+            A DISJOIN call with an explicit ``reference := features`` where
+            ``features`` is registered as 1-based closed.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should omit the coverage EXISTS subquery and still emit the
+            canonical 0-based shift on the breakpoint CTE endpoints.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT * FROM DISJOIN(features, reference := features)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                )
+            ],
+        )
+
+        # Assert
+        assert "EXISTS (" not in sql
+        assert '("start" - 1)' in sql
+
+    def test_giqldisjoin_sql_should_emit_one_exists_clause_when_query_mixes_self_and_distinct_reference_disjoins(
+        self,
+    ):
+        """Test that the EXISTS skip is decided per DISJOIN call.
+
+        Given:
+            A query containing one self-mode DISJOIN and one distinct-reference
+            DISJOIN in the same SELECT.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should produce SQL containing exactly one ``EXISTS (``
+            occurrence — only the distinct-reference call retains the
+            coverage filter.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT * FROM DISJOIN(features) "
+            "UNION ALL "
+            "SELECT * FROM DISJOIN(features, reference := refs)",
+            tables=["features", "refs"],
+        )
+
+        # Assert
+        assert sql.count("EXISTS (") == 1
+
+    def test_giqldisjoin_sql_should_emit_exists_clause_when_enclosing_cte_shadows_target_from_outer_scope(
+        self,
+    ):
+        """Test that a CTE shadowing the target name from an outer scope keeps EXISTS.
+
+        Given:
+            A nested query where the outer WITH defines a CTE named ``features``
+            and an inner subquery contains
+            ``DISJOIN(features, reference := features)``, with ``features``
+            also a registered table.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit the coverage EXISTS subquery — the enclosing-CTE
+            check follows the ancestor chain past the immediate WITH.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) "
+            "SELECT * FROM ("
+            "SELECT * FROM DISJOIN(features, reference := features)"
+            ") AS sub",
+            tables=["features"],
+        )
+
+        # Assert
+        assert "EXISTS (" in sql

--- a/tests/test_disjoin_transpilation.py
+++ b/tests/test_disjoin_transpilation.py
@@ -22,7 +22,7 @@ class TestDisjoinTranspilation:
         When:
             Transpiling to SQL.
         Then:
-            It should be a WITH-CTE subquery using UNION, LEAD, and EXISTS.
+            It should be a WITH-CTE subquery using UNION and LEAD.
         """
         # Arrange & act
         sql = transpile("SELECT * FROM DISJOIN(features)", tables=["features"]).upper()
@@ -31,7 +31,6 @@ class TestDisjoinTranspilation:
         assert "WITH __GIQL_DJ_REF" in sql
         assert "UNION" in sql
         assert "LEAD(" in sql
-        assert "EXISTS (" in sql
 
     def test_giqldisjoin_sql_should_emit_disjoin_columns(self):
         """Test that DISJOIN appends the sub-interval columns.
@@ -189,8 +188,7 @@ class TestDisjoinTranspilation:
         """
         # Arrange & act
         sql = transpile(
-            "WITH bins AS (SELECT 1) "
-            "SELECT * FROM DISJOIN(features, reference := bins)",
+            "WITH bins AS (SELECT 1) SELECT * FROM DISJOIN(features, reference := bins)",
             tables=["features"],
         )
 
@@ -210,8 +208,7 @@ class TestDisjoinTranspilation:
         """
         # Arrange & act
         sql = transpile(
-            "WITH refs AS (SELECT 1) "
-            "SELECT * FROM DISJOIN(features, reference := refs)",
+            "WITH refs AS (SELECT 1) SELECT * FROM DISJOIN(features, reference := refs)",
             tables=[
                 "features",
                 Table("refs", coordinate_system="1based", interval_type="closed"),
@@ -290,3 +287,108 @@ class TestDisjoinTranspilation:
                 "SELECT * FROM DISJOIN(features, reference := missing)",
                 tables=["features"],
             )
+
+    def test_giqldisjoin_sql_should_skip_exists_clause_when_reference_omitted(self):
+        """Test that an omitted reference suppresses the coverage EXISTS clause.
+
+        Given:
+            A DISJOIN call with no reference argument (self-mode).
+        When:
+            Transpiling to SQL.
+        Then:
+            It should omit the coverage EXISTS subquery, which is provably
+            always true when the reference equals the target set.
+        """
+        # Arrange & act
+        sql = transpile("SELECT * FROM DISJOIN(features)", tables=["features"])
+
+        # Assert
+        assert "EXISTS (" not in sql
+
+    def test_giqldisjoin_sql_should_skip_exists_clause_when_reference_resolves_to_target(
+        self,
+    ):
+        """Test that a reference naming the target table suppresses EXISTS.
+
+        Given:
+            A DISJOIN call whose explicit reference is the target table name.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should omit the coverage EXISTS subquery, since the reference
+            resolves to the same registered relation as the target.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT * FROM DISJOIN(features, reference := features)",
+            tables=["features"],
+        )
+
+        # Assert
+        assert "EXISTS (" not in sql
+
+    def test_giqldisjoin_sql_should_emit_exists_clause_when_reference_is_different_table(
+        self,
+    ):
+        """Test that an explicit distinct reference keeps the EXISTS clause.
+
+        Given:
+            A DISJOIN call with an explicit reference table distinct from the
+            target.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit the coverage EXISTS subquery against the reference
+            CTE.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT * FROM DISJOIN(features, reference := refs)",
+            tables=["features", "refs"],
+        )
+
+        # Assert
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_emit_exists_clause_when_cte_shadows_target_name(
+        self,
+    ):
+        """Test that a CTE shadowing the target name keeps the EXISTS clause.
+
+        Given:
+            A reference name shared by the target table and an in-query CTE.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit the coverage EXISTS subquery, since the CTE may
+            contain rows distinct from the registered target table.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) "
+            "SELECT * FROM DISJOIN(features, reference := features)",
+            tables=["features"],
+        )
+
+        # Assert
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_emit_exists_clause_when_reference_is_subquery(self):
+        """Test that a subquery reference keeps the EXISTS clause.
+
+        Given:
+            A DISJOIN call whose reference is a subquery.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit the coverage EXISTS subquery, since a subquery is
+            conservatively treated as a relation distinct from the target.
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT * FROM DISJOIN(features, reference := (SELECT * FROM features))",
+            tables=["features"],
+        )
+
+        # Assert
+        assert "EXISTS (" in sql

--- a/tests/test_disjoin_transpilation.py
+++ b/tests/test_disjoin_transpilation.py
@@ -531,4 +531,4 @@ class TestDisjoinTranspilation:
         )
 
         # Assert
-        assert "EXISTS (" in sql
+        assert sql.count("EXISTS (") == 1


### PR DESCRIPTION
## Summary

Skip emission of the coverage `EXISTS` subquery in `DISJOIN` whenever the reference provably resolves to the same registered relation as the target. In self-referencing mode every emitted segment is a sub-interval of its parent target row, and that row is itself a member of the reference set — the `EXISTS` is therefore always true and the planner spends a full equi+range hash semi-join filtering nothing. When an explicit, distinct reference is supplied the clause stays unchanged, as do CTE-shadowed and subquery references, which may legitimately exclude rows.

The optimization is gated entirely at transpile time on a new `is_self_reference` flag returned by the reference resolver and requires no opt-in surface. End-to-end row sets are identical to the pre-change output across the four coordinate conventions and across single-DISJOIN, mixed-DISJOIN, partial-coverage, and CTE-shadowed scenarios.

Closes #107.

## Proposed changes

### `src/giql/generators/base.py`

- Extend `_resolve_disjoin_reference` to return a sixth tuple element, `is_self_reference: bool`. The flag is `True` only when the reference is omitted, or when a bare reference name equals the target name, is not shadowed by an enclosing CTE, and maps to the same registered `Table` instance. Subquery references and CTE-shadowed names are treated as distinct relations even when they textually duplicate the target, since proving runtime row-set equivalence is out of scope.
- In the DISJOIN emitter, branch on `is_self_reference` when constructing the outer `WHERE`. The `WHERE s.seg_end IS NOT NULL AND s.seg_end > s.seg_start` predicate is unconditional; the `AND EXISTS (...)` containment clause is appended only on the distinct-reference path.
- Update the resolver docstring to describe the new tuple element and the semantics of each return branch (omitted, subquery, enclosing-CTE shadow, registered table).

### `tests/test_disjoin_transpilation.py`

- Loosen the baseline `DISJOIN(features)` shape assertion to no longer require `EXISTS (`, since self-mode no longer emits it.
- Add ten transpilation tests covering both sides of the gate: omitted reference, explicit self-reference, distinct registered reference, CTE shadowing the target name in the same WITH, subquery reference, 1-based closed target encoding in self-mode, custom genomic column names in self-mode, explicit self-reference under 1-based closed encoding, a query mixing self-mode and distinct-reference DISJOINs (exactly one `EXISTS (` survives), and a nested-scope CTE shadow that confirms the enclosing-CTE check walks the ancestor chain.

### `tests/integration/coordinate_space/test_disjoin_coordinate_space.py`

- Add a keystone parametrized test asserting that `DISJOIN(features)` and `DISJOIN(features, reference := features)` produce identical partitions across all four `(coordinate_system, interval_type)` conventions — direct evidence that both self-reference paths take the same optimized branch at runtime.
- Add guard tests for the load-bearing `EXISTS` that the optimization preserves: a partial-coverage distinct reference, the same scenario under mixed target/reference encodings (exercises the canonical shift inside the retained `EXISTS` body), a CTE-shadowed self-reference, and a subquery reference with a filter inducing partial coverage. Each of these would silently return extra rows if `EXISTS` were wrongly skipped on a non-self path.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestDisjoinTranspilation` | A `DISJOIN(features)` call with no reference argument | Transpiling to SQL | The output omits any `EXISTS (` subquery | Self-mode skip |
| 2 | `TestDisjoinTranspilation` | A `DISJOIN(features, reference := features)` call where the reference names the target table | Transpiling to SQL | The output omits any `EXISTS (` subquery | Explicit self-reference skip |
| 3 | `TestDisjoinTranspilation` | A `DISJOIN(features, reference := refs)` call with a distinct registered reference | Transpiling to SQL | The output emits the coverage `EXISTS (` subquery | Distinct-reference preservation |
| 4 | `TestDisjoinTranspilation` | A query whose outer `WITH` defines a CTE `features` and references it as `DISJOIN(features, reference := features)` | Transpiling to SQL | The output emits the coverage `EXISTS (` subquery | CTE-shadow preservation |
| 5 | `TestDisjoinTranspilation` | A `DISJOIN` call whose reference is a subquery `(SELECT * FROM features)` | Transpiling to SQL | The output emits the coverage `EXISTS (` subquery | Subquery-reference preservation |
| 6 | `TestDisjoinTranspilation` | A self-mode `DISJOIN` against a target registered 1-based closed | Transpiling to SQL | The output omits `EXISTS (` and still emits `(t."start" - 1)` on the target endpoints | Self-mode skip under non-default coordinates |
| 7 | `TestDisjoinTranspilation` | A self-mode `DISJOIN` against a target with custom column names `seqid`/`lo`/`hi` | Transpiling to SQL | The output omits `EXISTS (` and contains no dangling `r."seqid"`/`r."lo"`/`r."hi"` qualifier | Self-mode skip under custom column names |
| 8 | `TestDisjoinTranspilation` | An explicit `DISJOIN(features, reference := features)` against a 1-based closed target | Transpiling to SQL | The output omits `EXISTS (` and still emits `("start" - 1)` on the breakpoint endpoints | Explicit self-reference skip under non-default coordinates |
| 9 | `TestDisjoinTranspilation` | A query containing one self-mode DISJOIN and one distinct-reference DISJOIN | Transpiling to SQL | The output contains exactly one `EXISTS (` occurrence | Per-call gating |
| 10 | `TestDisjoinTranspilation` | A nested query where an outer `WITH features AS (...)` wraps a subquery containing `DISJOIN(features, reference := features)` | Transpiling to SQL | The output emits the coverage `EXISTS (` subquery | Enclosing-CTE check walks the ancestor chain |
| 11 | `TestDisjoinCoordinateSpace` | Two overlapping intervals re-encoded under each of the four conventions | `DISJOIN(features)` runs in self-mode | The result equals the partition `{[0,10), [10,20), [20,30)}` re-encoded under the target convention | Self-mode partition correctness across encodings |
| 12 | `TestDisjoinCoordinateSpace` | A target interval under each convention and a fixed 1-based closed reference set | `DISJOIN(features, reference := refs)` runs | The result equals `{[0,10), [10,30)}` re-encoded under the target convention | Distinct-reference partition correctness across encodings |
| 13 | `TestDisjoinCoordinateSpace` | Two overlapping intervals re-encoded under each convention, tagged across `DISJOIN(features)` and `DISJOIN(features, reference := features)` | The tagged union is selected | Both tag groups return the same partition re-encoded under the target convention | Self-mode equivalence between omitted and explicit self-reference |
| 14 | `TestDisjoinCoordinateSpace` | A target `[0, 100)` and a reference covering only `[0, 30)` and `[70, 100)` | `DISJOIN(features, reference := refs)` runs | The result equals `{[0, 30), [70, 100)}` and drops the uncovered `[30, 70)` segment | Partial-coverage `EXISTS` preservation |
| 15 | `TestDisjoinCoordinateSpace` | A 0-based half-open target and a 1-based closed partial-coverage reference | `DISJOIN(features, reference := refs)` runs | The result equals `{[0, 30), [70, 100)}` re-encoded under the target convention | Canonical shift inside the retained `EXISTS` body |
| 16 | `TestDisjoinCoordinateSpace` | A registered `features` table with two intervals and an outer `WITH features AS (SELECT ... WHERE name = 'a')` shadow | A tagged union of the CTE-shadowed `DISJOIN(features, reference := features)` and the registered-table self-mode partition runs | The shadowed result equals `{[0, 50)}` and the unshadowed result equals `{[0, 30), [30, 50), [50, 100)}` | CTE shadow keeps `EXISTS` active end-to-end |
| 17 | `TestDisjoinCoordinateSpace` | A target with one wide row `[0, 100)` and one narrow row `[20, 50)`, with a subquery reference filtering `"start" >= 20` | `DISJOIN(features, reference := (SELECT ... WHERE "start" >= 20))` runs | Only the `[20, 50)` sub-interval survives | Subquery reference keeps `EXISTS` active end-to-end |