### PR TITLE
Support an in-query CTE as the DISJOIN target — Closes #105

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -3728,6 +3728,30 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": "### Disjoining an in-query CTE\n\nThe target of `DISJOIN` may be a CTE built in an enclosing `WITH` clause, not just a registered table. The CTE is assumed to expose canonical 0-based half-open `chrom` / `start` / `end` columns, so a user with filtered or non-default-encoded data can canonicalise inline and disjoin the result without registering a derived table.\n\n**GIQL Query**: `WITH filtered AS (SELECT chrom, \"start\", \"end\" FROM toy_peaks WHERE name <> 'E') SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end FROM DISJOIN(filtered)`"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "giql_query = \"\"\"\n    WITH filtered AS (\n        SELECT chrom, \"start\", \"end\", name\n        FROM toy_peaks\n        WHERE name <> 'E'\n    )\n    SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end\n    FROM DISJOIN(filtered)\n    ORDER BY disjoin_chrom, disjoin_start\n\"\"\"\n\n# Note: toy_peaks is the only registered table; filtered is resolved as\n# an in-query CTE by DISJOIN's target resolver.\nsql = transpile(giql_query, tables=[\"toy_peaks\"])\nprint(\"Transpiled SQL:\")\nprint(sqlglot.transpile(sql, pretty=True)[0])\nprint(\"\\n\" + \"=\" * 80 + \"\\n\")\n\nresult = conn.execute(sql).fetchdf()\nresult"
+  },
+  {
+   "cell_type": "markdown",
+   "source": "### Canonicalising a non-default schema\n\nA source table on a 1-based closed convention (for example, a GFF/GTF-style feature table) can be aliased and shifted into canonical 0-based half-open form inside an enclosing `WITH`, then disjoined directly — no need to register a derived table.\n\n**GIQL Query**: `WITH canon AS (SELECT chrom, start - 1 AS \"start\", \"end\" AS \"end\" FROM features_1bc) SELECT * FROM DISJOIN(canon)`",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "source": "# A 1-based, closed-coordinate source table — the same intervals as toy_peaks\n# but shifted: start += 1 and \"end\" stays put, mirroring GFF/GTF conventions.\nconn.execute(\"DROP TABLE IF EXISTS toy_peaks_1bc\")\nconn.execute(\n    'CREATE TABLE toy_peaks_1bc(chrom VARCHAR, \"start\" INTEGER, \"end\" INTEGER, name VARCHAR)'\n)\nconn.executemany(\n    \"INSERT INTO toy_peaks_1bc VALUES (?, ?, ?, ?)\",\n    [\n        (\"chr1\", 1, 100, \"A\"),\n        (\"chr1\", 51, 150, \"B\"),\n        (\"chr1\", 121, 200, \"C\"),\n        (\"chr2\", 1, 80, \"D\"),\n        (\"chr2\", 41, 80, \"E\"),\n    ],\n)\n\n# Canonicalise inline in a CTE, then disjoin. The CTE exposes canonical\n# 0-based half-open columns, which is the contract DISJOIN assumes for a\n# CTE target — no derived table needs to be registered.\ngiql_query = \"\"\"\n    WITH canon AS (\n        SELECT chrom, \"start\" - 1 AS \"start\", \"end\" AS \"end\", name\n        FROM toy_peaks_1bc\n    )\n    SELECT name, disjoin_chrom, disjoin_start, disjoin_end\n    FROM DISJOIN(canon)\n    ORDER BY disjoin_chrom, disjoin_start, name\n\"\"\"\n\nsql = transpile(giql_query, tables=[\"toy_peaks_1bc\"])\nprint(\"Transpiled SQL:\")\nprint(sqlglot.transpile(sql, pretty=True)[0])\nprint(\"\\n\" + \"=\" * 80 + \"\\n\")\n\nresult = conn.execute(sql).fetchdf()\nresult",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "---\n",
     "\n",

--- a/docs/dialect/distance-operators.rst
+++ b/docs/dialect/distance-operators.rst
@@ -156,7 +156,10 @@ Parameters
 ~~~~~~~~~~
 
 **target_table**
-   The table to search for nearest features.
+   The table to search for nearest features. ``NEAREST`` requires the target
+   to be a registered table; a name resolving to a CTE defined in an
+   enclosing ``WITH`` is rejected at transpile time. (See ``DISJOIN`` if you
+   need to operate on a CTE.)
 
 **reference**
    The reference position to measure distances from. Can be a column reference

--- a/docs/dialect/set-operators.rst
+++ b/docs/dialect/set-operators.rst
@@ -59,12 +59,19 @@ Syntax
    -- The reference may be a subquery
    SELECT * FROM DISJOIN(features, reference := (SELECT * FROM mask))
 
+   -- The target may be a CTE assembled in the same query
+   WITH x AS (SELECT chrom, "start", "end" FROM features WHERE chrom = 'chr1')
+   SELECT * FROM DISJOIN(x)
+
 Parameters
 ~~~~~~~~~~
 
 **target**
-   The table of intervals to split. Must be a table registered with the
-   transpiler so its genomic columns can be resolved.
+   The set of intervals to split. May be a registered table (whose configured
+   genomic columns are used) or a CTE defined in an enclosing ``WITH`` clause
+   (assumed to expose canonical 0-based half-open ``chrom`` / ``start`` /
+   ``end`` columns). A CTE shadows a registered table of the same name,
+   matching SQL scoping. A bare name that is neither is rejected.
 
 **reference** *(optional)*
    A registered table, a CTE defined in the same query, or a ``(SELECT ...)``
@@ -96,6 +103,13 @@ target entirely, not merely trim it.
    silently renames the second, so ``SELECT disjoin_start`` then resolves to
    the passed-through parent column rather than the computed sub-interval.
    Rename the conflicting target column before the call.
+
+.. note::
+
+   ``DISJOIN`` reserves identifiers beginning with ``__giql_dj_`` for its
+   internal CTEs. A target, reference, or enclosing CTE that starts with
+   this prefix is rejected at transpile time -- rename the relation before
+   the call.
 
 Examples
 ~~~~~~~~
@@ -150,7 +164,9 @@ breakpoint ``20``:
    target table's coordinate system -- the same convention as its
    passed-through ``start`` / ``end`` columns, so every column of an output row
    shares one convention. Cut positions are computed canonically inside the
-   operator; only their final representation follows the target table.
+   operator; only their final representation follows the target table. A CTE
+   target is assumed canonical (0-based half-open), so its appended
+   ``disjoin_*`` columns are emitted canonically as well.
 
 .. note::
 
@@ -158,6 +174,15 @@ breakpoint ``20``:
    interval cuts a target interval regardless of either one's strand. To
    disjoin per strand, filter the target and reference to a single strand
    before the call.
+
+.. note::
+
+   Unlike ``DISJOIN``, ``NEAREST`` does not accept a CTE as its target -- only
+   a registered table. Naming an in-query CTE in ``NEAREST(...)`` raises a
+   transpilation error suggesting ``DISJOIN`` if a CTE target is desired.
+
+See also :doc:`../recipes/disjoin` for end-to-end recipes, including the
+CTE-target patterns for filtering and canonicalisation.
 
 Related Operators
 ~~~~~~~~~~~~~~~~~

--- a/docs/recipes/disjoin.rst
+++ b/docs/recipes/disjoin.rst
@@ -5,6 +5,10 @@ This section covers patterns for splitting intervals at breakpoints using
 GIQL's ``DISJOIN`` operator -- partitioning a set into non-overlapping
 segments and re-tiling features against a reference grid.
 
+See :doc:`../dialect/set-operators` for the operator's reference -- syntax,
+parameter semantics, and the reserved output column / identifier conventions
+the recipes below assume.
+
 Partition a Set of Intervals
 ----------------------------
 
@@ -79,6 +83,100 @@ single bin.
    ``range()`` is DuckDB-specific syntax for generating the bin grid; other
    engines need their own generator. The grid must also span every chromosome
    present in ``features``, or features on an uncovered chromosome are dropped.
+
+Disjoin a Filtered or Canonicalised Subset
+------------------------------------------
+
+Disjoin Only the Rows You Want
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Build the input to ``DISJOIN`` inline with a ``WITH`` clause, skipping the
+need to register the filtered subset as a separate table:
+
+.. code-block:: sql
+
+   WITH filtered AS (
+       SELECT chrom, "start", "end", name
+       FROM features
+       WHERE chrom = 'chr1'
+   )
+   SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end
+   FROM DISJOIN(filtered)
+   ORDER BY disjoin_start
+
+**Use case:** Partition only one chromosome (or any other inline filter) and
+let the operator see exactly that subset, without registering a derived table
+or materialising it on disk.
+
+Canonicalise a Non-Default Schema
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A CTE target is assumed to expose canonical 0-based half-open ``chrom`` /
+``start`` / ``end`` columns. When the underlying table uses custom column
+names or a non-default coordinate system, alias and convert inline:
+
+.. code-block:: sql
+
+   WITH canonical AS (
+       SELECT seqid AS chrom, lo - 1 AS "start", hi AS "end", name
+       FROM one_based_features
+   )
+   SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end
+   FROM DISJOIN(canonical)
+
+Additional columns (here, ``name``) may be projected through the CTE and
+will pass through to the DISJOIN output rows alongside the canonical three.
+
+**Use case:** Use a 1-based-closed source table without registering a custom
+``Table`` config -- the user takes responsibility for the canonical layout
+the CTE-target contract requires.
+
+.. warning::
+
+   The CTE-target contract is unvalidated. If the CTE does not actually
+   expose 0-based half-open ``chrom`` / ``start`` / ``end`` columns -- wrong
+   names, wrong coordinate system, wrong types -- results will be either
+   silently wrong or surfaced as an opaque engine error ("column not
+   found"). There is no GIQL-level diagnostic.
+
+Chain DISJOIN Through a CTE
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``DISJOIN`` emits its appended ``disjoin_*`` columns in the *target*
+table's coordinate system and passes the target's own ``chrom`` /
+``start`` / ``end`` (and any other columns) through unchanged. When the
+target is a registered non-canonical table, those passthrough columns
+carry the table's native encoding into the CTE -- and the CTE-target
+contract on a second ``DISJOIN`` assumes canonical 0-based half-open.
+Canonicalise inside the CTE before re-disjoining:
+
+.. code-block:: sql
+
+   WITH segments AS (
+       SELECT
+           disjoin_chrom AS chrom,
+           disjoin_start - 1 AS "start",          -- 1-based -> 0-based
+           disjoin_end AS "end",                  -- closed -> half-open
+           name
+       FROM DISJOIN(one_based_features)
+   )
+   SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end
+   FROM DISJOIN(segments)
+
+**Use case:** Two-stage partitioning -- e.g. disjoin features within
+sample, then disjoin across samples -- when the source table is not
+0-based half-open. Project only the canonicalised ``chrom`` / ``start`` /
+``end`` (plus any passthrough columns) through the CTE; do **not**
+re-export the raw ``start`` / ``end`` from the inner table, which still
+carry the original encoding.
+
+.. warning::
+
+   If the inner ``DISJOIN``'s target is canonical 0-based half-open --
+   either a CTE itself, or a registered table whose ``coordinate_system``
+   / ``interval_type`` resolve to canonical -- chained ``DISJOIN`` is
+   safe without any canonicalisation step. The trap is specifically
+   when chaining across a non-canonical registered table.
 
 Coming from Bedtools?
 ---------------------

--- a/docs/recipes/index.rst
+++ b/docs/recipes/index.rst
@@ -21,7 +21,8 @@ Recipe Categories
 
 :doc:`disjoin`
    Splitting intervals at breakpoints, partitioning a set into
-   non-overlapping segments, and re-tiling features against a reference grid.
+   non-overlapping segments, re-tiling features against a reference grid,
+   and disjoining filtered or canonicalised subsets defined as in-query CTEs.
 
 :doc:`advanced`
    Multi-range matching, complex filtering with joins, aggregate statistics,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
     { name = "Conrad Bzura", email = "conradbzura@gmail.com" },
 ]
 dependencies = [
-    "sqlglot>=20.0.0,<30",
+    "sqlglot>=28.0.0,<30",
 ]
 description = "Genomic Interval Query Language - SQL dialect for genomic range queries"
 dynamic = ["version"]
@@ -91,7 +91,7 @@ pytest-cov = ">=4.0.0"
 datafusion = ">=43.0.0"
 duckdb = ">=1.4.0"
 pandas = ">=2.0.0"
-sqlglot = ">=20.0.0,<30"
+sqlglot = ">=28.0.0,<30"
 pip = "*"
 hypothesis = ">=6.148.2,<7"
 

--- a/src/giql/constants.py
+++ b/src/giql/constants.py
@@ -10,5 +10,13 @@ DEFAULT_END_COL = "end"
 DEFAULT_STRAND_COL = "strand"
 DEFAULT_GENOMIC_COL = "interval"
 
+# Canonical column tuple a CTE or subquery input to DISJOIN is contractually
+# assumed to expose (0-based half-open).
+CANONICAL_DEFAULT_COLS: tuple[str, str, str] = (
+    DEFAULT_CHROM_COL,
+    DEFAULT_START_COL,
+    DEFAULT_END_COL,
+)
+
 # Default bin size for INTERSECTS binned equi-join optimization
 DEFAULT_BIN_SIZE = 10_000

--- a/src/giql/expressions.py
+++ b/src/giql/expressions.py
@@ -87,6 +87,35 @@ def _split_named_and_positional(args):
     return kwargs, positional_args
 
 
+def _validate_arg_list(
+    op_name: str,
+    kwargs: dict,
+    positional_args: list,
+    *,
+    allowed: set[str],
+    max_positional: int,
+) -> None:
+    """Reject unknown named arguments and excess positional arguments.
+
+    Each GIQL operator's ``from_arg_list`` calls this immediately after
+    ``_split_named_and_positional`` so a typo (``stranded`` → ``strandedd``)
+    or an extra positional surfaces as a clear ``ParseError`` instead of
+    being silently dropped by ``cls(**kwargs)``.
+    """
+    unknown = set(kwargs) - allowed
+    if unknown:
+        raise ParseError(
+            f"{op_name} got unexpected named argument(s): "
+            f"{', '.join(sorted(unknown))}. "
+            f"Valid arguments: {', '.join(sorted(allowed))}."
+        )
+    if len(positional_args) > max_positional:
+        raise ParseError(
+            f"{op_name} accepts at most {max_positional} positional "
+            f"argument(s); got {len(positional_args)}."
+        )
+
+
 class GIQLCluster(exp.Func):
     """CLUSTER window function for assigning cluster IDs to overlapping intervals.
 
@@ -108,14 +137,20 @@ class GIQLCluster(exp.Func):
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
+        _validate_arg_list(
+            "CLUSTER",
+            kwargs,
+            positional_args,
+            allowed=set(cls.arg_types),
+            max_positional=2,
+        )
         if len(positional_args) > 0:
             kwargs["this"] = positional_args[0]
         if len(positional_args) > 1:
             kwargs["distance"] = positional_args[1]
         if "this" not in kwargs:
             raise ParseError(
-                "CLUSTER requires a genomic interval column as its first "
-                "argument."
+                "CLUSTER requires a genomic interval column as its first argument."
             )
         return cls(**kwargs)
 
@@ -141,14 +176,20 @@ class GIQLMerge(exp.Func):
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
+        _validate_arg_list(
+            "MERGE",
+            kwargs,
+            positional_args,
+            allowed=set(cls.arg_types),
+            max_positional=2,
+        )
         if len(positional_args) > 0:
             kwargs["this"] = positional_args[0]
         if len(positional_args) > 1:
             kwargs["distance"] = positional_args[1]
         if "this" not in kwargs:
             raise ParseError(
-                "MERGE requires a genomic interval column as its first "
-                "argument."
+                "MERGE requires a genomic interval column as its first argument."
             )
         return cls(**kwargs)
 
@@ -177,6 +218,13 @@ class GIQLDistance(exp.Func):
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
+        _validate_arg_list(
+            "DISTANCE",
+            kwargs,
+            positional_args,
+            allowed=set(cls.arg_types),
+            max_positional=2,
+        )
         if len(positional_args) >= 1:
             kwargs["this"] = positional_args[0]
         if len(positional_args) >= 2:
@@ -209,12 +257,17 @@ class GIQLNearest(exp.Func):
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
+        _validate_arg_list(
+            "NEAREST",
+            kwargs,
+            positional_args,
+            allowed=set(cls.arg_types),
+            max_positional=1,
+        )
         if len(positional_args) >= 1:
             kwargs["this"] = positional_args[0]
         if "this" not in kwargs:
-            raise ParseError(
-                "NEAREST requires a target table as its first argument."
-            )
+            raise ParseError("NEAREST requires a target table as its first argument.")
         return cls(**kwargs)
 
 
@@ -233,32 +286,34 @@ class GIQLDisjoin(exp.Func):
         DISJOIN(features, reference := other)
         DISJOIN(features, reference => other)
         DISJOIN(features, reference := (SELECT ...))
+
+        With an enclosing CTE:
+            WITH x AS (SELECT chrom, "start", "end" FROM features WHERE ...)
+            SELECT * FROM DISJOIN(x)
     """
 
     arg_types = {
-        "this": True,  # Required: target table name
+        "this": True,  # Required: target table or CTE name
         "reference": False,  # Optional: reference table/CTE name or subquery
     }
 
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
-        unknown = set(kwargs) - set(cls.arg_types)
-        if unknown:
+        _validate_arg_list(
+            "DISJOIN",
+            kwargs,
+            positional_args,
+            allowed=set(cls.arg_types),
+            max_positional=1,
+        )
+        if "this" in kwargs and len(positional_args) >= 1:
             raise ParseError(
-                f"DISJOIN got unexpected named argument(s): "
-                f"{', '.join(sorted(unknown))}. Valid arguments: reference."
-            )
-        if len(positional_args) > 1:
-            raise ParseError(
-                "DISJOIN accepts at most one positional argument (the target "
-                f"table); got {len(positional_args)}. Pass the reference set "
-                "as 'reference := ...'."
+                "DISJOIN got both a positional target and an explicit "
+                "`this :=` kwarg; pass exactly one."
             )
         if len(positional_args) >= 1:
             kwargs["this"] = positional_args[0]
         if "this" not in kwargs:
-            raise ParseError(
-                "DISJOIN requires a target table as its first argument."
-            )
+            raise ParseError("DISJOIN requires a target table as its first argument.")
         return cls(**kwargs)

--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -1,3 +1,5 @@
+from dataclasses import dataclass
+
 from sqlglot import exp
 from sqlglot.generator import Generator
 
@@ -5,6 +7,7 @@ from giql.canonical import canonical_end
 from giql.canonical import canonical_start
 from giql.canonical import decanonical_end
 from giql.canonical import decanonical_start
+from giql.constants import CANONICAL_DEFAULT_COLS
 from giql.constants import DEFAULT_CHROM_COL
 from giql.constants import DEFAULT_END_COL
 from giql.constants import DEFAULT_START_COL
@@ -20,6 +23,216 @@ from giql.range_parser import ParsedRange
 from giql.range_parser import RangeParser
 from giql.table import Table
 from giql.table import Tables
+
+# Reserved identifier prefix for DISJOIN's internal CTE aliases. User-supplied
+# target/reference names or enclosing CTE names sharing this prefix would
+# collide with the generator's emitted SQL.
+_DISJOIN_RESERVED_PREFIX = "__giql_dj_"
+
+# Internal CTE aliases emitted by giqldisjoin_sql. Kept as named constants so
+# a typo in the emitted SQL produces a Python NameError rather than a
+# downstream engine "unknown CTE" error.
+#
+# - ``_DISJOIN_CTE_REF``: filtered/canonicalized reference rows.
+# - ``_DISJOIN_CTE_TGT``: target rows brought into scope.
+# - ``_DISJOIN_CTE_BP``: breakpoint positions ``(chrom, pos)``.
+# - ``_DISJOIN_CTE_CUTS``: cut points per target row.
+# - ``_DISJOIN_CTE_SEGS``: contiguous segments via ``LEAD()``.
+# - ``_DISJOIN_CTE_RS``: alias for an inlined subquery reference.
+_DISJOIN_CTE_REF = "__giql_dj_ref"
+_DISJOIN_CTE_TGT = "__giql_dj_tgt"
+_DISJOIN_CTE_BP = "__giql_dj_bp"
+_DISJOIN_CTE_CUTS = "__giql_dj_cuts"
+_DISJOIN_CTE_SEGS = "__giql_dj_segs"
+_DISJOIN_CTE_RS = "__giql_dj_rs"
+
+
+def _quote_relation(name: str) -> str:
+    """Quote a relation identifier for emission into SQL.
+
+    Escapes embedded double quotes by doubling them, matching the SQL
+    standard for delimited identifiers.
+    """
+    return '"' + name.replace('"', '""') + '"'
+
+
+class _NotABareName(Exception):
+    """Internal marker raised by :func:`_extract_bare_name`.
+
+    Callers catch this to attach operator/role-specific wording while
+    bare-name validation stays centralized.
+    """
+
+    def __init__(self, node: exp.Expression) -> None:
+        super().__init__()
+        self.node = node
+
+
+def _is_qualified_name(node: exp.Expression) -> bool:
+    """Return ``True`` when ``node`` is a db/schema-qualified Table or a
+    table-qualified Column. Used by callers to phrase ``is qualified``
+    error messages after :func:`_extract_bare_name` raises.
+    """
+    if isinstance(node, exp.Table):
+        return bool(node.db or node.catalog)
+    if isinstance(node, exp.Column):
+        return bool(node.table)
+    return False
+
+
+def _bare_name_or_none(node: exp.Expression | None) -> str | None:
+    """Return :func:`_extract_bare_name`\\ 's result, or ``None`` on failure.
+
+    Convenience wrapper for callers (e.g. ``_check_reserved_collisions``)
+    that only care whether the node *is* a bare name, not why it isn't.
+    """
+    if node is None:
+        return None
+    try:
+        return _extract_bare_name(node)
+    except _NotABareName:
+        return None
+
+
+def _extract_bare_name(node: exp.Expression) -> str:
+    """Return the bare identifier for a DISJOIN/NEAREST target or DISJOIN
+    reference node.
+
+    Quoted identifiers are normalized via sqlglot's unquoted ``.name`` so
+    ``DISJOIN("X")`` matches a same-named enclosing ``WITH "X" AS (...)``
+    whose alias is also collected unquoted.
+
+    :param node:
+        Accepts :class:`sqlglot.exp.Table`, unqualified
+        :class:`sqlglot.exp.Column`, and bare :class:`sqlglot.exp.Identifier`.
+    :return:
+        The bare identifier.
+    :raises _NotABareName:
+        If the node is a qualified column, db/schema-qualified table, or
+        any other shape that does not resolve to a single bare name.
+        Callers catch this marker to phrase operator/role-specific
+        wording.
+    """
+    if isinstance(node, exp.Table) and not (node.db or node.catalog):
+        return node.name
+    if isinstance(node, exp.Column) and not node.table:
+        return node.name
+    if isinstance(node, exp.Identifier):
+        return node.name
+    raise _NotABareName(node)
+
+
+def _enclosing_cte_names(expression: exp.Expression) -> set[str]:
+    """Collect CTE names visible from enclosing ``WITH`` clauses.
+
+    Walks the ancestor chain and gathers the aliases of every
+    :class:`exp.With`-clause CTE that is visible at ``expression``'s
+    position per SQL scoping rules: a CTE is visible from the containing
+    ``SELECT`` body, and from later siblings inside the same ``WITH``.
+    From inside a CTE body only earlier siblings are visible (forward
+    references are forbidden), and the CTE itself is visible only under
+    ``WITH RECURSIVE``.
+
+    ``WITH`` attaches to ``SELECT``, set operations (``UNION`` /
+    ``INTERSECT`` / ``EXCEPT``), and DML/DDL forms (``INSERT`` /
+    ``UPDATE`` / ``DELETE`` / ``MERGE`` / ``CREATE`` / ``SUBQUERY``);
+    reading the ``with_`` arg from every ancestor covers all of them.
+    Names are de-duplicated; innermost shadowing is not modeled —
+    callers only test membership.
+
+    :param expression:
+        Any sqlglot expression node. The walk starts at this node and
+        proceeds via ``.parent``.
+    :return:
+        Unordered set of CTE aliases visible at this node per SQL
+        scoping. Empty when no enclosing ``WITH`` exists.
+    """
+    names: set[str] = set()
+    last_cte: exp.CTE | None = None
+    node: exp.Expression | None = expression
+    while node is not None:
+        if isinstance(node, exp.CTE):
+            last_cte = node
+        with_clause = node.args.get("with_")
+        # Every WITH-bearing sqlglot node we care about stores the clause
+        # under ``with_``; surface a schema rename loudly rather than
+        # silently dropping visible CTE names. ``raise`` survives ``-O``,
+        # which strips ``assert``.
+        if with_clause is not None and not isinstance(with_clause, exp.With):
+            raise TypeError(
+                f"Expected exp.With under 'with_' arg, got {type(with_clause).__name__}"
+            )
+        if with_clause is not None:
+            ctes = list(with_clause.expressions)
+            if last_cte in ctes:
+                recursive = bool(with_clause.args.get("recursive"))
+                for cte in ctes:
+                    if cte is last_cte:
+                        if recursive and cte.alias:
+                            names.add(cte.alias)
+                        break
+                    if cte.alias:
+                        names.add(cte.alias)
+            else:
+                # Ascended from the SELECT body (or another non-CTE child);
+                # all sibling CTEs in this WITH are visible.
+                for cte in ctes:
+                    if cte.alias:
+                        names.add(cte.alias)
+        node = node.parent
+    return names
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class _ResolvedRelation:
+    """A bare-name reference resolved against registered tables or enclosing
+    CTEs.
+
+    :ivar name:
+        The unquoted identifier. Empty string for an inlined subquery
+        reference (its :attr:`_ResolvedReference.subquery` field carries
+        the AST node).
+    :ivar cols:
+        ``(chrom_col, start_col, end_col)``. Canonical defaults
+        (:data:`giql.constants.CANONICAL_DEFAULT_COLS`) for a CTE or
+        subquery relation; configured column names for a registered table.
+    :ivar table:
+        The registered :class:`Table` when the name maps to one, else
+        ``None``. ``None`` signals a CTE or subquery relation, which by
+        contract exposes canonical 0-based half-open columns.
+    """
+
+    name: str
+    cols: tuple[str, str, str]
+    table: Table | None
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class _ResolvedReference:
+    """A resolved DISJOIN reference.
+
+    :ivar relation:
+        The relation-level fields (name, cols, table). For a subquery
+        reference the relation's ``name`` is empty and its ``table`` is
+        ``None`` — :attr:`subquery` is what the emitter uses to build the
+        ``FROM`` clause.
+    :ivar subquery:
+        The inlined ``(SELECT ...)`` AST node when the user passed one as
+        ``reference := (SELECT ...)``; otherwise ``None``.
+    :ivar is_self_reference:
+        ``True`` only when both target and reference provably resolve to
+        the same registered :class:`Table`. The ``EXISTS`` coverage filter
+        in ``giqldisjoin_sql`` is then a tautology and is omitted. For a
+        CTE target the engine may inline the body twice with divergent
+        results, so the optimization is unsafe and this flag stays
+        ``False``; subquery references and CTE-shadowed names are also
+        treated as distinct because row-set identity to the target is not
+        provable from the AST.
+    """
+
+    relation: _ResolvedRelation
+    subquery: exp.Subquery | None
+    is_self_reference: bool
 
 
 class BaseGIQLGenerator(Generator):
@@ -38,6 +251,19 @@ class BaseGIQLGenerator(Generator):
     # Most databases support LATERAL joins (PostgreSQL 9.3+, DuckDB 0.7.0+)
     # SQLite does not support LATERAL, so it overrides this to False
     SUPPORTS_LATERAL = True
+
+    @staticmethod
+    def _extract_bool_param(param_expr: exp.Expression | None) -> bool:
+        """Extract boolean value from a parameter expression.
+
+        Handles exp.Boolean, exp.Literal, and string representations.
+        """
+        if not param_expr:
+            return False
+        elif isinstance(param_expr, exp.Boolean):
+            return param_expr.this
+        else:
+            return str(param_expr).upper() in ("TRUE", "1", "YES")
 
     def __init__(self, tables: Tables | None = None, **kwargs):
         super().__init__(**kwargs)
@@ -125,17 +351,33 @@ class BaseGIQLGenerator(Generator):
         - Correlated (LATERAL): Subquery for k-nearest neighbors
 
         :param expression:
-            GIQLNearest expression node
+            GIQLNearest expression node.
         :return:
-            SQL string for NEAREST operation
+            SQL string for NEAREST operation.
+        :raises ValueError:
+            If the target node is not a bare name (e.g. ``db.genes`` or a
+            subquery); if a bare target resolves to neither a registered
+            table nor an enclosing CTE; if a bare target name resolves to
+            both a registered table and an enclosing CTE (ambiguous); if
+            the target name resolves only to an enclosing CTE (CTE
+            targets are unsupported for NEAREST — register the relation
+            as a table); or if NEAREST runs in correlated mode against a
+            dialect lacking ``LATERAL`` support (SQLite).
         """
         # Detect mode
         mode = self._detect_nearest_mode(expression)
 
         # Resolve target table
-        table_name, (target_chrom, target_start, target_end) = (
-            self._resolve_target_table(expression)
+        target = self._resolve_target(
+            expression, accept_cte=False, operator_label="NEAREST"
         )
+        target_name = target.name
+        target_chrom, target_start, target_end = target.cols
+        target_table = target.table
+        # Quoted form used in emitted SQL (FROM clause and column prefixes).
+        # Quoting preserves case on engines that fold unquoted identifiers
+        # and escapes any embedded double quotes per the SQL standard.
+        target_ref = _quote_relation(target_name)
 
         # Resolve reference
         ref_chrom, ref_start, ref_end = self._resolve_nearest_reference(expression, mode)
@@ -149,8 +391,6 @@ class BaseGIQLGenerator(Generator):
 
         is_stranded = self._extract_bool_param(expression.args.get("stranded"))
         is_signed = self._extract_bool_param(expression.args.get("signed"))
-
-        target_table = self.tables.get(table_name) if self.tables else None
 
         # Resolve strand columns if stranded mode
         ref_strand = None
@@ -188,13 +428,15 @@ class BaseGIQLGenerator(Generator):
 
             # Get strand column for target table
             if target_table and target_table.strand_col:
-                target_strand = f'{table_name}."{target_table.strand_col}"'
+                target_strand = f'{target_ref}."{target_table.strand_col}"'
 
         # Distance math below assumes 0-based half-open.
         target_start_expr = canonical_start(
-            f'{table_name}."{target_start}"', target_table
+            f'{target_ref}."{target_start}"', target_table
         )
-        target_end_expr = canonical_end(f'{table_name}."{target_end}"', target_table)
+        target_end_expr = canonical_end(
+            f'{target_ref}."{target_end}"', target_table
+        )
 
         # Build distance calculation using CASE expression
         # For NEAREST: ORDER BY absolute distance, but RETURN signed distance
@@ -203,7 +445,7 @@ class BaseGIQLGenerator(Generator):
             ref_start,
             ref_end,
             ref_strand,
-            f'{table_name}."{target_chrom}"',
+            f'{target_ref}."{target_chrom}"',
             target_start_expr,
             target_end_expr,
             target_strand,
@@ -216,7 +458,7 @@ class BaseGIQLGenerator(Generator):
 
         # Build WHERE clauses
         where_clauses = [
-            f'{ref_chrom} = {table_name}."{target_chrom}"'  # Chromosome pre-filter
+            f'{ref_chrom} = {target_ref}."{target_chrom}"'  # Chromosome pre-filter
         ]
 
         # Add strand matching for stranded mode
@@ -233,8 +475,8 @@ class BaseGIQLGenerator(Generator):
             # Standalone mode: direct ORDER BY + LIMIT
             # Return signed distance, but order by absolute distance
             sql = f"""(
-                SELECT {table_name}.*, {distance_expr} AS distance
-                FROM {table_name}
+                SELECT {target_ref}.*, {distance_expr} AS distance
+                FROM {target_ref}
                 WHERE {where_sql}
                 ORDER BY {abs_distance_expr}
                 LIMIT {k_value}
@@ -255,8 +497,8 @@ class BaseGIQLGenerator(Generator):
             # LATERAL mode: subquery for k-nearest neighbors
             # Return signed distance, but order by absolute distance
             sql = f"""(
-                SELECT {table_name}.*, {distance_expr} AS distance
-                FROM {table_name}
+                SELECT {target_ref}.*, {distance_expr} AS distance
+                FROM {target_ref}
                 WHERE {where_sql}
                 ORDER BY {abs_distance_expr}
                 LIMIT {k_value}
@@ -274,47 +516,44 @@ class BaseGIQLGenerator(Generator):
         filter drops sub-intervals overlapping no reference interval. When no
         ``reference`` is given it defaults to the target set.
 
-        Coordinate-system round-tripping is handled by
-        :func:`giql.canonical.decanonical_start` /
-        :func:`giql.canonical.decanonical_end`.
+        The target may be a registered table or an enclosing-WITH CTE; a CTE
+        target is assumed canonical (0-based half-open), and its appended
+        ``disjoin_*`` columns are emitted in that convention.
 
         :param expression:
-            GIQLDisjoin expression node
+            GIQLDisjoin expression node.
         :return:
-            SQL string (a parenthesized WITH-CTE subquery) for the DISJOIN table
+            SQL string (a parenthesized WITH-CTE subquery) for the DISJOIN
+            table.
+        :raises ValueError:
+            If the target or reference name resolves to neither a registered
+            table nor an enclosing CTE; if the target or reference name uses
+            the reserved ``__giql_dj_`` prefix; or if any enclosing CTE alias
+            uses the reserved ``__giql_dj_`` prefix.
         """
-        # Resolve the target table and its genomic columns.
-        target_name, (target_chrom, target_start, target_end) = (
-            self._resolve_target_table(expression)
+        # Reject any user-visible identifier that would shadow DISJOIN's
+        # internal __giql_dj_* namespace. Run before resolution so a reserved
+        # name reports as such even when no table/CTE of that name exists.
+        self._check_reserved_collisions(expression)
+        target = self._resolve_target(
+            expression, accept_cte=True, operator_label="DISJOIN"
         )
-        target_table = self.tables.get(target_name)
+        reference = self._resolve_disjoin_reference(expression, target)
 
-        # The __giql_dj_ prefix names the operator's internal CTEs; a target
-        # table using it would collide with them.
-        if target_name.startswith("__giql_dj_"):
-            raise ValueError(
-                f"DISJOIN target {target_name!r} uses the reserved "
-                "'__giql_dj_' prefix, which names the operator's internal "
-                "CTEs. Rename the table."
-            )
+        target_name = target.name
+        target_chrom, target_start, target_end = target.cols
+        target_table = target.table
 
-        # Resolve the reference relation (defaults to the target set).
-        ref_from, ref_chrom, ref_start, ref_end, ref_table, is_self_reference = (
-            self._resolve_disjoin_reference(
-                expression,
-                target_name,
-                (target_chrom, target_start, target_end),
-                target_table,
-            )
-        )
+        ref_chrom, ref_start, ref_end = reference.relation.cols
+        ref_table = reference.relation.table
 
-        # Canonical target endpoints, qualified by the __giql_dj_tgt alias.
+        # Endpoint qualification scheme: target endpoints are qualified by the
+        # ``__giql_dj_tgt`` alias (``t``); reference endpoints appear
+        # unqualified in the breakpoint CTE and qualified by ``r`` in the
+        # coverage ``EXISTS`` filter.
         t_chrom = f't."{target_chrom}"'
         t_start = canonical_start(f't."{target_start}"', target_table)
         t_end = canonical_end(f't."{target_end}"', target_table)
-
-        # Canonical reference endpoints: unqualified for the breakpoint CTE,
-        # qualified by 'r' for the coverage EXISTS filter.
         bp_start = canonical_start(f'"{ref_start}"', ref_table)
         bp_end = canonical_end(f'"{ref_end}"', ref_table)
         r_start = canonical_start(f'r."{ref_start}"', ref_table)
@@ -326,54 +565,63 @@ class BaseGIQLGenerator(Generator):
         out_start = decanonical_start("s.seg_start", target_table)
         out_end = decanonical_end("s.seg_end", target_table)
 
-        # Build the WITH clause one named fragment per __giql_dj_* CTE so each
-        # block reads on its own. The `seg_end > seg_start` guard in the final
-        # WHERE is belt-and-suspenders: UNION already dedupes cut positions, so
-        # LEAD cannot produce a zero-length segment unless it becomes UNION ALL.
-        ref_cte = f"__giql_dj_ref AS (SELECT * FROM {ref_from})"
-        tgt_cte = f"__giql_dj_tgt AS (SELECT * FROM {target_name})"
+        # Build the FROM clause for the reference CTE. A subquery reference is
+        # aliased with the reserved ``__giql_dj_rs`` so downstream column refs
+        # resolve unambiguously; bare references quote the relation name.
+        if reference.subquery is not None:
+            ref_from = f"{self.sql(reference.subquery)} AS {_DISJOIN_CTE_RS}"
+        else:
+            ref_from = _quote_relation(reference.relation.name)
+
+        ref_cte = f"{_DISJOIN_CTE_REF} AS (SELECT * FROM {ref_from})"
+        tgt_cte = f"{_DISJOIN_CTE_TGT} AS (SELECT * FROM {_quote_relation(target_name)})"
         bp_cte = (
-            "__giql_dj_bp AS ("
-            f'SELECT "{ref_chrom}" AS chrom, {bp_start} AS pos FROM __giql_dj_ref '
+            f"{_DISJOIN_CTE_BP} AS ("
+            f'SELECT "{ref_chrom}" AS chrom, {bp_start} AS pos '
+            f"FROM {_DISJOIN_CTE_REF} "
             "UNION "
-            f'SELECT "{ref_chrom}" AS chrom, {bp_end} AS pos FROM __giql_dj_ref)'
+            f'SELECT "{ref_chrom}" AS chrom, {bp_end} AS pos '
+            f"FROM {_DISJOIN_CTE_REF})"
         )
         cuts_cte = (
-            "__giql_dj_cuts AS ("
+            f"{_DISJOIN_CTE_CUTS} AS ("
             f'SELECT t."{target_chrom}" AS kc, t."{target_start}" AS ks, '
-            f't."{target_end}" AS ke, {t_start} AS pos FROM __giql_dj_tgt AS t '
+            f't."{target_end}" AS ke, {t_start} AS pos '
+            f"FROM {_DISJOIN_CTE_TGT} AS t "
             "UNION "
             f'SELECT t."{target_chrom}", t."{target_start}", t."{target_end}", '
-            f"{t_end} FROM __giql_dj_tgt AS t "
+            f"{t_end} FROM {_DISJOIN_CTE_TGT} AS t "
             "UNION "
             f'SELECT t."{target_chrom}", t."{target_start}", t."{target_end}", '
-            "bp.pos FROM __giql_dj_tgt AS t JOIN __giql_dj_bp AS bp "
+            f"bp.pos FROM {_DISJOIN_CTE_TGT} AS t JOIN {_DISJOIN_CTE_BP} AS bp "
             f"ON bp.chrom = {t_chrom} AND bp.pos > {t_start} "
             f"AND bp.pos < {t_end})"
         )
         segs_cte = (
-            "__giql_dj_segs AS ("
+            f"{_DISJOIN_CTE_SEGS} AS ("
             "SELECT kc, ks, ke, pos AS seg_start, "
             "LEAD(pos) OVER (PARTITION BY kc, ks, ke ORDER BY pos) AS seg_end "
-            "FROM __giql_dj_cuts)"
+            f"FROM {_DISJOIN_CTE_CUTS})"
         )
-        # In self-reference mode the coverage EXISTS is provably always true:
-        # every emitted segment lies inside its parent target row, and that
-        # row is itself a member of the reference set. Skip the clause so the
-        # planner does not waste work on a no-op semi-join. The __giql_dj_ref
-        # CTE itself stays live because __giql_dj_bp still draws breakpoints
-        # from it.
+        # The ``seg_end > seg_start`` guard is belt-and-suspenders: UNION
+        # already dedupes cut positions, so LEAD cannot produce a zero-length
+        # segment unless it becomes UNION ALL.
         where_clauses = ["s.seg_end IS NOT NULL", "s.seg_end > s.seg_start"]
-        if not is_self_reference:
+        if not reference.is_self_reference:
+            # See ``_ResolvedReference.is_self_reference`` for when the
+            # coverage EXISTS may be skipped. giql does not emit dialect-
+            # specific MATERIALIZED hints, so we keep EXISTS rather than rely
+            # on engine-specific materialization guarantees for CTE bodies.
             where_clauses.append(
-                f'EXISTS (SELECT 1 FROM __giql_dj_ref AS r WHERE r."{ref_chrom}" = s.kc '
+                f"EXISTS (SELECT 1 FROM {_DISJOIN_CTE_REF} AS r "
+                f'WHERE r."{ref_chrom}" = s.kc '
                 f"AND {r_start} <= s.seg_start AND {r_end} > s.seg_start)"
             )
         where_sql = " AND ".join(where_clauses)
         final_select = (
             f"SELECT t.*, s.kc AS disjoin_chrom, {out_start} AS disjoin_start, "
-            f"{out_end} AS disjoin_end FROM __giql_dj_tgt AS t "
-            f'JOIN __giql_dj_segs AS s ON t."{target_chrom}" = s.kc '
+            f"{out_end} AS disjoin_end FROM {_DISJOIN_CTE_TGT} AS t "
+            f'JOIN {_DISJOIN_CTE_SEGS} AS s ON t."{target_chrom}" = s.kc '
             f'AND t."{target_start}" = s.ks AND t."{target_end}" = s.ke '
             f"WHERE {where_sql}"
         )
@@ -801,8 +1049,8 @@ class BaseGIQLGenerator(Generator):
             Tuple of (chromosome, start, end) or (chromosome, start, end, strand)
             Returns SQL expressions (column refs for correlated, literals for standalone)
             Endpoints are canonicalized to 0-based half-open: literal references via
-            :meth:`~giql.range_parser.RangeParser.to_zero_based_half_open`, column
-            references via :func:`giql.canonical.canonical_start` /
+            :meth:`RangeParser.to_zero_based_half_open`, column references via
+            :func:`giql.canonical.canonical_start` /
             :func:`giql.canonical.canonical_end`.
         :raises ValueError:
             If reference is missing in standalone mode or invalid format
@@ -885,186 +1133,267 @@ class BaseGIQLGenerator(Generator):
                     canonical_end(end, table),
                 )
 
-    def _resolve_target_table(
-        self, expression: GIQLNearest | GIQLDisjoin
-    ) -> tuple[str, tuple[str, str, str]]:
-        """Resolve the target table name and its genomic column references.
+    def _resolve_cte_or_registered(
+        self, name: str, expression: exp.Expression
+    ) -> _ResolvedRelation | None:
+        """Resolve ``name`` against enclosing CTEs first, then registered tables.
+
+        A CTE shadowing a registered table of the same name yields the
+        canonical default columns and ``None`` for the table config; a
+        registered table contributes its configured column names and config.
+
+        :param name:
+            Bare identifier extracted from a target or reference node.
+        :param expression:
+            The operator expression; the ancestor walk for CTE collection
+            starts from this node.
+        :return:
+            A :class:`_ResolvedRelation` on a hit, or ``None`` when the name
+            matches neither an enclosing CTE nor a registered table.
+        """
+        if name in _enclosing_cte_names(expression):
+            return _ResolvedRelation(name=name, cols=CANONICAL_DEFAULT_COLS, table=None)
+        table = self.tables.get(name)
+        if table is not None:
+            return _ResolvedRelation(
+                name=name,
+                cols=(table.chrom_col, table.start_col, table.end_col),
+                table=table,
+            )
+        return None
+
+    def _resolve_target(
+        self,
+        expression: GIQLDisjoin | GIQLNearest,
+        *,
+        accept_cte: bool,
+        operator_label: str,
+    ) -> _ResolvedRelation:
+        """Resolve a DISJOIN or NEAREST target to a :class:`_ResolvedRelation`.
+
+        When ``accept_cte`` is true (DISJOIN), a name defined by an enclosing
+        ``WITH`` shadows a same-named registered table (matching SQL scoping)
+        and is assumed to expose canonical 0-based half-open ``chrom`` /
+        ``start`` / ``end`` columns — the CTE contract is *unvalidated*: the
+        resolver does not inspect the CTE body. When ``accept_cte`` is false
+        (NEAREST), a CTE-only match is rejected, and a name matching *both*
+        an enclosing CTE and a registered table is rejected as ambiguous —
+        the emitted ``FROM "x"`` would be shadowed by the CTE under SQL
+        lexical scoping while column references resolve against the
+        registered table, so the two interpretations would silently diverge.
 
         :param expression:
-            GIQLNearest or GIQLDisjoin expression node
+            A :class:`GIQLDisjoin` or :class:`GIQLNearest` expression node.
+        :param accept_cte:
+            ``True`` for DISJOIN (CTE shadow allowed); ``False`` for NEAREST.
+        :param operator_label:
+            ``"DISJOIN"`` or ``"NEAREST"`` for operator-specific error
+            wording.
         :return:
-            Tuple of (table_name, (chromosome_col, start_col, end_col))
+            The :class:`_ResolvedRelation`. ``table`` is ``None`` for a CTE
+            target (DISJOIN only); never ``None`` for NEAREST.
         :raises ValueError:
-            If target table is not found or doesn't have genomic columns
+            If the target node is not a bare name (qualified, subquery,
+            etc.); if a bare name resolves to neither a registered table
+            nor an enclosing CTE; for NEAREST, if a bare name matches an
+            enclosing CTE (rejected) or matches both a registered table and
+            an enclosing CTE (ambiguous).
         """
-        # Extract target table from 'this' argument
-        target = expression.this
-
-        if isinstance(target, exp.Table):
-            table_name = target.name
-        elif isinstance(target, exp.Column):
-            # If it's a column reference, extract table name
-            table_name = target.table if target.table else str(target.this)
-        else:
-            # Try to extract as string
-            table_name = str(target)
-
-        table = self.tables.get(table_name)
-        if not table:
+        target_node = expression.this
+        try:
+            name = _extract_bare_name(target_node)
+        except _NotABareName:
+            if _is_qualified_name(target_node):
+                raise ValueError(
+                    f"Target {target_node.sql()!r} is qualified; "
+                    "pass a bare table or CTE name."
+                ) from None
             raise ValueError(
-                f"Target table '{table_name}' not found in tables. "
-                "Register the table before transpiling."
-            )
+                f"Target must be a bare table or CTE name; "
+                f"got {type(target_node).__name__}: {target_node.sql()!r}."
+            ) from None
 
-        # Get physical column names from table config
-        return table_name, (table.chrom_col, table.start_col, table.end_col)
+        if accept_cte:
+            resolved = self._resolve_cte_or_registered(name, expression)
+            if resolved is None:
+                raise ValueError(
+                    f"{operator_label} target {name!r} is neither a "
+                    "registered table nor a CTE defined in an enclosing "
+                    "WITH clause. Pass the relation via "
+                    "`transpile(..., tables=[...])` or define the CTE in an "
+                    "enclosing WITH clause before transpiling."
+                )
+            return resolved
+
+        # NEAREST policy: registered tables only.
+        table = self.tables.get(name)
+        is_cte = name in _enclosing_cte_names(expression)
+        if table is not None and is_cte:
+            raise ValueError(
+                f"{operator_label} target {name!r} resolves to both a "
+                "registered table and an enclosing CTE. The engine's SQL "
+                "scoping would route NEAREST's rows from the CTE while "
+                "column references resolve against the registered table — "
+                "rename one of them to disambiguate."
+            )
+        if table is not None:
+            return _ResolvedRelation(
+                name=name,
+                cols=(table.chrom_col, table.start_col, table.end_col),
+                table=table,
+            )
+        if is_cte:
+            raise ValueError(
+                f"{operator_label} target {name!r} matches an enclosing CTE. "
+                f"{operator_label} does not accept CTE targets; register the "
+                "relation as a table via `transpile(..., tables=[...])`, or "
+                "rephrase the query against a registered table."
+            )
+        raise ValueError(
+            f"Target table {name!r} not found in tables. "
+            "Register the table before transpiling."
+        )
 
     def _resolve_disjoin_reference(
         self,
         expression: GIQLDisjoin,
-        target_name: str,
-        target_cols: tuple[str, str, str],
-        target_table: Table | None,
-    ) -> tuple[str, str, str, str, Table | None, bool]:
+        target: _ResolvedRelation,
+    ) -> _ResolvedReference:
         """Resolve the reference relation for a DISJOIN query.
 
-        The reference contributes the breakpoints at which target intervals are
-        cut. When ``reference`` is omitted it defaults to the target set.
+        The reference contributes the breakpoints at which target intervals
+        are cut. When ``reference`` is omitted it defaults to the target set.
 
         A bare reference name is resolved against the query's CTEs first: a
-        name defined by an enclosing ``WITH`` clause shadows a registered table
-        of the same name (matching SQL scoping) and is assumed to expose
-        canonical 0-based half-open ``chrom`` / ``start`` / ``end`` columns. A
-        name with no such CTE but a registered table contributes that table's
-        column names and coordinate system. A name that is neither is an error.
+        name defined by an enclosing ``WITH`` clause shadows a registered
+        table of the same name (matching SQL scoping) and is assumed to
+        expose canonical 0-based half-open ``chrom`` / ``start`` / ``end``
+        columns. A name with no such CTE but a registered table contributes
+        that table's column names and coordinate system. A name that is
+        neither is an error. A ``(SELECT ...)`` subquery is inlined verbatim
+        and assumed to project the canonical columns.
 
         :param expression:
-            GIQLDisjoin expression node
-        :param target_name:
-            Resolved target table name (the default reference)
-        :param target_cols:
-            ``(chrom, start, end)`` column names of the target table
-        :param target_table:
-            Table config of the target (the default reference config)
+            GIQLDisjoin expression node.
+        :param target:
+            The already-resolved target relation (used to default the
+            reference and to determine whether the coverage EXISTS may be
+            omitted).
         :return:
-            Tuple of ``(from_clause, chrom_col, start_col, end_col, table,
-            is_self_reference)`` where ``from_clause`` is the text following
-            ``FROM`` inside the ``__giql_dj_ref`` CTE. A subquery or CTE
-            reference is assumed to expose canonical 0-based half-open
-            ``chrom`` / ``start`` / ``end`` columns, so ``table`` is ``None``
-            for those. ``is_self_reference`` is ``True`` only when the
-            reference provably resolves to the same registered relation as the
-            target (omitted reference, or a bare name equal to the target name
-            that is not shadowed by an enclosing CTE and maps to the same
-            registered table). It is ``False`` in all other cases, including
-            subquery and CTE references that may textually duplicate the
-            target.
+            A :class:`_ResolvedReference`. For a subquery reference,
+            ``subquery`` carries the AST node and ``relation.name`` is
+            empty. ``is_self_reference`` is ``True`` only when both sides
+            provably resolve to the same registered :class:`Table` — i.e.
+            an omitted reference against a registered target, or a bare
+            name that maps to the same Table instance.
         :raises ValueError:
-            If the reference is not a table name, a CTE, or a subquery, or if
-            a bare name resolves to neither a registered table nor a CTE.
+            If the reference is not a bare table/CTE name or a
+            ``(SELECT ...)`` subquery, or if a bare name resolves to neither
+            a registered table nor a CTE.
         """
         reference = expression.args.get("reference")
-        tc, ts, te = target_cols
 
         # No reference: default to the target set (single-mode).
         if reference is None:
-            return target_name, tc, ts, te, target_table, True
-
-        # Subquery reference: inline it as an aliased derived table. The
-        # subquery may textually duplicate the target, but proving equivalence
-        # is out of scope, so treat it as a distinct relation.
-        if isinstance(reference, (exp.Subquery, exp.Select, exp.Union)):
-            from_clause = f"{self.sql(reference)} AS __giql_dj_rs"
-            return (
-                from_clause,
-                DEFAULT_CHROM_COL,
-                DEFAULT_START_COL,
-                DEFAULT_END_COL,
-                None,
-                False,
+            return _ResolvedReference(
+                relation=target,
+                subquery=None,
+                is_self_reference=target.table is not None,
             )
 
-        # Anything that is not a bare table/CTE name is unsupported.
+        # Subquery reference: inline as an aliased derived table. The subquery
+        # may textually duplicate the target but proving equivalence is out
+        # of scope, so treat it as a distinct relation.
+        if isinstance(reference, exp.Subquery):
+            return _ResolvedReference(
+                relation=_ResolvedRelation(
+                    name="", cols=CANONICAL_DEFAULT_COLS, table=None
+                ),
+                subquery=reference,
+                is_self_reference=False,
+            )
+
         if not isinstance(reference, (exp.Table, exp.Column, exp.Identifier)):
             raise ValueError(
                 "DISJOIN reference must be a table name, a CTE, or a "
                 f"(SELECT ...) subquery; got {type(reference).__name__}: "
-                f"{reference}"
+                f"{reference.sql() if hasattr(reference, 'sql') else reference!r}"
             )
 
-        ref_name = reference.name
-
-        # The __giql_dj_ prefix names the operator's internal CTEs.
-        if ref_name.startswith("__giql_dj_"):
+        try:
+            ref_name = _extract_bare_name(reference)
+        except _NotABareName:
+            if _is_qualified_name(reference):
+                raise ValueError(
+                    f"Reference {reference.sql()!r} is qualified; "
+                    "pass a bare table or CTE name, or a (SELECT ...) "
+                    "subquery."
+                ) from None
             raise ValueError(
-                f"DISJOIN reference {ref_name!r} uses the reserved "
-                "'__giql_dj_' prefix, which names the operator's internal "
-                "CTEs. Rename the reference relation."
-            )
+                "Reference must be a bare table or CTE name, or a "
+                f"(SELECT ...) subquery; got {type(reference).__name__}: "
+                f"{reference.sql()!r}."
+            ) from None
 
-        # A CTE from an enclosing WITH shadows a registered table of the same
-        # name; it is assumed to expose canonical default columns. A CTE may
-        # contain rows distinct from any same-named registered table, so it is
-        # never treated as a self-reference.
-        if ref_name in self._enclosing_cte_names(expression):
-            return (
-                ref_name,
-                DEFAULT_CHROM_COL,
-                DEFAULT_START_COL,
-                DEFAULT_END_COL,
-                None,
-                False,
+        resolved = self._resolve_cte_or_registered(ref_name, expression)
+        if resolved is None:
+            raise ValueError(
+                f"DISJOIN reference {ref_name!r} is neither a registered "
+                "table nor a CTE defined in an enclosing WITH clause. Pass "
+                "the relation via `transpile(..., tables=[...])` or define "
+                "the CTE in an enclosing WITH clause before transpiling. "
+                "You may also inline the rows via `reference := (SELECT ...)`."
             )
-
-        ref_table = self.tables.get(ref_name)
-        if ref_table:
-            return (
-                ref_name,
-                ref_table.chrom_col,
-                ref_table.start_col,
-                ref_table.end_col,
-                ref_table,
-                ref_name == target_name and ref_table is target_table,
-            )
-        raise ValueError(
-            f"DISJOIN reference {ref_name!r} is neither a registered table "
-            "nor a CTE defined in this query. Register the table or define "
-            "the CTE before transpiling."
+        is_self_reference = (
+            resolved.table is not None
+            and resolved.name == target.name
+            and resolved.table is target.table
+        )
+        return _ResolvedReference(
+            relation=resolved,
+            subquery=None,
+            is_self_reference=is_self_reference,
         )
 
-    @staticmethod
-    def _extract_bool_param(param_expr: exp.Expression | None) -> bool:
-        """Extract boolean value from a parameter expression.
+    def _check_reserved_collisions(self, expression: GIQLDisjoin) -> None:
+        """Reject identifiers that would shadow DISJOIN's internal
+        ``__giql_dj_*`` CTE namespace.
 
-        Handles :class:`exp.Boolean`, :class:`exp.Literal`, and string
-        representations.
+        Three sources are checked: every CTE alias visible in an enclosing
+        ``WITH``, the target's bare name, and the reference's bare name
+        (subquery references and non-bare reference shapes are skipped —
+        their own resolution paths handle them). Surfacing the collision
+        here keeps the diagnostic at transpile time; without it the
+        duplicate-CTE name reaches the engine as an opaque parse error.
+
+        :raises ValueError:
+            If any of the three sources begins with ``__giql_dj_``.
         """
-        if not param_expr:
-            return False
-        elif isinstance(param_expr, exp.Boolean):
-            return param_expr.this
-        else:
-            return str(param_expr).upper() in ("TRUE", "1", "YES")
-
-    @staticmethod
-    def _enclosing_cte_names(expression: exp.Expression) -> set[str]:
-        """Collect CTE names visible to an expression from enclosing WITH clauses.
-
-        Walks the ancestor chain and gathers the aliases of every ``WITH``-clause
-        CTE, so a DISJOIN reference can be recognized as an in-query CTE rather
-        than a registered table.
-        """
-        names: set[str] = set()
-        node: exp.Expression | None = expression
-        while node is not None:
-            if isinstance(node, exp.Select):
-                with_clause = node.args.get("with_") or node.args.get("with")
-                if with_clause is not None:
-                    for cte in with_clause.expressions:
-                        if cte.alias:
-                            names.add(cte.alias)
-            node = node.parent
-        return names
+        prefix = _DISJOIN_RESERVED_PREFIX
+        for cte_name in _enclosing_cte_names(expression):
+            if cte_name.startswith(prefix):
+                raise ValueError(
+                    f"Enclosing CTE {cte_name!r} uses the reserved "
+                    f"{prefix!r} prefix, which names DISJOIN's internal "
+                    "CTEs — this CTE collides with DISJOIN's internal "
+                    "namespace and would shadow its emitted SQL. Rename "
+                    "the CTE before invoking DISJOIN."
+                )
+        target_name = _bare_name_or_none(expression.this)
+        if target_name and target_name.startswith(prefix):
+            raise ValueError(
+                f"DISJOIN target {target_name!r} uses the reserved "
+                f"{prefix!r} prefix, which names the operator's internal "
+                "CTEs. Rename the relation."
+            )
+        ref_node = expression.args.get("reference")
+        ref_name = _bare_name_or_none(ref_node) if ref_node is not None else None
+        if ref_name and ref_name.startswith(prefix):
+            raise ValueError(
+                f"DISJOIN reference {ref_name!r} uses the reserved "
+                f"{prefix!r} prefix, which names the operator's internal "
+                "CTEs. Rename the relation."
+            )
 
     def _get_column_refs(
         self,

--- a/src/giql/mcp/server.py
+++ b/src/giql/mcp/server.py
@@ -126,16 +126,28 @@ OPERATORS: dict[str, dict[str, Any]] = {
     "DISJOIN": {
         "category": "set-operation",
         "description": "Split genomic intervals into sub-intervals at reference breakpoints",
-        "syntax": "SELECT * FROM DISJOIN(target, reference := refs)",
+        "syntax": "SELECT * FROM DISJOIN(target_or_cte, reference := refs)",
         "parameters": [
-            {"name": "target", "description": "Table of intervals to split"},
+            {
+                "name": "target",
+                "description": (
+                    "Registered table or in-query CTE of intervals to split. A "
+                    "CTE shadows a same-named registered table and is assumed "
+                    "to expose canonical 0-based half-open chrom/start/end "
+                    "columns."
+                ),
+            },
             {
                 "name": "reference",
-                "description": "Table, CTE, or subquery supplying breakpoints (defaults to target)",
+                "description": (
+                    "Table, CTE, or subquery supplying breakpoints (defaults "
+                    "to target). A CTE or subquery is assumed to expose "
+                    "canonical 0-based half-open chrom/start/end columns."
+                ),
             },
         ],
         "returns": "Each target row with the sub-interval appended (disjoin_chrom, disjoin_start, disjoin_end)",
-        "example": "SELECT * FROM DISJOIN(features, reference := mask)",
+        "example": "SELECT * FROM DISJOIN(features, reference := other)",
         "doc_file": "dialect/set-operators.rst",
     },
     "ANY": {
@@ -453,6 +465,7 @@ Set Operations
 --------------
 DISJOIN - Split intervals at reference breakpoints
   SELECT * FROM DISJOIN(target, reference := refs)
+  -- target may also be a CTE defined in an enclosing WITH clause
 
 Set Quantifiers
 ---------------

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -409,20 +409,20 @@ class TestBaseGIQLGenerator:
 
         expected = (
             "SELECT * FROM (\n"
-            "                SELECT genes.*, "
-            "CASE WHEN 'chr1' != genes.\"chrom\" THEN NULL "
-            'WHEN 1000 < genes."end" AND 2000 > genes."start" THEN 0 '
-            'WHEN 2000 <= genes."start" '
-            'THEN (genes."start" - 2000) '
-            'ELSE (1000 - genes."end") END AS distance\n'
-            "                FROM genes\n"
-            "                WHERE 'chr1' = genes.\"chrom\"\n"
+            '                SELECT "genes".*, '
+            'CASE WHEN \'chr1\' != "genes"."chrom" THEN NULL '
+            'WHEN 1000 < "genes"."end" AND 2000 > "genes"."start" THEN 0 '
+            'WHEN 2000 <= "genes"."start" '
+            'THEN ("genes"."start" - 2000) '
+            'ELSE (1000 - "genes"."end") END AS distance\n'
+            '                FROM "genes"\n'
+            '                WHERE \'chr1\' = "genes"."chrom"\n'
             "                ORDER BY ABS("
-            "CASE WHEN 'chr1' != genes.\"chrom\" THEN NULL "
-            'WHEN 1000 < genes."end" AND 2000 > genes."start" THEN 0 '
-            'WHEN 2000 <= genes."start" '
-            'THEN (genes."start" - 2000) '
-            'ELSE (1000 - genes."end") END)\n'
+            'CASE WHEN \'chr1\' != "genes"."chrom" THEN NULL '
+            'WHEN 1000 < "genes"."end" AND 2000 > "genes"."start" THEN 0 '
+            'WHEN 2000 <= "genes"."start" '
+            'THEN ("genes"."start" - 2000) '
+            'ELSE (1000 - "genes"."end") END)\n'
             "                LIMIT 3\n"
             "            )"
         )
@@ -445,22 +445,22 @@ class TestBaseGIQLGenerator:
 
         expected = (
             "SELECT * FROM peaks CROSS JOIN LATERAL (\n"
-            "                SELECT genes.*, "
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END AS distance\n'
-            "                FROM genes\n"
-            '                WHERE peaks."chrom" = genes."chrom"\n'
+            '                SELECT "genes".*, '
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
+            'THEN ("genes"."start" - peaks."end") '
+            'ELSE (peaks."start" - "genes"."end") END AS distance\n'
+            '                FROM "genes"\n'
+            '                WHERE peaks."chrom" = "genes"."chrom"\n'
             "                ORDER BY ABS("
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END)\n'
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
+            'THEN ("genes"."start" - peaks."end") '
+            'ELSE (peaks."start" - "genes"."end") END)\n'
             "                LIMIT 3\n"
             "            )"
         )
@@ -484,29 +484,29 @@ class TestBaseGIQLGenerator:
 
         expected = (
             "SELECT * FROM peaks CROSS JOIN LATERAL (\n"
-            "                SELECT genes.*, "
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END AS distance\n'
-            "                FROM genes\n"
-            '                WHERE peaks."chrom" = genes."chrom" '
+            '                SELECT "genes".*, '
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
+            'THEN ("genes"."start" - peaks."end") '
+            'ELSE (peaks."start" - "genes"."end") END AS distance\n'
+            '                FROM "genes"\n'
+            '                WHERE peaks."chrom" = "genes"."chrom" '
             "AND (ABS("
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END)) <= 100000\n'
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
+            'THEN ("genes"."start" - peaks."end") '
+            'ELSE (peaks."start" - "genes"."end") END)) <= 100000\n'
             "                ORDER BY ABS("
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END)\n'
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
+            'THEN ("genes"."start" - peaks."end") '
+            'ELSE (peaks."start" - "genes"."end") END)\n'
             "                LIMIT 5\n"
             "            )"
         )
@@ -530,37 +530,37 @@ class TestBaseGIQLGenerator:
 
         expected = (
             "SELECT * FROM peaks CROSS JOIN LATERAL (\n"
-            "                SELECT genes.*, "
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."strand" IS NULL OR genes."strand" IS NULL THEN NULL '
+            '                SELECT "genes".*, '
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."strand" IS NULL OR "genes"."strand" IS NULL THEN NULL '
             "WHEN peaks.\"strand\" = '.' OR peaks.\"strand\" = '?' THEN NULL "
-            "WHEN genes.\"strand\" = '.' OR genes.\"strand\" = '?' THEN NULL "
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
+            'WHEN "genes"."strand" = \'.\' OR "genes"."strand" = \'?\' THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
             "THEN CASE WHEN peaks.\"strand\" = '-' "
-            'THEN -(genes."start" - peaks."end") '
-            'ELSE (genes."start" - peaks."end") END '
+            'THEN -("genes"."start" - peaks."end") '
+            'ELSE ("genes"."start" - peaks."end") END '
             "ELSE CASE WHEN peaks.\"strand\" = '-' "
-            'THEN -(peaks."start" - genes."end") '
-            'ELSE (peaks."start" - genes."end") END END AS distance\n'
-            "                FROM genes\n"
-            '                WHERE peaks."chrom" = genes."chrom" '
-            'AND peaks."strand" = genes."strand"\n'
+            'THEN -(peaks."start" - "genes"."end") '
+            'ELSE (peaks."start" - "genes"."end") END END AS distance\n'
+            '                FROM "genes"\n'
+            '                WHERE peaks."chrom" = "genes"."chrom" '
+            'AND peaks."strand" = "genes"."strand"\n'
             "                ORDER BY ABS("
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."strand" IS NULL OR genes."strand" IS NULL THEN NULL '
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."strand" IS NULL OR "genes"."strand" IS NULL THEN NULL '
             "WHEN peaks.\"strand\" = '.' OR peaks.\"strand\" = '?' THEN NULL "
-            "WHEN genes.\"strand\" = '.' OR genes.\"strand\" = '?' THEN NULL "
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
+            'WHEN "genes"."strand" = \'.\' OR "genes"."strand" = \'?\' THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
             "THEN CASE WHEN peaks.\"strand\" = '-' "
-            'THEN -(genes."start" - peaks."end") '
-            'ELSE (genes."start" - peaks."end") END '
+            'THEN -("genes"."start" - peaks."end") '
+            'ELSE ("genes"."start" - peaks."end") END '
             "ELSE CASE WHEN peaks.\"strand\" = '-' "
-            'THEN -(peaks."start" - genes."end") '
-            'ELSE (peaks."start" - genes."end") END END)\n'
+            'THEN -(peaks."start" - "genes"."end") '
+            'ELSE (peaks."start" - "genes"."end") END END)\n'
             "                LIMIT 3\n"
             "            )"
         )
@@ -584,22 +584,22 @@ class TestBaseGIQLGenerator:
 
         expected = (
             "SELECT * FROM peaks CROSS JOIN LATERAL (\n"
-            "                SELECT genes.*, "
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE -(peaks."start" - genes."end") END AS distance\n'
-            "                FROM genes\n"
-            '                WHERE peaks."chrom" = genes."chrom"\n'
+            '                SELECT "genes".*, '
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
+            'THEN ("genes"."start" - peaks."end") '
+            'ELSE -(peaks."start" - "genes"."end") END AS distance\n'
+            '                FROM "genes"\n'
+            '                WHERE peaks."chrom" = "genes"."chrom"\n'
             "                ORDER BY ABS("
-            'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
-            'WHEN peaks."start" < genes."end" '
-            'AND peaks."end" > genes."start" THEN 0 '
-            'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE -(peaks."start" - genes."end") END)\n'
+            'CASE WHEN peaks."chrom" != "genes"."chrom" THEN NULL '
+            'WHEN peaks."start" < "genes"."end" '
+            'AND peaks."end" > "genes"."start" THEN 0 '
+            'WHEN peaks."end" <= "genes"."start" '
+            'THEN ("genes"."start" - peaks."end") '
+            'ELSE -(peaks."start" - "genes"."end") END)\n'
             "                LIMIT 3\n"
             "            )"
         )
@@ -877,7 +877,7 @@ class TestBaseGIQLGenerator:
 
         # Should contain strand literal '+' and strand filtering
         assert "'+'" in output
-        assert 'genes."strand"' in output
+        assert '"genes"."strand"' in output
 
     def test_giqlnearest_sql_stranded_implicit_reference(
         self, tables_with_peaks_and_genes
@@ -895,7 +895,7 @@ class TestBaseGIQLGenerator:
 
         # Should have strand columns from both tables
         assert 'peaks."strand"' in output
-        assert 'genes."strand"' in output
+        assert '"genes"."strand"' in output
 
     def test_giqlnearest_should_not_apply_gap_plus_one_for_closed_intervals(
         self,
@@ -914,8 +914,7 @@ class TestBaseGIQLGenerator:
         tables = Tables()
         tables.register("genes_closed", Table("genes_closed", interval_type="closed"))
         sql = (
-            "SELECT * FROM NEAREST("
-            "genes_closed, reference := 'chr1:1000-2000', k := 3)"
+            "SELECT * FROM NEAREST(genes_closed, reference := 'chr1:1000-2000', k := 3)"
         )
         ast = parse_one(sql, dialect=GIQLDialect)
         generator = BaseGIQLGenerator(tables=tables)
@@ -925,11 +924,11 @@ class TestBaseGIQLGenerator:
 
         # Assert — canonicalization is applied, but neither gap branch carries
         # a trailing "+ 1".
-        assert '(genes_closed."end" + 1)' in output
-        assert 'THEN (genes_closed."start" - 2000)' in output
-        assert 'ELSE (1000 - (genes_closed."end" + 1))' in output
-        assert '(genes_closed."start" - 2000 + 1)' not in output
-        assert '(1000 - (genes_closed."end" + 1) + 1)' not in output
+        assert '("genes_closed"."end" + 1)' in output
+        assert 'THEN ("genes_closed"."start" - 2000)' in output
+        assert 'ELSE (1000 - ("genes_closed"."end" + 1))' in output
+        assert '("genes_closed"."start" - 2000 + 1)' not in output
+        assert '(1000 - ("genes_closed"."end" + 1) + 1)' not in output
 
     def test_giqldistance_sql_literal_first_arg_error(self, tables_with_two_tables):
         """
@@ -1261,8 +1260,7 @@ class TestBaseGIQLGenerator:
 
         # Assert
         expected = (
-            "SELECT * FROM variants WHERE "
-            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+            f"SELECT * FROM variants WHERE (\"chrom\" = 'chr1' AND {expected_predicate})"
         )
         assert output == expected
 
@@ -1318,8 +1316,7 @@ class TestBaseGIQLGenerator:
 
         # Assert
         expected = (
-            "SELECT * FROM variants WHERE "
-            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+            f"SELECT * FROM variants WHERE (\"chrom\" = 'chr1' AND {expected_predicate})"
         )
         assert output == expected
 
@@ -1375,8 +1372,7 @@ class TestBaseGIQLGenerator:
 
         # Assert
         expected = (
-            "SELECT * FROM variants WHERE "
-            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+            f"SELECT * FROM variants WHERE (\"chrom\" = 'chr1' AND {expected_predicate})"
         )
         assert output == expected
 
@@ -1545,24 +1541,39 @@ class TestBaseGIQLGenerator:
         "coordinate_system, interval_type, start_a, end_a, start_b, end_b",
         [
             pytest.param(
-                "0based", "half_open",
-                'a."start"', 'a."end"', 'b."start"', 'b."end"',
+                "0based",
+                "half_open",
+                'a."start"',
+                'a."end"',
+                'b."start"',
+                'b."end"',
                 id="0based-half_open",
             ),
             pytest.param(
-                "0based", "closed",
-                'a."start"', '(a."end" + 1)', 'b."start"', '(b."end" + 1)',
+                "0based",
+                "closed",
+                'a."start"',
+                '(a."end" + 1)',
+                'b."start"',
+                '(b."end" + 1)',
                 id="0based-closed",
             ),
             pytest.param(
-                "1based", "half_open",
-                '(a."start" - 1)', '(a."end" - 1)',
-                '(b."start" - 1)', '(b."end" - 1)',
+                "1based",
+                "half_open",
+                '(a."start" - 1)',
+                '(a."end" - 1)',
+                '(b."start" - 1)',
+                '(b."end" - 1)',
                 id="1based-half_open",
             ),
             pytest.param(
-                "1based", "closed",
-                '(a."start" - 1)', 'a."end"', '(b."start" - 1)', 'b."end"',
+                "1based",
+                "closed",
+                '(a."start" - 1)',
+                'a."end"',
+                '(b."start" - 1)',
+                'b."end"',
                 id="1based-closed",
             ),
         ],
@@ -1660,23 +1671,31 @@ class TestBaseGIQLGenerator:
         "coordinate_system, interval_type, target_start, target_end",
         [
             pytest.param(
-                "0based", "half_open",
-                'genes."start"', 'genes."end"',
+                "0based",
+                "half_open",
+                '"genes"."start"',
+                '"genes"."end"',
                 id="0based-half_open",
             ),
             pytest.param(
-                "0based", "closed",
-                'genes."start"', '(genes."end" + 1)',
+                "0based",
+                "closed",
+                '"genes"."start"',
+                '("genes"."end" + 1)',
                 id="0based-closed",
             ),
             pytest.param(
-                "1based", "half_open",
-                '(genes."start" - 1)', '(genes."end" - 1)',
+                "1based",
+                "half_open",
+                '("genes"."start" - 1)',
+                '("genes"."end" - 1)',
                 id="1based-half_open",
             ),
             pytest.param(
-                "1based", "closed",
-                '(genes."start" - 1)', 'genes."end"',
+                "1based",
+                "closed",
+                '("genes"."start" - 1)',
+                '"genes"."end"',
                 id="1based-closed",
             ),
         ],
@@ -1715,9 +1734,7 @@ class TestBaseGIQLGenerator:
 
         # Assert — distance CASE expression uses canonicalized target endpoints
         # against the (already-canonical) literal reference [1000, 2000).
-        assert (
-            f"WHEN 1000 < {target_end} AND 2000 > {target_start} THEN 0" in output
-        )
+        assert f"WHEN 1000 < {target_end} AND 2000 > {target_start} THEN 0" in output
         assert f"WHEN 2000 <= {target_start} THEN ({target_start} - 2000)" in output
         assert f"ELSE (1000 - {target_end})" in output
 
@@ -1747,10 +1764,10 @@ class TestBaseGIQLGenerator:
         output = generator.generate(ast)
 
         # Assert — reference's start canonicalized via _canonical_start
-        assert '(b."start" - 1) < bed_a."end"' in output
-        assert 'bed_a."end" <= (b."start" - 1)' not in output  # reference is left side
+        assert '(b."start" - 1) < "bed_a"."end"' in output
+        assert '"bed_a"."end" <= (b."start" - 1)' not in output  # reference is left side
         # Reference's end stays raw (1-based closed → identity for end)
-        assert 'b."end" > bed_a."start" THEN 0' in output
+        assert 'b."end" > "bed_a"."start" THEN 0' in output
 
     def test_giqlnearest_should_canonicalize_outer_table_columns_when_reference_is_implicit(
         self, tables_mixed_conventions
@@ -1769,9 +1786,7 @@ class TestBaseGIQLGenerator:
             leaving end raw — while leaving bed_a's target columns raw.
         """
         # Arrange
-        sql = (
-            "SELECT * FROM vcf_b CROSS JOIN LATERAL NEAREST(bed_a, k := 1)"
-        )
+        sql = "SELECT * FROM vcf_b CROSS JOIN LATERAL NEAREST(bed_a, k := 1)"
         ast = parse_one(sql, dialect=GIQLDialect)
         generator = BaseGIQLGenerator(tables=tables_mixed_conventions)
 
@@ -1781,9 +1796,9 @@ class TestBaseGIQLGenerator:
         # Assert — distance CASE uses canonicalized outer-table columns and
         # raw target-table columns.
         assert (
-            'WHEN (vcf_b."start" - 1) < bed_a."end" '
-            'AND vcf_b."end" > bed_a."start" THEN 0'
+            'WHEN (vcf_b."start" - 1) < "bed_a"."end" '
+            'AND vcf_b."end" > "bed_a"."start" THEN 0'
         ) in output
-        assert 'WHEN vcf_b."end" <= bed_a."start"' in output
-        assert 'THEN (bed_a."start" - vcf_b."end")' in output
-        assert 'ELSE ((vcf_b."start" - 1) - bed_a."end")' in output
+        assert 'WHEN vcf_b."end" <= "bed_a"."start"' in output
+        assert 'THEN ("bed_a"."start" - vcf_b."end")' in output
+        assert 'ELSE ((vcf_b."start" - 1) - "bed_a"."end")' in output

--- a/tests/integration/coordinate_space/test_disjoin_coordinate_space.py
+++ b/tests/integration/coordinate_space/test_disjoin_coordinate_space.py
@@ -311,3 +311,61 @@ class TestDisjoinCoordinateSpace:
 
         # Assert
         assert result == [(20, 50)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_user_canonicalized_cte_target_yields_canonical_partition(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test that a user-canonicalized CTE target yields the canonical partition.
+
+        Given:
+            A registered ``features`` table re-encoded under one convention.
+        When:
+            A WITH clause projects user-canonicalized 0-based half-open
+            ``chrom`` / ``start`` / ``end`` columns and DISJOIN runs against
+            the CTE.
+        Then:
+            The output should equal the canonical partition ``{[0, 10),
+            [10, 20), [20, 30)}`` regardless of the source convention — a
+            CTE target is assumed canonical, so the user's canonicalization
+            formula determines the result, not the registered table's config.
+        """
+        # Arrange
+        s_a, e_a = encode(0, 20, coordinate_system, interval_type)
+        s_b, e_b = encode(10, 30, coordinate_system, interval_type)
+        tables = [make_table("features", coordinate_system, interval_type)]
+
+        # Per-convention canonicalization formulae (inverse of encode):
+        # `start` shifts by `-1` for 1-based; `end` shifts by `+1` (closed)
+        # or `-1` (1-based half-open).
+        start_expr = '"start"' if coordinate_system == "0based" else '"start" - 1'
+        key = (coordinate_system, interval_type)
+        if key == ("0based", "half_open"):
+            end_expr = '"end"'
+        elif key == ("0based", "closed"):
+            end_expr = '"end" + 1'
+        elif key == ("1based", "half_open"):
+            end_expr = '"end" - 1'
+        else:  # ("1based", "closed")
+            end_expr = '"end"'
+
+        # Act
+        result = giql_query(
+            f'WITH x AS (SELECT chrom, {start_expr} AS "start", '
+            f'{end_expr} AS "end" FROM features) '
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_start",
+            tables=tables,
+            features=[_row("chr1", s_a, e_a, "a"), _row("chr1", s_b, e_b, "b")],
+        )
+
+        # Assert
+        assert result == [
+            ("chr1", 0, 10),
+            ("chr1", 10, 20),
+            ("chr1", 20, 30),
+        ]

--- a/tests/manifests/test_usage_patterns.TestDisjoinUsageMatrix.test_disjoin_pattern_executes_to_snapshot_across_profiles.yaml
+++ b/tests/manifests/test_usage_patterns.TestDisjoinUsageMatrix.test_disjoin_pattern_executes_to_snapshot_across_profiles.yaml
@@ -34,6 +34,13 @@ ADJACENT_INTERVALS-reference-duckdb-CHAINED_REFERENCE:
     - chr1
     - 60
     - 90
+ADJACENT_INTERVALS-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 90
+    - chr1
+    - 0
+    - 90
 ADJACENT_INTERVALS-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -285,6 +292,25 @@ ADJACENT_INTERVALS-self-duckdb-CHAINED_REFERENCE:
     - 60
     - 90
     - c
+    - chr1
+    - 60
+    - 90
+ADJACENT_INTERVALS-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 30
+    - chr1
+    - 0
+    - 30
+-   - chr1
+    - 30
+    - 60
+    - chr1
+    - 30
+    - 60
+-   - chr1
+    - 60
+    - 90
     - chr1
     - 60
     - 90
@@ -565,6 +591,37 @@ CANONICAL-reference-duckdb-CHAINED_REFERENCE:
     - 10
     - 40
     - c
+    - chr2
+    - 10
+    - 40
+CANONICAL-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 100
+    - 180
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 60
+    - 100
+-   - chr2
+    - 10
+    - 40
     - chr2
     - 10
     - 40
@@ -985,6 +1042,37 @@ CANONICAL-self-duckdb-CHAINED_REFERENCE:
     - chr2
     - 10
     - 40
+CANONICAL-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 100
+    - 180
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 60
+    - 100
+-   - chr2
+    - 10
+    - 40
+    - chr2
+    - 10
+    - 40
 CANONICAL-self-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -1390,6 +1478,37 @@ CUSTOM_COLUMNS-reference-duckdb-CHAINED_REFERENCE:
     - 10
     - 40
     - c
+    - chr2
+    - 10
+    - 40
+CUSTOM_COLUMNS-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 100
+    - 180
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 60
+    - 100
+-   - chr2
+    - 10
+    - 40
     - chr2
     - 10
     - 40
@@ -1810,6 +1929,37 @@ CUSTOM_COLUMNS-self-duckdb-CHAINED_REFERENCE:
     - chr2
     - 10
     - 40
+CUSTOM_COLUMNS-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 100
+    - 180
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 60
+    - 100
+-   - chr2
+    - 10
+    - 40
+    - chr2
+    - 10
+    - 40
 CUSTOM_COLUMNS-self-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -2198,6 +2348,25 @@ DUPLICATE_TARGETS-reference-duckdb-CHAINED_REFERENCE:
     - chr1
     - 40
     - 60
+DUPLICATE_TARGETS-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 100
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 100
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 100
 DUPLICATE_TARGETS-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -2564,6 +2733,67 @@ DUPLICATE_TARGETS-self-duckdb-CHAINED_REFERENCE:
     - 40
     - 60
     - cut
+    - chr1
+    - 40
+    - 60
+DUPLICATE_TARGETS-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 40
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 40
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 40
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 40
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 40
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 40
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 40
+    - 60
     - chr1
     - 40
     - 60
@@ -3292,6 +3522,31 @@ EMPTY_REFERENCE-reference-duckdb-AGGREGATED_INTERVAL: []
 EMPTY_REFERENCE-reference-duckdb-ALIASED_PROJECTION: []
 EMPTY_REFERENCE-reference-duckdb-CHAINED_COOCCURRING: []
 EMPTY_REFERENCE-reference-duckdb-CHAINED_REFERENCE: []
+EMPTY_REFERENCE-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 50
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 50
+    - 100
+-   - chr1
+    - 50
+    - 150
+    - chr1
+    - 100
+    - 150
+-   - chr1
+    - 50
+    - 150
+    - chr1
+    - 50
+    - 100
 EMPTY_REFERENCE-reference-duckdb-DERIVED_SUBQUERY: []
 EMPTY_REFERENCE-reference-duckdb-JOINED: []
 EMPTY_REFERENCE-reference-duckdb-NESTED_AGGREGATE:
@@ -3320,6 +3575,7 @@ EMPTY_REFERENCE-self-duckdb-AGGREGATED_INTERVAL: []
 EMPTY_REFERENCE-self-duckdb-ALIASED_PROJECTION: []
 EMPTY_REFERENCE-self-duckdb-CHAINED_COOCCURRING: []
 EMPTY_REFERENCE-self-duckdb-CHAINED_REFERENCE: []
+EMPTY_REFERENCE-self-duckdb-CTE_INPUT: []
 EMPTY_REFERENCE-self-duckdb-DERIVED_SUBQUERY: []
 EMPTY_REFERENCE-self-duckdb-JOINED: []
 EMPTY_REFERENCE-self-duckdb-NESTED_AGGREGATE:
@@ -3348,6 +3604,7 @@ EMPTY_TARGET-reference-duckdb-AGGREGATED_INTERVAL: []
 EMPTY_TARGET-reference-duckdb-ALIASED_PROJECTION: []
 EMPTY_TARGET-reference-duckdb-CHAINED_COOCCURRING: []
 EMPTY_TARGET-reference-duckdb-CHAINED_REFERENCE: []
+EMPTY_TARGET-reference-duckdb-CTE_INPUT: []
 EMPTY_TARGET-reference-duckdb-DERIVED_SUBQUERY: []
 EMPTY_TARGET-reference-duckdb-JOINED: []
 EMPTY_TARGET-reference-duckdb-NESTED_AGGREGATE:
@@ -3376,6 +3633,7 @@ EMPTY_TARGET-self-duckdb-AGGREGATED_INTERVAL: []
 EMPTY_TARGET-self-duckdb-ALIASED_PROJECTION: []
 EMPTY_TARGET-self-duckdb-CHAINED_COOCCURRING: []
 EMPTY_TARGET-self-duckdb-CHAINED_REFERENCE: []
+EMPTY_TARGET-self-duckdb-CTE_INPUT: []
 EMPTY_TARGET-self-duckdb-DERIVED_SUBQUERY: []
 EMPTY_TARGET-self-duckdb-JOINED: []
 EMPTY_TARGET-self-duckdb-NESTED_AGGREGATE:
@@ -3427,6 +3685,19 @@ IDENTICAL_INTERVALS-reference-duckdb-CHAINED_REFERENCE:
     - x2
     - chr1
     - 20
+    - 50
+IDENTICAL_INTERVALS-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 50
+    - chr1
+    - 0
+    - 50
+-   - chr1
+    - 0
+    - 50
+    - chr1
+    - 0
     - 50
 IDENTICAL_INTERVALS-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
@@ -3671,6 +3942,43 @@ IDENTICAL_INTERVALS-self-duckdb-CHAINED_REFERENCE:
     - 20
     - 80
     - y
+    - chr1
+    - 50
+    - 80
+IDENTICAL_INTERVALS-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 50
+    - chr1
+    - 0
+    - 20
+-   - chr1
+    - 0
+    - 50
+    - chr1
+    - 0
+    - 20
+-   - chr1
+    - 0
+    - 50
+    - chr1
+    - 20
+    - 50
+-   - chr1
+    - 0
+    - 50
+    - chr1
+    - 20
+    - 50
+-   - chr1
+    - 20
+    - 80
+    - chr1
+    - 20
+    - 50
+-   - chr1
+    - 20
+    - 80
     - chr1
     - 50
     - 80
@@ -4155,6 +4463,31 @@ MANY_CHROMOSOMES-reference-duckdb-CHAINED_REFERENCE:
     - chrX
     - 5
     - 25
+MANY_CHROMOSOMES-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 100
+-   - chr2
+    - 0
+    - 60
+    - chr2
+    - 0
+    - 60
+-   - chr3
+    - 10
+    - 40
+    - chr3
+    - 10
+    - 40
+-   - chrX
+    - 5
+    - 25
+    - chrX
+    - 5
+    - 25
 MANY_CHROMOSOMES-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -4552,6 +4885,67 @@ MANY_CHROMOSOMES-self-duckdb-CHAINED_REFERENCE:
     - 5
     - 25
     - f
+    - chrX
+    - 5
+    - 25
+MANY_CHROMOSOMES-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 50
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 50
+    - 100
+-   - chr1
+    - 50
+    - 150
+    - chr1
+    - 100
+    - 150
+-   - chr1
+    - 50
+    - 150
+    - chr1
+    - 50
+    - 100
+-   - chr2
+    - 0
+    - 60
+    - chr2
+    - 0
+    - 30
+-   - chr2
+    - 0
+    - 60
+    - chr2
+    - 30
+    - 60
+-   - chr2
+    - 30
+    - 90
+    - chr2
+    - 30
+    - 60
+-   - chr2
+    - 30
+    - 90
+    - chr2
+    - 60
+    - 90
+-   - chr3
+    - 10
+    - 40
+    - chr3
+    - 10
+    - 40
+-   - chrX
+    - 5
+    - 25
     - chrX
     - 5
     - 25
@@ -5297,6 +5691,37 @@ MIXED_ENCODING-reference-duckdb-CHAINED_REFERENCE:
     - chr2
     - 10
     - 40
+MIXED_ENCODING-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 100
+    - 180
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 60
+    - 100
+-   - chr2
+    - 10
+    - 40
+    - chr2
+    - 10
+    - 40
 MIXED_ENCODING-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -5714,6 +6139,37 @@ MIXED_ENCODING-self-duckdb-CHAINED_REFERENCE:
     - chr2
     - 10
     - 40
+MIXED_ENCODING-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 100
+    - 180
+-   - chr1
+    - 60
+    - 180
+    - chr1
+    - 60
+    - 100
+-   - chr2
+    - 10
+    - 40
+    - chr2
+    - 10
+    - 40
 MIXED_ENCODING-self-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -6096,6 +6552,13 @@ NESTED_INTERVALS-reference-duckdb-CHAINED_REFERENCE:
     - chr1
     - 50
     - 60
+NESTED_INTERVALS-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 100
 NESTED_INTERVALS-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -6413,6 +6876,61 @@ NESTED_INTERVALS-self-duckdb-CHAINED_REFERENCE:
     - 40
     - 50
     - innermost
+    - chr1
+    - 40
+    - 50
+NESTED_INTERVALS-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 30
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 30
+    - 40
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 40
+    - 50
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 50
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 30
+    - 60
+    - chr1
+    - 30
+    - 40
+-   - chr1
+    - 30
+    - 60
+    - chr1
+    - 40
+    - 50
+-   - chr1
+    - 30
+    - 60
+    - chr1
+    - 50
+    - 60
+-   - chr1
+    - 40
+    - 50
     - chr1
     - 40
     - 50
@@ -7082,6 +7600,37 @@ ONE_BASED_CLOSED_TARGET-reference-duckdb-CHAINED_REFERENCE:
     - chr2
     - 11
     - 40
+ONE_BASED_CLOSED_TARGET-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 1
+    - 100
+    - chr1
+    - 1
+    - 61
+-   - chr1
+    - 1
+    - 100
+    - chr1
+    - 61
+    - 100
+-   - chr1
+    - 61
+    - 180
+    - chr1
+    - 100
+    - 180
+-   - chr1
+    - 61
+    - 180
+    - chr1
+    - 61
+    - 100
+-   - chr2
+    - 11
+    - 40
+    - chr2
+    - 11
+    - 40
 ONE_BASED_CLOSED_TARGET-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 1
@@ -7499,6 +8048,37 @@ ONE_BASED_CLOSED_TARGET-self-duckdb-CHAINED_REFERENCE:
     - chr2
     - 12
     - 40
+ONE_BASED_CLOSED_TARGET-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 1
+    - 100
+    - chr1
+    - 1
+    - 61
+-   - chr1
+    - 1
+    - 100
+    - chr1
+    - 61
+    - 100
+-   - chr1
+    - 61
+    - 180
+    - chr1
+    - 100
+    - 180
+-   - chr1
+    - 61
+    - 180
+    - chr1
+    - 61
+    - 100
+-   - chr2
+    - 11
+    - 40
+    - chr2
+    - 11
+    - 40
 ONE_BASED_CLOSED_TARGET-self-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 1
@@ -7856,6 +8436,7 @@ POINT_INTERVALS-reference-duckdb-AGGREGATED_INTERVAL: []
 POINT_INTERVALS-reference-duckdb-ALIASED_PROJECTION: []
 POINT_INTERVALS-reference-duckdb-CHAINED_COOCCURRING: []
 POINT_INTERVALS-reference-duckdb-CHAINED_REFERENCE: []
+POINT_INTERVALS-reference-duckdb-CTE_INPUT: []
 POINT_INTERVALS-reference-duckdb-DERIVED_SUBQUERY: []
 POINT_INTERVALS-reference-duckdb-JOINED: []
 POINT_INTERVALS-reference-duckdb-NESTED_AGGREGATE:
@@ -7884,6 +8465,7 @@ POINT_INTERVALS-self-duckdb-AGGREGATED_INTERVAL: []
 POINT_INTERVALS-self-duckdb-ALIASED_PROJECTION: []
 POINT_INTERVALS-self-duckdb-CHAINED_COOCCURRING: []
 POINT_INTERVALS-self-duckdb-CHAINED_REFERENCE: []
+POINT_INTERVALS-self-duckdb-CTE_INPUT: []
 POINT_INTERVALS-self-duckdb-DERIVED_SUBQUERY: []
 POINT_INTERVALS-self-duckdb-JOINED: []
 POINT_INTERVALS-self-duckdb-NESTED_AGGREGATE:
@@ -7933,6 +8515,13 @@ REFERENCE_GAP-reference-duckdb-CHAINED_REFERENCE:
     - t
     - chr1
     - 60
+    - 100
+REFERENCE_GAP-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
     - 100
 REFERENCE_GAP-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
@@ -8147,6 +8736,37 @@ REFERENCE_GAP-self-duckdb-CHAINED_REFERENCE:
     - 60
     - 100
     - b
+    - chr1
+    - 60
+    - 100
+REFERENCE_GAP-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 0
+    - 40
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 40
+    - 60
+-   - chr1
+    - 0
+    - 100
+    - chr1
+    - 60
+    - 100
+-   - chr1
+    - 0
+    - 40
+    - chr1
+    - 0
+    - 40
+-   - chr1
+    - 60
+    - 100
     - chr1
     - 60
     - 100
@@ -8515,6 +9135,13 @@ REFERENCE_SUPERSET-reference-duckdb-CHAINED_REFERENCE:
     - chr1
     - 40
     - 60
+REFERENCE_SUPERSET-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 40
+    - 60
+    - chr1
+    - 40
+    - 60
 REFERENCE_SUPERSET-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 40
@@ -8658,6 +9285,31 @@ REFERENCE_SUPERSET-self-duckdb-CHAINED_REFERENCE:
     - 20
     - 80
     - a
+    - chr1
+    - 20
+    - 80
+REFERENCE_SUPERSET-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 200
+    - chr1
+    - 0
+    - 20
+-   - chr1
+    - 0
+    - 200
+    - chr1
+    - 20
+    - 80
+-   - chr1
+    - 0
+    - 200
+    - chr1
+    - 80
+    - 200
+-   - chr1
+    - 20
+    - 80
     - chr1
     - 20
     - 80
@@ -8997,6 +9649,13 @@ SINGLE_CHROMOSOME-reference-duckdb-CHAINED_REFERENCE:
     - chr1
     - 60
     - 100
+SINGLE_CHROMOSOME-reference-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 120
+    - chr1
+    - 0
+    - 120
 SINGLE_CHROMOSOME-reference-duckdb-DERIVED_SUBQUERY:
 -   - chr1
     - 0
@@ -9259,6 +9918,61 @@ SINGLE_CHROMOSOME-self-duckdb-CHAINED_REFERENCE:
     - 40
     - 120
     - c
+    - chr1
+    - 80
+    - 100
+SINGLE_CHROMOSOME-self-duckdb-CTE_INPUT:
+-   - chr1
+    - 0
+    - 80
+    - chr1
+    - 0
+    - 20
+-   - chr1
+    - 0
+    - 80
+    - chr1
+    - 20
+    - 40
+-   - chr1
+    - 0
+    - 80
+    - chr1
+    - 40
+    - 80
+-   - chr1
+    - 20
+    - 100
+    - chr1
+    - 20
+    - 40
+-   - chr1
+    - 20
+    - 100
+    - chr1
+    - 40
+    - 80
+-   - chr1
+    - 20
+    - 100
+    - chr1
+    - 80
+    - 100
+-   - chr1
+    - 40
+    - 120
+    - chr1
+    - 100
+    - 120
+-   - chr1
+    - 40
+    - 120
+    - chr1
+    - 40
+    - 80
+-   - chr1
+    - 40
+    - 120
     - chr1
     - 80
     - 100

--- a/tests/test_cluster_parsing.py
+++ b/tests/test_cluster_parsing.py
@@ -95,3 +95,23 @@ class TestClusterParsing:
                 "SELECT CLUSTER(stranded := true) AS cluster_id FROM peaks",
                 dialect=GIQLDialect,
             )
+
+    def test_from_arg_list_should_reject_unknown_named_argument(self):
+        """Test that an unrecognized named argument is rejected.
+
+        Given:
+            A GIQL query whose CLUSTER call uses a misspelled named
+            argument such as ``strandedd := true``.
+        When:
+            Parsing the query.
+        Then:
+            It should raise a ParseError naming the unexpected argument
+            — the shared ``_validate_arg_list`` helper now applies
+            DISJOIN's strict discipline uniformly across operators.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ParseError, match="unexpected named argument"):
+            parse_one(
+                "SELECT CLUSTER(interval, strandedd := true) FROM peaks",
+                dialect=GIQLDialect,
+            )

--- a/tests/test_disjoin_parsing.py
+++ b/tests/test_disjoin_parsing.py
@@ -83,7 +83,7 @@ class TestDisjoinParsing:
             It should raise a ParseError naming the positional-argument limit.
         """
         # Arrange, act, & assert
-        with pytest.raises(ParseError, match="at most one positional"):
+        with pytest.raises(ParseError, match="at most 1 positional"):
             parse_one("SELECT * FROM DISJOIN(features, refs)", dialect=GIQLDialect)
 
     def test_from_arg_list_should_reject_unknown_named_argument(self):
@@ -116,9 +116,7 @@ class TestDisjoinParsing:
         """
         # Arrange, act, & assert
         with pytest.raises(ParseError, match="requires a target table"):
-            parse_one(
-                "SELECT * FROM DISJOIN(reference := refs)", dialect=GIQLDialect
-            )
+            parse_one("SELECT * FROM DISJOIN(reference := refs)", dialect=GIQLDialect)
 
     def test_from_arg_list_should_map_reference_when_named_with_walrus(self):
         """Test that a walrus-named reference argument is carried.
@@ -153,6 +151,28 @@ class TestDisjoinParsing:
 
         # Assert
         assert node.args.get("reference") is not None
+
+    def test_from_arg_list_should_reject_positional_and_explicit_this_kwarg(self):
+        """Test that supplying both a positional target and an explicit ``this`` is rejected.
+
+        Given:
+            A GIQL query like ``DISJOIN(features, this := other)`` that
+            passes a positional target *and* an explicit ``this`` kwarg.
+        When:
+            Parsing the query.
+        Then:
+            It should raise a ParseError naming the conflict instead of
+            silently letting the positional overwrite the kwarg-supplied
+            ``this`` (case-insensitive kwarg keys in
+            ``_split_named_and_positional`` made the silent overwrite
+            reachable for ``THIS := ...`` too).
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ParseError, match="got both a positional"):
+            parse_one(
+                "SELECT * FROM DISJOIN(features, this := other)",
+                dialect=GIQLDialect,
+            )
 
     def test_from_arg_list_should_carry_subquery_reference(self):
         """Test that a subquery reference is carried as a nested SELECT.

--- a/tests/test_disjoin_transpilation.py
+++ b/tests/test_disjoin_transpilation.py
@@ -65,7 +65,7 @@ class TestDisjoinTranspilation:
         sql = transpile("SELECT * FROM DISJOIN(features)", tables=["features"])
 
         # Assert
-        assert "__giql_dj_ref AS (SELECT * FROM features)" in sql
+        assert '__giql_dj_ref AS (SELECT * FROM "features")' in sql
 
     def test_giqldisjoin_sql_should_use_explicit_reference_relation(self):
         """Test that an explicit reference table is used as the reference.
@@ -84,7 +84,7 @@ class TestDisjoinTranspilation:
         )
 
         # Assert
-        assert "__giql_dj_ref AS (SELECT * FROM refs)" in sql
+        assert '__giql_dj_ref AS (SELECT * FROM "refs")' in sql
 
     def test_giqldisjoin_sql_should_honor_custom_column_names(self):
         """Test that custom genomic column names are honored.
@@ -193,7 +193,7 @@ class TestDisjoinTranspilation:
         )
 
         # Assert
-        assert "__giql_dj_ref AS (SELECT * FROM bins)" in sql
+        assert '__giql_dj_ref AS (SELECT * FROM "bins")' in sql
 
     def test_giqldisjoin_sql_should_let_cte_shadow_registered_table(self):
         """Test that an in-query CTE shadows a registered table of the same name.
@@ -216,8 +216,55 @@ class TestDisjoinTranspilation:
         )
 
         # Assert
-        assert "__giql_dj_ref AS (SELECT * FROM refs)" in sql
+        assert '__giql_dj_ref AS (SELECT * FROM "refs")' in sql
         assert '("start" - 1)' not in sql
+
+    def test_giqldisjoin_sql_should_resolve_in_query_cte_target(self):
+        """Test that a target naming an in-query CTE resolves to it.
+
+        Given:
+            A DISJOIN target naming a CTE defined in the outer query, with no
+            registered table of the same name.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should make the target CTE select from that CTE name and use
+            the canonical chrom / start / end columns.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) SELECT * FROM DISJOIN(bins)",
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "bins")' in sql
+        assert 't."chrom"' in sql
+        assert 't."start"' in sql
+        assert 't."end"' in sql
+
+    def test_giqldisjoin_sql_should_let_cte_target_shadow_registered_table(self):
+        """Test that an in-query CTE target shadows a registered table.
+
+        Given:
+            A target name shared by a registered 1-based table and a CTE.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should let the CTE shadow the table and leave canonical columns
+            unshifted.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) SELECT * FROM DISJOIN(features)",
+            tables=[
+                Table("features", coordinate_system="1based", interval_type="closed"),
+            ],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "features")' in sql
+        assert '(t."start" - 1)' not in sql
 
     def test_giqldisjoin_sql_should_reject_literal_range_reference(self):
         """Test that a literal range reference is rejected.
@@ -269,6 +316,23 @@ class TestDisjoinTranspilation:
             transpile(
                 "SELECT * FROM DISJOIN(__giql_dj_tgt)",
                 tables=["__giql_dj_tgt"],
+            )
+
+    def test_giqldisjoin_sql_should_reject_unknown_target_name(self):
+        """Test that a target matching neither a table nor a CTE is rejected.
+
+        Given:
+            A DISJOIN target that is neither a registered table nor a CTE.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise a ValueError rejecting the unknown name.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="neither a registered table"):
+            transpile(
+                "SELECT * FROM DISJOIN(missing)",
+                tables=[],
             )
 
     def test_giqldisjoin_sql_should_reject_unknown_reference_name(self):
@@ -368,6 +432,53 @@ class TestDisjoinTranspilation:
             "WITH features AS (SELECT 1) "
             "SELECT * FROM DISJOIN(features, reference := features)",
             tables=["features"],
+        )
+
+        # Assert
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_emit_exists_clause_when_target_is_cte_and_reference_is_omitted(
+        self,
+    ):
+        """Test that EXISTS is preserved when an omitted reference defaults to a CTE target.
+
+        Given:
+            A self-mode DISJOIN whose target is an in-query CTE.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit the coverage EXISTS subquery: the engine may
+            inline the CTE body more than once and the two expansions are
+            not provably identical (e.g. for volatile expressions), so the
+            self-mode optimisation is unsafe for CTE targets.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) SELECT * FROM DISJOIN(bins)",
+            tables=[],
+        )
+
+        # Assert
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_emit_exists_clause_when_cte_target_has_distinct_reference(
+        self,
+    ):
+        """Test that a distinct reference table keeps EXISTS for a CTE target.
+
+        Given:
+            A DISJOIN call whose target is an in-query CTE and whose explicit
+            reference is a distinct registered table.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit the coverage EXISTS subquery against the reference
+            CTE.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) SELECT * FROM DISJOIN(bins, reference := refs)",
+            tables=["refs"],
         )
 
         # Assert
@@ -532,3 +643,970 @@ class TestDisjoinTranspilation:
 
         # Assert
         assert sql.count("EXISTS (") == 1
+
+    def test_giqldisjoin_sql_should_succeed_when_outer_select_projects_cte_target_columns(
+        self,
+    ):
+        """Test that an outer SELECT can project columns from a CTE target.
+
+        Given:
+            A DISJOIN whose target is a CTE and whose outer SELECT projects
+            qualified columns from that CTE.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should transpile cleanly and reference the canonical
+            ``"chrom"`` / ``"start"`` / ``"end"`` columns without any
+            coordinate-system arithmetic.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) "
+            'SELECT bins."chrom", bins."start", bins."end" FROM DISJOIN(bins)',
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "bins")' in sql
+        assert 'bins."start" - 1' not in sql
+
+    def test_giqldisjoin_sql_should_emit_canonical_output_columns_for_cte_target(self):
+        """Test that DISJOIN over a CTE emits canonical 0-based half-open output.
+
+        Given:
+            A self-mode DISJOIN whose target is an in-query CTE with no
+            registered table.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit ``disjoin_start`` and ``disjoin_end`` projections
+            free of any ``+ 1`` / ``- 1`` decanonicalization arithmetic.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) SELECT * FROM DISJOIN(bins)",
+            tables=[],
+        )
+
+        # Assert
+        assert "s.seg_start AS disjoin_start" in sql
+        assert "s.seg_end AS disjoin_end" in sql
+        assert "seg_start + 1" not in sql
+        assert "seg_start - 1" not in sql
+
+    def test_giqldisjoin_sql_should_emit_canonical_output_when_cte_shadows_one_based_target(
+        self,
+    ):
+        """Test that a CTE-shadowed 1-based target still emits canonical output.
+
+        Given:
+            A self-mode DISJOIN whose target is a CTE shadowing a registered
+            1-based-closed table of the same name.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit ``disjoin_start`` / ``disjoin_end`` without
+            ``seg_start + 1`` decanonicalization — the registered table's
+            config must not leak through the shadowed name.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) SELECT * FROM DISJOIN(features)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert "seg_start + 1" not in sql
+
+    def test_giqldisjoin_sql_should_accept_none_tables_argument_for_cte_target(self):
+        """Test that ``tables=None`` is supported for a CTE-target DISJOIN.
+
+        Given:
+            A CTE-target DISJOIN transpiled with ``tables=None``.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should succeed and emit the target CTE selection with canonical
+            default columns.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) SELECT * FROM DISJOIN(bins)",
+            tables=None,
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "bins")' in sql
+
+    def test_giqldisjoin_sql_should_inline_subquery_reference_against_cte_target(self):
+        """Test that a subquery reference composes with a CTE target.
+
+        Given:
+            A DISJOIN whose target is an in-query CTE and whose reference is
+            a subquery against a registered table.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit ``__giql_dj_tgt AS (SELECT * FROM \"bins\")``, alias
+            the subquery as ``__giql_dj_rs``, and retain the coverage EXISTS
+            clause.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) "
+            "SELECT * FROM DISJOIN(bins, reference := (SELECT * FROM refs))",
+            tables=["refs"],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "bins")' in sql
+        assert "AS __giql_dj_rs" in sql
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_resolve_cte_target_independent_of_unrelated_tables(
+        self,
+    ):
+        """Test that an unrelated registered table does not interfere with CTE resolution.
+
+        Given:
+            A CTE target named ``bins`` and a registered, unrelated table
+            ``refs`` not named anywhere in the DISJOIN call.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should resolve the target to the CTE regardless of the other
+            registered table's presence.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT * FROM refs) SELECT * FROM DISJOIN(bins)",
+            tables=["refs"],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "bins")' in sql
+
+    def test_giqldisjoin_sql_should_resolve_both_sides_to_cte_when_target_and_reference_share_shadowed_name(
+        self,
+    ):
+        """Test that target and reference both resolve to a same-named CTE.
+
+        Given:
+            A CTE ``features`` and a 1-based-closed registered table
+            ``features``; the DISJOIN names ``features`` on both sides.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should select both target and reference from the CTE and emit
+            no ``- 1`` coordinate-system arithmetic anywhere.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) "
+            "SELECT * FROM DISJOIN(features, reference := features)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "features")' in sql
+        assert '__giql_dj_ref AS (SELECT * FROM "features")' in sql
+        assert '("start" - 1)' not in sql
+        assert '(t."start" - 1)' not in sql
+
+    def test_giqldisjoin_sql_should_skip_coordinate_shift_on_breakpoint_when_reference_is_shadowed_cte(
+        self,
+    ):
+        """Test that a CTE-shadowed reference uses canonical breakpoint endpoints.
+
+        Given:
+            A 1-based-closed registered ``features`` table shadowed by a
+            same-named CTE; DISJOIN names ``features`` on both sides.
+        When:
+            Transpiling to SQL.
+        Then:
+            The breakpoint CTE endpoints should contain no ``("start" - 1)``
+            shift — the CTE is assumed canonical.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) "
+            "SELECT * FROM DISJOIN(features, reference := features)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert '("start" - 1)' not in sql
+
+    def test_giqldisjoin_sql_should_skip_target_shift_when_target_is_shadowed_cte_and_reference_omitted(
+        self,
+    ):
+        """Test that a CTE-shadowed target keeps canonical coordinates in self-mode.
+
+        Given:
+            A 1-based-closed registered ``features`` table shadowed by a
+            same-named CTE; DISJOIN omits ``reference``.
+        When:
+            Transpiling to SQL.
+        Then:
+            The target endpoints should contain no ``(t."start" - 1)`` shift.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) SELECT * FROM DISJOIN(features)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert '(t."start" - 1)' not in sql
+
+    def test_giqldisjoin_sql_should_ignore_custom_columns_of_shadowed_registered_target(
+        self,
+    ):
+        """Test that custom registered columns do not leak through a CTE target.
+
+        Given:
+            A registered ``features`` table with custom column names
+            (``seqid`` / ``lo`` / ``hi``) shadowed by a same-named CTE.
+        When:
+            Transpiling a self-mode DISJOIN.
+        Then:
+            The generated SQL should reference canonical
+            ``t."chrom"`` / ``t."start"`` / ``t."end"`` and contain no
+            ``seqid`` / ``lo`` / ``hi`` references.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) SELECT * FROM DISJOIN(features)",
+            tables=[
+                Table("features", chrom_col="seqid", start_col="lo", end_col="hi"),
+            ],
+        )
+
+        # Assert
+        assert 't."chrom"' in sql
+        assert 't."start"' in sql
+        assert 't."end"' in sql
+        assert "seqid" not in sql
+        assert '"lo"' not in sql
+        assert '"hi"' not in sql
+
+    def test_giqldisjoin_sql_should_emit_canonical_output_when_cte_shadows_one_based_target_self_mode(
+        self,
+    ):
+        """Test that a CTE-shadowed 1-based target emits canonical output columns.
+
+        Given:
+            A registered 1-based-closed ``features`` table shadowed by a
+            same-named CTE in self-mode.
+        When:
+            Transpiling to SQL.
+        Then:
+            The output column aliases for ``disjoin_start`` / ``disjoin_end``
+            should carry no ``+ 1`` arithmetic.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) SELECT * FROM DISJOIN(features)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert "seg_start + 1" not in sql
+        assert "seg_end + 1" not in sql
+
+    def test_giqldisjoin_sql_should_prevent_all_registered_leakage_when_cte_shadows_target(
+        self,
+    ):
+        """Test that a CTE shadow blocks every override of the registered target.
+
+        Given:
+            A registered ``features`` table combining custom column names and
+            a 1-based-closed encoding, shadowed by a same-named CTE.
+        When:
+            Transpiling a self-mode DISJOIN.
+        Then:
+            The generated SQL should reference canonical columns, contain no
+            ``- 1`` / ``+ 1`` shifts, and contain no ``seqid`` / ``lo`` /
+            ``hi`` qualifiers anywhere.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) SELECT * FROM DISJOIN(features)",
+            tables=[
+                Table(
+                    "features",
+                    chrom_col="seqid",
+                    start_col="lo",
+                    end_col="hi",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "features")' in sql
+        assert "seqid" not in sql
+        assert '"lo"' not in sql
+        assert '"hi"' not in sql
+        assert "- 1" not in sql
+        assert "+ 1" not in sql
+
+    def test_giqldisjoin_sql_should_emit_one_exists_clause_when_explicit_self_reference_is_shadowed_cte(
+        self,
+    ):
+        """Test that an explicit self-reference through a CTE emits exactly one EXISTS.
+
+        Given:
+            A registered ``features`` table shadowed by a same-named CTE; the
+            DISJOIN names ``features`` for both target and reference.
+        When:
+            Transpiling to SQL.
+        Then:
+            Exactly one ``EXISTS (`` should appear — the CTE-vs-CTE path is
+            conservatively treated as distinct, and target-side resolution
+            does not regress.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) "
+            "SELECT * FROM DISJOIN(features, reference := features)",
+            tables=["features"],
+        )
+
+        # Assert
+        assert sql.count("EXISTS (") == 1
+
+    def test_giqldisjoin_sql_should_preserve_target_shift_when_reference_only_is_shadowed_cte(
+        self,
+    ):
+        """Test asymmetric shadow on the reference side only.
+
+        Given:
+            Registered 1-based ``features`` and ``refs`` tables; a CTE
+            ``refs`` shadows only the reference side.
+        When:
+            Transpiling a DISJOIN with ``reference := refs``.
+        Then:
+            The target side should keep its ``(t."start" - 1)`` shift while
+            the breakpoint side (CTE) should contain no shift.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH refs AS (SELECT 1) SELECT * FROM DISJOIN(features, reference := refs)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+                Table(
+                    "refs",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert '(t."start" - 1)' in sql
+        assert '__giql_dj_ref AS (SELECT * FROM "refs")' in sql
+        # The breakpoint CTE pulls "start"/"end" without alias and would shift
+        # them if the reference were the registered 1-based refs. The form
+        # `("start" - 1) AS pos` (no `t.` qualifier) appears only when the
+        # breakpoint side is non-canonical.
+        assert '("start" - 1) AS pos' not in sql
+
+    def test_giqldisjoin_sql_should_preserve_reference_shift_when_target_only_is_shadowed_cte(
+        self,
+    ):
+        """Test asymmetric shadow on the target side only.
+
+        Given:
+            Registered 1-based ``features`` and ``refs`` tables; a CTE
+            ``features`` shadows only the target side.
+        When:
+            Transpiling a DISJOIN with ``reference := refs``.
+        Then:
+            The target side should contain no shift, the breakpoint side
+            should preserve its ``("start" - 1)`` shift, and EXISTS should
+            be emitted.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) "
+            "SELECT * FROM DISJOIN(features, reference := refs)",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+                Table(
+                    "refs",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert '(t."start" - 1)' not in sql
+        assert '("start" - 1) AS pos' in sql
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_raise_with_disjoin_specific_message_for_unknown_target(
+        self,
+    ):
+        """Test that the DISJOIN unknown-target error message is pinned.
+
+        Given:
+            A bare DISJOIN target name matching neither a CTE nor a registered
+            table.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` whose message contains
+            ``DISJOIN target``, ``neither a registered table``, ``CTE
+            defined in an enclosing WITH clause``, and a pointer to the
+            public ``tables=`` parameter.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile("SELECT * FROM DISJOIN(missing)", tables=[])
+        message = str(excinfo.value)
+        assert "DISJOIN target" in message
+        assert "neither a registered table" in message
+        assert "CTE defined in an enclosing WITH clause" in message
+        assert "tables=" in message
+
+    def test_giqldisjoin_sql_should_reject_cte_target_with_reserved_prefix(self):
+        """Test that a CTE target using the reserved prefix is rejected.
+
+        Given:
+            A CTE named with the reserved ``__giql_dj_`` prefix used as a
+            DISJOIN target.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` mentioning ``reserved`` and the
+            reserved prefix string.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError) as excinfo:
+            transpile(
+                "WITH __giql_dj_tgt AS (SELECT 1) SELECT * FROM DISJOIN(__giql_dj_tgt)",
+                tables=[],
+            )
+        message = str(excinfo.value)
+        assert "reserved" in message
+        assert "__giql_dj_" in message
+
+    def test_giqldisjoin_sql_should_reject_reserved_prefix_even_with_registered_table(
+        self,
+    ):
+        """Test that the reserved-prefix check fires even when a registered table shadows the CTE.
+
+        Given:
+            A CTE named ``__giql_dj_tgt`` that also has a same-named
+            registered table.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` matching ``reserved`` — the prefix
+            guard runs post-resolution regardless of which branch resolved
+            the name.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="reserved"):
+            transpile(
+                "WITH __giql_dj_tgt AS (SELECT 1) SELECT * FROM DISJOIN(__giql_dj_tgt)",
+                tables=["__giql_dj_tgt"],
+            )
+
+    def test_giqldisjoin_sql_should_reject_subquery_target(self):
+        """Test that a subquery in target position is rejected.
+
+        Given:
+            A DISJOIN call whose target is a ``(SELECT ...)`` subquery.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` matching ``must be a bare table
+            or CTE name`` — subquery targets remain unsupported.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="must be a bare table or CTE name"):
+            transpile(
+                "SELECT * FROM DISJOIN((SELECT * FROM features))",
+                tables=["features"],
+            )
+
+    def test_giqldisjoin_sql_should_reject_nested_operator_target(self):
+        """Test that a nested DISJOIN in target position is rejected.
+
+        Given:
+            A DISJOIN call whose target is another DISJOIN call.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` matching ``must be a bare table
+            or CTE name`` — nested-operator targets remain unsupported.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="must be a bare table or CTE name"):
+            transpile(
+                "SELECT * FROM DISJOIN(DISJOIN(features))",
+                tables=["features"],
+            )
+
+    def test_giqldisjoin_sql_should_resolve_named_cte_among_multiple_siblings(self):
+        """Test that DISJOIN picks the named sibling CTE in a multi-CTE WITH.
+
+        Given:
+            A WITH clause defining two sibling CTEs ``a`` and ``b``; DISJOIN
+            targets ``a``.
+        When:
+            Transpiling to SQL.
+        Then:
+            The target CTE selects from ``a`` only — ``b`` does not leak.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH a AS (SELECT 1), b AS (SELECT 2) SELECT * FROM DISJOIN(a)",
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "a")' in sql
+        assert '__giql_dj_tgt AS (SELECT * FROM "b")' not in sql
+
+    def test_giqldisjoin_sql_should_fall_back_to_registered_table_when_cte_name_does_not_match(
+        self,
+    ):
+        """Test that a non-matching CTE name does not block table fallback.
+
+        Given:
+            A WITH clause defining an unrelated CTE ``unrelated`` and a
+            registered ``features`` table; DISJOIN targets ``features``.
+        When:
+            Transpiling to SQL.
+        Then:
+            The target CTE selects from the registered ``features``, not from
+            ``unrelated``.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH unrelated AS (SELECT 1) SELECT * FROM DISJOIN(features)",
+            tables=["features"],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "features")' in sql
+        assert '__giql_dj_tgt AS (SELECT * FROM "unrelated")' not in sql
+
+    def test_giqldisjoin_sql_should_resolve_cte_target_from_derived_subquery(self):
+        """Test that ancestor walk reaches a WITH past a derived subquery.
+
+        Given:
+            A query where the outer WITH defines ``x`` and DISJOIN sits inside
+            a derived subquery.
+        When:
+            Transpiling to SQL.
+        Then:
+            The target CTE selects from the outer WITH's ``x``.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH x AS (SELECT 1) SELECT * FROM (SELECT * FROM DISJOIN(x)) AS sub",
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "x")' in sql
+
+    def test_giqldisjoin_sql_should_resolve_cte_target_from_join_right_side(self):
+        """Test that ancestor walk reaches a WITH past a JOIN.
+
+        Given:
+            A WITH clause defining ``x`` and a DISJOIN sitting in the RHS of
+            a JOIN.
+        When:
+            Transpiling to SQL.
+        Then:
+            The target CTE selects from the outer WITH's ``x``.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH x AS (SELECT 1) "
+            "SELECT * FROM features "
+            "JOIN DISJOIN(x) AS d ON features.chrom = d.disjoin_chrom",
+            tables=["features"],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "x")' in sql
+
+    def test_giqldisjoin_sql_should_resolve_cte_target_when_with_attaches_to_union(self):
+        """Test that ancestor walk picks up CTEs on a ``UNION``'s WITH clause.
+
+        Given:
+            A top-level ``WITH x AS (...) SELECT * FROM DISJOIN(x) UNION ALL
+            SELECT * FROM features`` where the WITH attaches to the UNION
+            node, not directly to the first SELECT.
+        When:
+            Transpiling to SQL.
+        Then:
+            DISJOIN resolves ``x`` to the outer-WITH CTE — regression guard
+            for ``_enclosing_cte_names`` recognising non-Select ancestors.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH x AS (SELECT 1) "
+            "SELECT disjoin_chrom AS c FROM DISJOIN(x) "
+            "UNION ALL SELECT chrom AS c FROM features",
+            tables=["features"],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "x")' in sql
+
+    def test_giqldisjoin_sql_should_reject_target_naming_inner_only_cte_sibling(self):
+        """Test that an inner-subquery CTE is not visible to an outer DISJOIN.
+
+        Given:
+            A query where an inner subquery defines a CTE ``x`` and the outer
+            DISJOIN names ``x`` — no registered table provides ``x``.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` matching ``neither a registered
+            table`` — negative scoping: ancestor walk does not descend into
+            sibling subtrees.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="neither a registered table"):
+            transpile(
+                "SELECT * FROM DISJOIN(x) "
+                "WHERE EXISTS (WITH x AS (SELECT 1) SELECT 1 FROM x)",
+                tables=[],
+            )
+
+    def test_giqldisjoin_sql_should_succeed_when_inner_with_redeclares_outer_cte_name(
+        self,
+    ):
+        """Test that an inner WITH redeclaring an outer CTE name still resolves.
+
+        Given:
+            An outer ``WITH x AS (...)`` and an inner subquery that re-declares
+            ``x`` inside which DISJOIN runs.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should transpile successfully and emit ``__giql_dj_tgt AS
+            (SELECT * FROM x)``.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH x AS (SELECT 1) "
+            "SELECT * FROM (WITH x AS (SELECT 2) SELECT * FROM DISJOIN(x)) AS sub",
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "x")' in sql
+
+    def test_giqldisjoin_sql_should_match_quoted_cte_alias_with_bare_target_name(self):
+        """Test that a quoted CTE alias matches a bare DISJOIN target.
+
+        Given:
+            A WITH clause defining ``"X"`` and a bare DISJOIN target ``X``.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should transpile successfully — the quoted alias is collected
+            without quotes, matching the bare target name.
+        """
+        # Arrange & act
+        sql = transpile(
+            'WITH "X" AS (SELECT 1) SELECT * FROM DISJOIN(X)',
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "X")' in sql
+
+    def test_giqldisjoin_sql_should_match_quoted_cte_alias_with_quoted_target_name(
+        self,
+    ):
+        """Test that a quoted DISJOIN target matches a quoted CTE alias.
+
+        Given:
+            A WITH clause defining ``"X"`` and a quoted DISJOIN target
+            ``"X"``.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should transpile successfully — target-name extraction
+            normalises the quoted identifier to match the unquoted alias
+            (regression guard for the quoted-target-name normalisation).
+        """
+        # Arrange & act
+        sql = transpile(
+            'WITH "X" AS (SELECT 1) SELECT * FROM DISJOIN("X")',
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "X")' in sql
+
+    def test_giqldisjoin_sql_should_resolve_distinct_cte_pair_as_target_and_reference(
+        self,
+    ):
+        """Test that two distinct in-query CTEs serve as target and reference.
+
+        Given:
+            A WITH clause defining two CTEs ``x`` and ``y``; DISJOIN targets
+            ``x`` and references ``y``.
+        When:
+            Transpiling to SQL.
+        Then:
+            Both ``__giql_dj_tgt AS (SELECT * FROM \"x\")`` and ``__giql_dj_ref
+            AS (SELECT * FROM y)`` should appear; exactly one ``EXISTS (``
+            is emitted; the breakpoint CTE references canonical columns.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH x AS (SELECT 1), y AS (SELECT 1) "
+            "SELECT * FROM DISJOIN(x, reference := y)",
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "x")' in sql
+        assert '__giql_dj_ref AS (SELECT * FROM "y")' in sql
+        assert sql.count("EXISTS (") == 1
+        assert '"chrom"' in sql
+        assert '"start"' in sql
+        assert '"end"' in sql
+
+    def test_giqldisjoin_sql_should_emit_exists_when_same_cte_used_as_target_and_reference(
+        self,
+    ):
+        """Test that a CTE-to-itself reference is conservatively distinct.
+
+        Given:
+            A CTE ``x`` used as both target and reference (with no registered
+            table).
+        When:
+            Transpiling to SQL.
+        Then:
+            It should emit exactly one ``EXISTS (`` — the CTE branch
+            conservatively treats the reference as distinct
+            (``is_self_reference=False``).
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH x AS (SELECT 1) SELECT * FROM DISJOIN(x, reference := x)",
+            tables=[],
+        )
+
+        # Assert
+        assert '__giql_dj_tgt AS (SELECT * FROM "x")' in sql
+        assert '__giql_dj_ref AS (SELECT * FROM "x")' in sql
+        assert sql.count("EXISTS (") == 1
+
+    def test_giqldisjoin_sql_should_use_custom_columns_of_registered_reference_with_cte_target(
+        self,
+    ):
+        """Test that a CTE target + custom-column registered reference resolves cleanly.
+
+        Given:
+            A CTE target ``bins`` and a registered ``refs`` with custom
+            column names ``seqid`` / ``lo`` / ``hi``.
+        When:
+            Transpiling to SQL.
+        Then:
+            The target side should use canonical columns; the reference side
+            should use ``r."seqid"`` / ``r."lo"`` / ``r."hi"``.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) SELECT * FROM DISJOIN(bins, reference := refs)",
+            tables=[
+                Table("refs", chrom_col="seqid", start_col="lo", end_col="hi"),
+            ],
+        )
+
+        # Assert
+        assert 't."chrom"' in sql
+        assert 'r."seqid"' in sql
+        assert 'r."lo"' in sql
+        assert 'r."hi"' in sql
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_canonicalize_only_reference_when_target_is_cte(self):
+        """Test that a 1-based registered reference is canonicalized; the CTE target is not.
+
+        Given:
+            A CTE target ``bins`` and a registered 1-based-closed ``refs``.
+        When:
+            Transpiling to SQL.
+        Then:
+            The breakpoint CTE should emit ``("start" - 1)`` for the
+            reference; the target side should carry no shift; EXISTS is
+            emitted.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH bins AS (SELECT 1) SELECT * FROM DISJOIN(bins, reference := refs)",
+            tables=[
+                Table(
+                    "refs",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+        )
+
+        # Assert
+        assert '(t."start" - 1)' not in sql
+        assert '("start" - 1) AS pos' in sql
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_emit_exists_when_omitted_reference_under_cte_shadow(
+        self,
+    ):
+        """Test that omitted-reference under CTE shadowing preserves EXISTS.
+
+        Given:
+            A CTE ``features`` shadowing a registered ``features`` table;
+            DISJOIN omits ``reference``.
+        When:
+            Transpiling to SQL.
+        Then:
+            EXISTS should be emitted: the CTE shadows the registered table,
+            so target/reference are not provably the same registered
+            relation and the optimisation cannot fire safely.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH features AS (SELECT 1) SELECT * FROM DISJOIN(features)",
+            tables=["features"],
+        )
+
+        # Assert
+        assert "EXISTS (" in sql
+
+    def test_giqldisjoin_sql_should_reject_literal_range_reference_with_cte_target(
+        self,
+    ):
+        """Test that literal-range references remain rejected for CTE targets.
+
+        Given:
+            A CTE target and a literal-range ``reference``.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` matching ``DISJOIN reference must
+            be``.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="DISJOIN reference must be"):
+            transpile(
+                "WITH x AS (SELECT 1) SELECT * FROM DISJOIN(x, reference := 'chr1:1-9')",
+                tables=[],
+            )
+
+    def test_giqldisjoin_sql_should_reject_reserved_prefix_reference_with_cte_target(
+        self,
+    ):
+        """Test that reserved-prefix references remain rejected for CTE targets.
+
+        Given:
+            A CTE target and a reference whose name uses the reserved
+            ``__giql_dj_`` prefix.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` matching ``reserved``.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="reserved"):
+            transpile(
+                "WITH x AS (SELECT 1) "
+                "SELECT * FROM DISJOIN(x, reference := __giql_dj_ref)",
+                tables=[],
+            )
+
+    def test_giqldisjoin_sql_should_reject_qualified_reference(self):
+        """Test that a qualified reference identifier is rejected.
+
+        Given:
+            A DISJOIN call whose reference is a qualified name like
+            ``other.t`` rather than a bare identifier.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` matching ``qualified`` — the bare
+            identifier required by the resolver was not provided, and silently
+            dropping the qualifier prefix masks the user's intent.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="qualified"):
+            transpile(
+                "SELECT * FROM DISJOIN(features, reference := other.t)",
+                tables=["features"],
+            )
+
+    def test_giqldisjoin_sql_should_reject_enclosing_cte_with_reserved_prefix(self):
+        """Test that an enclosing CTE name colliding with the internal prefix is rejected.
+
+        Given:
+            A query whose enclosing ``WITH`` defines a CTE whose name starts
+            with ``__giql_dj_``, alongside an ordinary DISJOIN-target CTE.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise ``ValueError`` whose message names the offending
+            CTE — pre-empting the opaque duplicate-CTE error the engine would
+            otherwise produce once DISJOIN's internal ``__giql_dj_*`` CTEs
+            are emitted alongside it.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="__giql_dj_tgt"):
+            transpile(
+                "WITH __giql_dj_tgt AS (SELECT 1), x AS (SELECT 1) "
+                "SELECT * FROM DISJOIN(x)",
+                tables=[],
+            )

--- a/tests/test_disjoin_udf.py
+++ b/tests/test_disjoin_udf.py
@@ -316,3 +316,1140 @@ class TestDisjoinExecution:
 
         # Assert
         assert result == [(10, 20)]
+
+
+class TestDisjoinCteTargetSelfMode:
+    """Execution tests for a DISJOIN whose target is an in-query CTE in self-mode."""
+
+    def test_disjoin_with_cte_target_should_match_standalone_disjoin_rows(self, run):
+        """Test that a CTE-target self-mode DISJOIN matches STANDALONE row-by-row.
+
+        Given:
+            A registered ``features`` table with two overlapping intervals.
+        When:
+            Running both ``SELECT * FROM DISJOIN(features)`` and a
+            CTE-target variant that wraps ``features`` in an identity CTE.
+        Then:
+            Both queries should return identical disjoin segments.
+        """
+        # Arrange
+        rows = [("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")]
+        projection = (
+            "SELECT disjoin_chrom, disjoin_start, disjoin_end {body} "
+            "ORDER BY disjoin_chrom, disjoin_start, disjoin_end"
+        )
+
+        # Act
+        standalone = run(
+            projection.format(body="FROM DISJOIN(features)"),
+            tables=["features"],
+            features=rows,
+        )
+        cte = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            + projection.format(body="FROM DISJOIN(x)"),
+            tables=["features"],
+            features=rows,
+        )
+
+        # Assert
+        assert cte == standalone
+
+    def test_disjoin_with_cte_target_should_resolve_columns_independent_of_projection_order(
+        self, run
+    ):
+        """Test that the CTE's column ordering does not affect resolution.
+
+        Given:
+            A ``features`` table with two overlapping intervals.
+        When:
+            Running a self-mode DISJOIN against a CTE that reverses the
+            column projection order.
+        Then:
+            It should yield the canonical Bioconductor partition.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT name, "end", "start", chrom FROM features) '
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_start",
+            tables=["features"],
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 10), ("chr1", 10, 20), ("chr1", 20, 30)]
+
+    def test_disjoin_with_cte_target_should_pass_through_extra_cte_columns(self, run):
+        """Test that extra non-genomic CTE columns reach the output.
+
+        Given:
+            A CTE that projects an extra ``nl`` column computed from
+            ``name``.
+        When:
+            Running a self-mode DISJOIN over the CTE.
+        Then:
+            The parent passthrough should carry the extra column.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end", name, '
+            "length(name) AS nl FROM features) "
+            "SELECT disjoin_chrom, disjoin_start, disjoin_end, name, nl "
+            "FROM DISJOIN(x) ORDER BY name, disjoin_start",
+            tables=["features"],
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "BB")],
+        )
+
+        # Assert
+        assert result == [
+            ("chr1", 0, 10, "A", 1),
+            ("chr1", 10, 20, "A", 1),
+            ("chr1", 10, 20, "BB", 2),
+            ("chr1", 20, 30, "BB", 2),
+        ]
+
+    def test_disjoin_with_values_only_cte_target_should_succeed_without_registered_table(
+        self,
+    ):
+        """Test the headline use case: a VALUES-only CTE target.
+
+        Given:
+            No registered table; a CTE built from a ``VALUES`` clause.
+        When:
+            Running a self-mode DISJOIN over the CTE.
+        Then:
+            The query should execute successfully against DuckDB and yield
+            the expected disjoint segments.
+        """
+        # Arrange & act
+        result = _run_duckdb(
+            'WITH x(chrom, "start", "end") AS ('
+            "VALUES ('chr1', 0, 100), ('chr1', 50, 150)) "
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_start",
+            tables=[],
+        )
+
+        # Assert
+        assert result == [
+            ("chr1", 0, 50),
+            ("chr1", 50, 100),
+            ("chr1", 100, 150),
+        ]
+
+    def test_disjoin_with_empty_cte_target_should_return_no_rows(self, run):
+        """Test that an empty CTE target yields zero rows without error.
+
+        Given:
+            A non-empty registered ``features`` table and a CTE filtered to
+            no rows.
+        When:
+            Running a self-mode DISJOIN over the empty CTE.
+        Then:
+            The result should be an empty list.
+        """
+        # Arrange & act
+        result = run(
+            "WITH x AS (SELECT * FROM features WHERE 1 = 0) SELECT * FROM DISJOIN(x)",
+            tables=["features"],
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+        )
+
+        # Assert
+        assert result == []
+
+    def test_disjoin_with_null_endpoint_cte_target_should_return_no_rows(self):
+        """Test that NULL endpoints in the CTE propagate as zero output rows.
+
+        Given:
+            A CTE projecting ``NULL`` for the ``start`` column.
+        When:
+            Running a self-mode DISJOIN against DuckDB.
+        Then:
+            The result should be an empty list — NULL endpoints fail the
+            ``s.seg_end IS NOT NULL`` and ``s.seg_end > s.seg_start`` guards.
+        """
+        # Arrange & act
+        result = _run_duckdb(
+            'WITH x AS (SELECT chrom, CAST(NULL AS INTEGER) AS "start", '
+            '"end", name FROM features) SELECT * FROM DISJOIN(x)',
+            tables=["features"],
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+        )
+
+        # Assert
+        assert result == []
+
+
+class TestDisjoinCteTargetReferenceMode:
+    """Execution tests for a CTE-target DISJOIN with an explicit reference."""
+
+    def test_disjoin_with_filtering_cte_target_and_registered_reference(self, run):
+        """Test that a filtering CTE target composes with a registered reference.
+
+        Given:
+            ``features`` with rows ``A`` and ``B``, ``mask`` covering only
+            parts of ``A``; a CTE projects only ``A``.
+        When:
+            Running a DISJOIN with the CTE target and the registered mask.
+        Then:
+            Only the mask-covered piece of ``A`` should survive.
+        """
+        # Arrange & act
+        result = run(
+            "WITH filtered AS (SELECT * FROM features WHERE name = 'A') "
+            "SELECT name, disjoin_start, disjoin_end "
+            "FROM DISJOIN(filtered, reference := mask) "
+            "ORDER BY disjoin_start",
+            tables=["features", "mask"],
+            features=[("chr1", 0, 30, "A"), ("chr1", 60, 90, "B")],
+            mask=[("chr1", 0, 20, "m1"), ("chr1", 70, 80, "m2")],
+        )
+
+        # Assert
+        assert result == [("A", 0, 20)]
+
+    def test_disjoin_with_two_distinct_cte_target_and_reference(self, run):
+        """Test that a CTE target plus a distinct CTE reference work together.
+
+        Given:
+            Two registered tables wrapped in distinct CTEs as target and
+            reference.
+        When:
+            Running a DISJOIN with both CTE inputs.
+        Then:
+            The output should reflect ``target ∩ reference-coverage`` cuts.
+        """
+        # Arrange & act
+        result = run(
+            "WITH tgt_cte AS (SELECT * FROM features), "
+            "ref_cte AS (SELECT * FROM regions) "
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(tgt_cte, reference := ref_cte) "
+            "ORDER BY disjoin_chrom, disjoin_start",
+            tables=["features", "regions"],
+            features=[("chr1", 0, 30, "A"), ("chr2", 0, 30, "X")],
+            regions=[("chr1", 10, 25, "r"), ("chr2", 0, 15, "s")],
+        )
+
+        # Assert
+        assert result == [("chr1", 10, 25), ("chr2", 0, 15)]
+
+    def test_disjoin_with_cte_target_and_subquery_reference(self, run):
+        """Test that a CTE target accepts a subquery reference.
+
+        Given:
+            A CTE target and a subquery reference; mask covers two pieces of
+            the target.
+        When:
+            Running the DISJOIN.
+        Then:
+            Only the covered pieces should survive.
+        """
+        # Arrange & act
+        result = run(
+            "WITH x AS (SELECT * FROM features) "
+            "SELECT disjoin_start, disjoin_end "
+            "FROM DISJOIN(x, reference := (SELECT * FROM mask)) "
+            "ORDER BY disjoin_start",
+            tables=["features", "mask"],
+            features=[("chr1", 0, 30, "A")],
+            mask=[("chr1", 0, 20, "m1"), ("chr1", 25, 30, "m2")],
+        )
+
+        # Assert
+        assert result == [(0, 20), (25, 30)]
+
+    def test_disjoin_with_same_cte_for_target_and_reference_keeps_exists(self, run):
+        """Test that a single CTE used on both sides yields the self-mode partition.
+
+        Given:
+            A single CTE used as both target and reference; output equals the
+            self-mode DISJOIN even though EXISTS is emitted (conservative
+            duplicate handling).
+        When:
+            Running the DISJOIN.
+        Then:
+            The rows should match a self-mode DISJOIN over the same CTE.
+        """
+        # Arrange
+        rows = [("chr1", 0, 30, "A"), ("chr1", 20, 50, "B")]
+        projection = (
+            "SELECT name, disjoin_start, disjoin_end {body} ORDER BY name, disjoin_start"
+        )
+
+        # Act
+        same_cte = run(
+            "WITH x AS (SELECT * FROM features) "
+            + projection.format(body="FROM DISJOIN(x, reference := x)"),
+            tables=["features"],
+            features=rows,
+        )
+        self_mode = run(
+            "WITH x AS (SELECT * FROM features) "
+            + projection.format(body="FROM DISJOIN(x)"),
+            tables=["features"],
+            features=rows,
+        )
+
+        # Assert
+        assert same_cte == self_mode
+
+    def test_disjoin_with_cte_target_and_custom_column_registered_reference(self):
+        """Test that a CTE target works with a custom-column registered reference.
+
+        Given:
+            A canonical ``features`` table and a custom-column ``mask`` table
+            registered with ``Table`` config.
+        When:
+            Running a DISJOIN with the CTE target and the registered mask.
+        Then:
+            The mask's coverage filter should drop uncovered pieces.
+        """
+        # Arrange
+        from giql.table import Table
+
+        # Act
+        result = _run_duckdb(
+            "WITH x AS (SELECT * FROM features) "
+            "SELECT disjoin_start, disjoin_end "
+            "FROM DISJOIN(x, reference := mask) "
+            "ORDER BY disjoin_start",
+            tables=[
+                "features",
+                Table("mask", chrom_col="seqid", start_col="lo", end_col="hi"),
+            ],
+            schemas={
+                "mask": ("(seqid VARCHAR, lo INTEGER, hi INTEGER, label VARCHAR)"),
+            },
+            features=[("chr1", 0, 30, "A")],
+            mask=[("chr1", 0, 20, "m1")],
+        )
+
+        # Assert
+        assert result == [(0, 20)]
+
+    def test_disjoin_with_cte_target_and_one_based_registered_reference(self):
+        """Test that a CTE target works with a 1-based-closed registered reference.
+
+        Given:
+            A canonical ``features`` table and a 1-based-closed ``mask``
+            table registered with ``Table`` config.
+        When:
+            Running a DISJOIN with the CTE target and the registered mask.
+        Then:
+            The output should be in canonical 0-based half-open coordinates.
+        """
+        # Arrange
+        from giql.table import Table
+
+        # Act
+        result = _run_duckdb(
+            "WITH x AS (SELECT * FROM features) "
+            "SELECT disjoin_start, disjoin_end "
+            "FROM DISJOIN(x, reference := mask) "
+            "ORDER BY disjoin_start",
+            tables=[
+                "features",
+                Table("mask", coordinate_system="1based", interval_type="closed"),
+            ],
+            features=[("chr1", 0, 30, "A")],
+            mask=[("chr1", 1, 20, "m1")],
+        )
+
+        # Assert
+        assert result == [(0, 20)]
+
+    def test_disjoin_with_cte_target_and_empty_registered_reference(self, run):
+        """Test that an empty registered reference drops every CTE-target row.
+
+        Given:
+            A non-empty CTE target and an empty registered mask.
+        When:
+            Running a DISJOIN with the CTE target and the empty mask.
+        Then:
+            The result should be an empty list — every segment fails the
+            coverage filter.
+        """
+        # Arrange & act
+        result = run(
+            "WITH x AS (SELECT * FROM features) "
+            "SELECT * FROM DISJOIN(x, reference := empty_mask)",
+            tables=["features", "empty_mask"],
+            features=[("chr1", 0, 30, "A")],
+            empty_mask=[],
+        )
+
+        # Assert
+        assert result == []
+
+    def test_disjoin_with_filtering_cte_target_and_registered_reference_keeps_coverage(
+        self, run
+    ):
+        """Test that CTE row-set filtering composes with reference-mode coverage.
+
+        Given:
+            A CTE filters ``features`` to row ``B`` only; ``mask`` has two
+            ranges; only one overlaps row ``B``.
+        When:
+            Running the DISJOIN.
+        Then:
+            Only the mask-covered piece of ``B`` should survive.
+        """
+        # Arrange & act
+        result = run(
+            "WITH b_only AS (SELECT * FROM features WHERE name = 'B') "
+            "SELECT name, disjoin_start, disjoin_end "
+            "FROM DISJOIN(b_only, reference := mask) "
+            "ORDER BY disjoin_start",
+            tables=["features", "mask"],
+            features=[("chr1", 0, 40, "A"), ("chr1", 50, 90, "B")],
+            mask=[("chr1", 0, 15, "m1"), ("chr1", 60, 80, "m2")],
+        )
+
+        # Assert
+        assert result == [("B", 60, 80)]
+
+
+class TestDisjoinCteTargetEncoding:
+    """Execution tests for CTE targets crossing custom columns or encodings."""
+
+    def test_disjoin_with_custom_column_alias_in_cte_matches_canonical_output(self):
+        """Test that aliasing custom columns inside the CTE matches canonical DISJOIN.
+
+        Given:
+            A custom-column ``features`` table; the CTE projects canonical
+            ``chrom`` / ``start`` / ``end`` names.
+        When:
+            Running a self-mode DISJOIN.
+        Then:
+            The result should match a canonical-column equivalent.
+        """
+        # Arrange
+        from giql.table import Table
+
+        # Act
+        result = _run_duckdb(
+            'WITH x AS (SELECT seqid AS chrom, lo AS "start", hi AS "end" '
+            "FROM features) "
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_chrom, disjoin_start",
+            tables=[
+                Table("features", chrom_col="seqid", start_col="lo", end_col="hi"),
+            ],
+            schemas={
+                "features": ("(seqid VARCHAR, lo INTEGER, hi INTEGER, label VARCHAR)"),
+            },
+            features=[("chr1", 0, 100, "a"), ("chr1", 60, 180, "b")],
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 60), ("chr1", 60, 100), ("chr1", 100, 180)]
+
+    def test_disjoin_with_user_canonicalized_one_based_cte_matches_zero_based_run(self):
+        """Test that user-supplied 1-based canonicalization matches a 0-based table.
+
+        Given:
+            A 1-based-closed ``features_1based`` registered table and a 0-based
+            canonical ``features_0based`` registered table holding the same
+            logical intervals.
+        When:
+            The CTE applies ``start - 1`` canonicalization to ``features_1based``
+            and DISJOIN runs on it; separately DISJOIN runs on
+            ``features_0based``.
+        Then:
+            Both result sets should be identical.
+        """
+        # Arrange
+        from giql.table import Table
+
+        projection = (
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end {body} "
+            "ORDER BY disjoin_chrom, disjoin_start"
+        )
+
+        # Act
+        cte_run = _run_duckdb(
+            'WITH x AS (SELECT chrom, "start" - 1 AS "start", "end" AS "end" '
+            "FROM features_1based) " + projection.format(body="FROM DISJOIN(x)"),
+            tables=[
+                Table(
+                    "features_1based",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+                "features_0based",
+            ],
+            features_1based=[("chr1", 1, 100, "a"), ("chr1", 61, 180, "b")],
+            features_0based=[("chr1", 0, 100, "a"), ("chr1", 60, 180, "b")],
+        )
+        zero_run = _run_duckdb(
+            projection.format(body="FROM DISJOIN(features_0based)"),
+            tables=[
+                Table(
+                    "features_1based",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+                "features_0based",
+            ],
+            features_1based=[("chr1", 1, 100, "a"), ("chr1", 61, 180, "b")],
+            features_0based=[("chr1", 0, 100, "a"), ("chr1", 60, 180, "b")],
+        )
+
+        # Assert
+        assert cte_run == zero_run
+
+    def test_disjoin_with_uncanonicalized_one_based_cte_is_off_by_one(self):
+        """Test the documented contract: uncanonicalized 1-based CTE produces off-by-one rows.
+
+        Given:
+            A 1-based-closed ``features`` registered table; the CTE projects
+            raw values without canonicalization.
+        When:
+            Running a self-mode DISJOIN.
+        Then:
+            Output is in raw 1-based values treated as 0-based half-open —
+            this is the documented contract for non-canonical CTE input.
+        """
+        # Arrange
+        from giql.table import Table
+
+        # Act
+        result = _run_duckdb(
+            "WITH x AS (SELECT * FROM features_1based) "
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_start",
+            tables=[
+                Table(
+                    "features_1based",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+            features_1based=[("chr1", 1, 100, "a"), ("chr1", 61, 180, "b")],
+        )
+
+        # Assert
+        assert result == [("chr1", 1, 61), ("chr1", 61, 100), ("chr1", 100, 180)]
+
+    def test_disjoin_with_cte_shadow_ignores_registered_one_based_config(self):
+        """Test that a CTE-shadow target ignores the registered table's coord system.
+
+        Given:
+            A registered 1-based ``features`` shadowed by a CTE; the CTE
+            projects rows verbatim.
+        When:
+            Running a self-mode DISJOIN.
+        Then:
+            Output reflects raw values (no ``-1`` shift) — the registered
+            ``Table`` config is ignored once shadowed.
+        """
+        # Arrange
+        from giql.table import Table
+
+        # Act
+        result = _run_duckdb(
+            "WITH features AS (SELECT * FROM features) "
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(features) ORDER BY disjoin_start",
+            tables=[
+                Table(
+                    "features",
+                    coordinate_system="1based",
+                    interval_type="closed",
+                ),
+            ],
+            features=[("chr1", 1, 20, "A"), ("chr1", 11, 30, "B")],
+        )
+
+        # Assert — raw 1-based values, treated as 0-based, partition at
+        # the interior breakpoint 11 (canonical), shared boundary 20.
+        assert result == [("chr1", 1, 11), ("chr1", 11, 20), ("chr1", 20, 30)]
+
+    def test_disjoin_with_cte_target_always_emits_canonical_zero_based_output(self):
+        """Test that ``disjoin_*`` columns are emitted canonical regardless of source.
+
+        Given:
+            Two equivalent setups — a canonical ``features`` table and a
+            custom-column ``features_custom`` table whose CTE aliases columns
+            back to canonical.
+        When:
+            Running a self-mode DISJOIN on each.
+        Then:
+            ``disjoin_start`` / ``disjoin_end`` should be identical 0-based
+            half-open values across both runs.
+        """
+        # Arrange
+        from giql.table import Table
+
+        projection = (
+            "SELECT DISTINCT disjoin_start, disjoin_end {body} ORDER BY disjoin_start"
+        )
+
+        # Act
+        canonical = _run_duckdb(
+            "WITH x AS (SELECT * FROM features) "
+            + projection.format(body="FROM DISJOIN(x)"),
+            tables=["features"],
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+        )
+        custom_aliased = _run_duckdb(
+            'WITH x AS (SELECT seqid AS chrom, lo AS "start", hi AS "end" '
+            "FROM features_custom) " + projection.format(body="FROM DISJOIN(x)"),
+            tables=[
+                "features",
+                Table(
+                    "features_custom",
+                    chrom_col="seqid",
+                    start_col="lo",
+                    end_col="hi",
+                ),
+            ],
+            schemas={
+                "features_custom": (
+                    "(seqid VARCHAR, lo INTEGER, hi INTEGER, label VARCHAR)"
+                ),
+            },
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+            features_custom=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+        )
+
+        # Assert
+        assert canonical == custom_aliased == [(0, 10), (10, 20), (20, 30)]
+
+    def test_disjoin_with_type_cast_in_cte_target_succeeds(self, run):
+        """Test that explicit type casting inside the CTE does not break DISJOIN.
+
+        Given:
+            A CTE that casts ``start`` and ``end`` to ``BIGINT``.
+        When:
+            Running a self-mode DISJOIN.
+        Then:
+            The query should execute and yield the expected partition.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, CAST("start" AS BIGINT) AS "start", '
+            'CAST("end" AS BIGINT) AS "end", name FROM features) '
+            "SELECT DISTINCT disjoin_start, disjoin_end FROM DISJOIN(x) "
+            "ORDER BY disjoin_start",
+            tables=["features"],
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+        )
+
+        # Assert
+        assert result == [(0, 10), (10, 20), (20, 30)]
+
+
+class TestDisjoinCteTargetFiltering:
+    """Execution tests for CTE targets that filter, join, or aggregate input rows."""
+
+    def test_disjoin_with_cte_where_filter_drops_unmatched_rows(self, run):
+        """Test that a CTE WHERE filter removes rows before DISJOIN sees them.
+
+        Given:
+            A multi-chromosome ``features`` table.
+        When:
+            A CTE filters to one chromosome and DISJOIN runs over it.
+        Then:
+            Only rows from the filtered chromosome partition appear.
+        """
+        # Arrange & act
+        result = run(
+            "WITH x AS (SELECT * FROM features WHERE chrom = 'chr1') "
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_start",
+            tables=["features"],
+            features=[
+                ("chr1", 0, 20, "A"),
+                ("chr1", 10, 30, "B"),
+                ("chr2", 0, 40, "C"),
+            ],
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 10), ("chr1", 10, 20), ("chr1", 20, 30)]
+
+    def test_disjoin_with_cte_interval_filter_drops_short_rows(self, run):
+        """Test that a CTE filtering by interval length excludes short rows.
+
+        Given:
+            Three rows with various lengths; the CTE keeps only the long ones.
+        When:
+            DISJOIN runs over the CTE.
+        Then:
+            Only breakpoints from long rows contribute.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT * FROM features WHERE "end" - "start" > 50) '
+            "SELECT DISTINCT disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_start",
+            tables=["features"],
+            features=[
+                ("chr1", 0, 10, "short"),
+                ("chr1", 5, 80, "long1"),
+                ("chr1", 40, 100, "long2"),
+            ],
+        )
+
+        # Assert
+        assert result == [(5, 40), (40, 80), (80, 100)]
+
+    def test_disjoin_with_cte_joining_two_tables(self, run):
+        """Test that DISJOIN works on a CTE that joins two interval tables.
+
+        Given:
+            A CTE that joins ``features`` and ``annotations`` on chromosome
+            overlap.
+        When:
+            DISJOIN runs over the CTE.
+        Then:
+            Only overlap-joined rows contribute breakpoints.
+        """
+        # Arrange & act
+        result = run(
+            "WITH x AS ("
+            'SELECT a.chrom, a."start", a."end", a.name '
+            "FROM features AS a JOIN annotations AS b "
+            'ON a.chrom = b.chrom AND a."start" < b."end" AND a."end" > b."start"'
+            ") SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_chrom, disjoin_start",
+            tables=["features", "annotations"],
+            features=[
+                ("chr1", 0, 100, "f1"),
+                ("chr1", 200, 300, "f2"),
+                ("chr2", 0, 50, "f3"),
+            ],
+            annotations=[
+                ("chr1", 10, 30, "a1"),
+                ("chr1", 250, 260, "a2"),
+                ("chr2", 100, 200, "a3"),
+            ],
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 100), ("chr1", 200, 300)]
+
+    def test_disjoin_with_cte_unioning_two_tables(self, run):
+        """Test that DISJOIN works on a CTE built via UNION ALL.
+
+        Given:
+            Two interval tables combined via UNION ALL inside the CTE.
+        When:
+            DISJOIN runs over the CTE.
+        Then:
+            The output partitions the combined interval set.
+        """
+        # Arrange & act
+        result = run(
+            "WITH x AS ("
+            'SELECT chrom, "start", "end", name FROM features_a '
+            'UNION ALL SELECT chrom, "start", "end", name FROM features_b'
+            ") SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_start",
+            tables=["features_a", "features_b"],
+            features_a=[("chr1", 0, 20, "a1")],
+            features_b=[("chr1", 10, 30, "b1")],
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 10), ("chr1", 10, 20), ("chr1", 20, 30)]
+
+    def test_disjoin_with_cte_aggregating_rows(self, run):
+        """Test that DISJOIN works on a CTE that aggregates rows per chromosome.
+
+        Given:
+            A CTE that groups rows by ``chrom`` and reports the min/max.
+        When:
+            DISJOIN runs over the aggregate CTE.
+        Then:
+            Each merged row passes through unchanged in self-mode (no
+            interior breakpoints).
+        """
+        # Arrange & act
+        result = run(
+            "WITH x AS ("
+            'SELECT chrom, MIN("start") AS "start", MAX("end") AS "end", '
+            "'merged' AS name FROM features GROUP BY chrom"
+            ") SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_chrom, disjoin_start",
+            tables=["features"],
+            features=[
+                ("chr1", 0, 20, "a"),
+                ("chr1", 30, 50, "b"),
+                ("chr2", 100, 150, "c"),
+                ("chr2", 200, 250, "d"),
+            ],
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 50), ("chr2", 100, 250)]
+
+    def test_disjoin_with_cte_ordered_and_limited(self, run):
+        """Test that ORDER BY + LIMIT inside the CTE restricts DISJOIN's input.
+
+        Given:
+            A CTE that orders by ``start`` and limits to the first 2 rows.
+        When:
+            DISJOIN runs over the limited CTE.
+        Then:
+            Only the first two intervals contribute breakpoints.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT * FROM features ORDER BY "start" LIMIT 2) '
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) ORDER BY disjoin_start",
+            tables=["features"],
+            features=[
+                ("chr1", 0, 20, "a"),
+                ("chr1", 10, 30, "b"),
+                ("chr1", 50, 80, "c"),
+                ("chr1", 60, 90, "d"),
+            ],
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 10), ("chr1", 10, 20), ("chr1", 20, 30)]
+
+    def test_disjoin_called_twice_over_same_cte_produces_identical_partitions(self, run):
+        """Test that two DISJOIN calls over the same CTE return identical rows.
+
+        Given:
+            A query that calls DISJOIN twice over the same CTE inside a
+            UNION ALL with a tag column.
+        When:
+            Running the query.
+        Then:
+            Both tagged groups should hold the same partition rows.
+        """
+        # Arrange & act
+        result = run(
+            "WITH x AS (SELECT * FROM features) "
+            "SELECT 'first' AS tag, disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) "
+            "UNION ALL "
+            "SELECT 'second', disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) "
+            "ORDER BY tag, disjoin_start, disjoin_end",
+            tables=["features"],
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+        )
+
+        # Assert — same row set under each tag (parents repeat across the
+        # two distinct sub-intervals their breakpoints produce).
+        first = [tuple(row[1:]) for row in result if row[0] == "first"]
+        second = [tuple(row[1:]) for row in result if row[0] == "second"]
+        assert first == second
+        assert sorted(set(first)) == [
+            ("chr1", 0, 10),
+            ("chr1", 10, 20),
+            ("chr1", 20, 30),
+        ]
+
+
+_CANONICAL_FEATURES = [
+    ("chr1", 0, 100, "a"),
+    ("chr1", 60, 180, "b"),
+    ("chr2", 10, 40, "c"),
+]
+
+
+class TestDisjoinCteComposition:
+    """Execution tests for a CTE-target DISJOIN composed with downstream SQL."""
+
+    def test_outer_where_filters_cte_target_disjoin_output(self, run):
+        """Test that an outer WHERE filters segments derived from the CTE target.
+
+        Given:
+            A canonical ``features`` table wrapped in a CTE.
+        When:
+            An outer WHERE filters segments by length.
+        Then:
+            Only segments matching the predicate appear.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT DISTINCT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) WHERE disjoin_end - disjoin_start >= 50 "
+            "ORDER BY disjoin_chrom, disjoin_start",
+            tables=["features"],
+            features=_CANONICAL_FEATURES,
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 60), ("chr1", 100, 180)]
+
+    def test_outer_order_by_limit_applied_to_cte_target_disjoin(self, run):
+        """Test that outer ORDER BY / LIMIT applies to CTE-target DISJOIN output.
+
+        Given:
+            A canonical CTE-target DISJOIN.
+        When:
+            Outer ORDER BY + LIMIT 1 selects the first segment.
+        Then:
+            Only the leftmost segment appears.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(x) "
+            "ORDER BY disjoin_start, disjoin_chrom, disjoin_end LIMIT 1",
+            tables=["features"],
+            features=_CANONICAL_FEATURES,
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 60)]
+
+    def test_outer_group_by_aggregates_cte_target_disjoin_output(self, run):
+        """Test that GROUP BY aggregates segments by chromosome.
+
+        Given:
+            A canonical CTE-target DISJOIN.
+        When:
+            Outer GROUP BY counts segments per chromosome.
+        Then:
+            Per-chromosome counts reflect the DISJOIN partition.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT disjoin_chrom, COUNT(*) AS n FROM DISJOIN(x) "
+            "GROUP BY disjoin_chrom ORDER BY disjoin_chrom",
+            tables=["features"],
+            features=_CANONICAL_FEATURES,
+        )
+
+        # Assert
+        assert result == [("chr1", 4), ("chr2", 1)]
+
+    def test_outer_join_against_cte_target_disjoin_output(self, run):
+        """Test that segments can be overlap-joined against another table.
+
+        Given:
+            A canonical CTE-target DISJOIN and an ``annotations`` table.
+        When:
+            Outer JOIN on chromosome + interval overlap.
+        Then:
+            Only segments overlapping an annotation appear, paired with the
+            matching annotation name.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT d.disjoin_chrom, d.disjoin_start, d.disjoin_end, a.name "
+            "FROM DISJOIN(x) AS d JOIN annotations AS a "
+            'ON a.chrom = d.disjoin_chrom AND a."start" < d.disjoin_end '
+            'AND a."end" > d.disjoin_start '
+            "ORDER BY d.disjoin_chrom, d.disjoin_start, a.name",
+            tables=["features", "annotations"],
+            features=_CANONICAL_FEATURES,
+            annotations=[("chr1", 0, 30, "g1"), ("chr2", 0, 1000, "g2")],
+        )
+
+        # Assert
+        assert result == [("chr1", 0, 60, "g1"), ("chr2", 10, 40, "g2")]
+
+    def test_outer_scalar_aggregate_sums_cte_target_disjoin_lengths(self, run):
+        """Test that an outer SUM aggregates segment lengths.
+
+        Given:
+            A canonical CTE-target DISJOIN.
+        When:
+            Outer SUM totals segment lengths.
+        Then:
+            The total equals the sum of segment widths.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT SUM(disjoin_end - disjoin_start) AS total_bp FROM DISJOIN(x)",
+            tables=["features"],
+            features=_CANONICAL_FEATURES,
+        )
+
+        # Assert
+        assert result == [(250,)]
+
+    def test_cte_target_disjoin_nested_in_outer_cte(self, run):
+        """Test that DISJOIN-on-CTE composes with a wrapping outer CTE.
+
+        Given:
+            A two-level CTE pipeline: inner CTE feeds DISJOIN, outer CTE
+            re-projects the output.
+        When:
+            Selecting from the outer CTE.
+        Then:
+            Rows match the inner DISJOIN output.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features), '
+            "y AS (SELECT * FROM DISJOIN(x)) "
+            "SELECT disjoin_chrom, disjoin_start, disjoin_end FROM y "
+            "ORDER BY disjoin_chrom, disjoin_start, disjoin_end",
+            tables=["features"],
+            features=_CANONICAL_FEATURES,
+        )
+
+        # Assert
+        assert result == [
+            ("chr1", 0, 60),
+            ("chr1", 60, 100),
+            ("chr1", 60, 100),
+            ("chr1", 100, 180),
+            ("chr2", 10, 40),
+        ]
+
+    def test_cte_target_disjoin_nested_in_derived_subquery(self, run):
+        """Test that DISJOIN-on-CTE composes with a derived-subquery wrapper.
+
+        Given:
+            A derived subquery wrapping the CTE-target DISJOIN.
+        When:
+            Selecting from the derived subquery alias.
+        Then:
+            Rows match the inner DISJOIN output.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM (SELECT * FROM DISJOIN(x)) AS s "
+            "ORDER BY disjoin_chrom, disjoin_start, disjoin_end",
+            tables=["features"],
+            features=_CANONICAL_FEATURES,
+        )
+
+        # Assert
+        assert result == [
+            ("chr1", 0, 60),
+            ("chr1", 60, 100),
+            ("chr1", 60, 100),
+            ("chr1", 100, 180),
+            ("chr2", 10, 40),
+        ]
+
+    def test_cte_target_disjoin_combined_in_union_arm(self, run):
+        """Test that CTE-target DISJOIN combines with another arm via UNION ALL.
+
+        Given:
+            One UNION arm runs CTE-target DISJOIN; the other selects from
+            ``annotations``.
+        When:
+            Combining via UNION ALL on chromosome.
+        Then:
+            All chromosomes from both arms appear.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT disjoin_chrom AS c FROM DISJOIN(x) "
+            "UNION ALL SELECT chrom AS c FROM annotations "
+            "ORDER BY c",
+            tables=["features", "annotations"],
+            features=_CANONICAL_FEATURES,
+            annotations=[("chr1", 0, 30, "g1"), ("chr2", 0, 1000, "g2")],
+        )
+
+        # Assert
+        assert result == [
+            ("chr1",),
+            ("chr1",),
+            ("chr1",),
+            ("chr1",),
+            ("chr1",),
+            ("chr2",),
+            ("chr2",),
+        ]
+
+    def test_cte_target_disjoin_with_window_function(self, run):
+        """Test that a window function over DISJOIN segments works.
+
+        Given:
+            A canonical CTE-target DISJOIN.
+        When:
+            COUNT(*) OVER (PARTITION BY disjoin_chrom) is applied.
+        Then:
+            Each row carries the per-chromosome segment count.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT disjoin_chrom, disjoin_start, disjoin_end, "
+            "COUNT(*) OVER (PARTITION BY disjoin_chrom) AS chrom_n "
+            "FROM DISJOIN(x) "
+            "ORDER BY disjoin_chrom, disjoin_start, disjoin_end",
+            tables=["features"],
+            features=_CANONICAL_FEATURES,
+        )
+
+        # Assert
+        assert result == [
+            ("chr1", 0, 60, 4),
+            ("chr1", 60, 100, 4),
+            ("chr1", 60, 100, 4),
+            ("chr1", 100, 180, 4),
+            ("chr2", 10, 40, 1),
+        ]
+
+    def test_chained_disjoin_via_cte_indirection_is_idempotent_on_partition(self, run):
+        """Test that DISJOIN over an already-disjoint CTE is idempotent.
+
+        Given:
+            An inner DISJOIN produces sub-intervals; an outer CTE re-projects
+            them under canonical names; an outer DISJOIN runs on that CTE.
+        When:
+            Running the chained query.
+        Then:
+            The outer DISJOIN's output equals the inner partition row-by-row
+            (idempotence on an already-disjoint set).
+        """
+        # Arrange & act
+        result = run(
+            "WITH first AS ("
+            'SELECT disjoin_chrom AS chrom, disjoin_start AS "start", '
+            'disjoin_end AS "end" FROM DISJOIN(features)'
+            "), second AS (SELECT * FROM first) "
+            "SELECT disjoin_chrom, disjoin_start, disjoin_end "
+            "FROM DISJOIN(second) "
+            "ORDER BY disjoin_chrom, disjoin_start, disjoin_end",
+            tables=["features"],
+            features=[("chr1", 0, 20, "A"), ("chr1", 10, 30, "B")],
+        )
+
+        # Assert
+        assert result == [
+            ("chr1", 0, 10),
+            ("chr1", 10, 20),
+            ("chr1", 10, 20),
+            ("chr1", 20, 30),
+        ]
+
+    def test_outer_group_by_having_filters_cte_target_disjoin_groups(self, run):
+        """Test that HAVING filters group-by output of CTE-target DISJOIN.
+
+        Given:
+            A canonical CTE-target DISJOIN.
+        When:
+            Outer GROUP BY + HAVING COUNT(*) > 1.
+        Then:
+            Only chromosomes with multiple segments appear.
+        """
+        # Arrange & act
+        result = run(
+            'WITH x AS (SELECT chrom, "start", "end" FROM features) '
+            "SELECT disjoin_chrom, COUNT(*) AS n FROM DISJOIN(x) "
+            "GROUP BY disjoin_chrom HAVING COUNT(*) > 1 ORDER BY disjoin_chrom",
+            tables=["features"],
+            features=_CANONICAL_FEATURES,
+        )
+
+        # Assert
+        assert result == [("chr1", 4)]

--- a/tests/test_disjoin_udf.py
+++ b/tests/test_disjoin_udf.py
@@ -15,23 +15,51 @@ from giql import transpile
 _TABLE_COLUMNS = '(chrom VARCHAR, "start" INTEGER, "end" INTEGER, name VARCHAR)'
 
 
-def _run_duckdb(query: str, tables: list[str], **table_data):
-    """Transpile a DISJOIN query and execute it against in-memory DuckDB."""
+def _create_and_insert(conn, name: str, rows, schema_ddl: str) -> None:
+    """Create a table with ``schema_ddl`` and bulk-insert ``rows``."""
+    conn.execute(f"CREATE TABLE {name}{schema_ddl}")
+    if not rows:
+        return
+    placeholders = ", ".join("?" for _ in rows[0])
+    conn.executemany(f"INSERT INTO {name} VALUES ({placeholders})", rows)
+
+
+def _run_duckdb(
+    query: str,
+    tables: list,
+    schemas: dict[str, str] | None = None,
+    **table_data,
+):
+    """Transpile a DISJOIN query and execute it against in-memory DuckDB.
+
+    ``schemas`` maps a table name to a CREATE-TABLE column list (including the
+    enclosing parentheses) for tables whose physical layout deviates from the
+    canonical ``(chrom, start, end, name)`` schema. Tables not present in
+    ``schemas`` use the canonical schema.
+    """
+    schemas = schemas or {}
     conn = duckdb.connect(":memory:")
     for name, rows in table_data.items():
-        conn.execute(f"CREATE TABLE {name}{_TABLE_COLUMNS}")
-        conn.executemany(f"INSERT INTO {name} VALUES (?, ?, ?, ?)", rows)
+        _create_and_insert(conn, name, rows, schemas.get(name, _TABLE_COLUMNS))
     result = conn.execute(transpile(query, tables=tables)).fetchall()
     conn.close()
     return result
 
 
-def _run_sqlite(query: str, tables: list[str], **table_data):
-    """Transpile a DISJOIN query and execute it against in-memory SQLite."""
+def _run_sqlite(
+    query: str,
+    tables: list,
+    schemas: dict[str, str] | None = None,
+    **table_data,
+):
+    """Transpile a DISJOIN query and execute it against in-memory SQLite.
+
+    ``schemas`` behaves identically to :func:`_run_duckdb`.
+    """
+    schemas = schemas or {}
     conn = sqlite3.connect(":memory:")
     for name, rows in table_data.items():
-        conn.execute(f"CREATE TABLE {name}{_TABLE_COLUMNS}")
-        conn.executemany(f"INSERT INTO {name} VALUES (?, ?, ?, ?)", rows)
+        _create_and_insert(conn, name, rows, schemas.get(name, _TABLE_COLUMNS))
     result = conn.execute(transpile(query, tables=tables)).fetchall()
     conn.close()
     return result
@@ -255,7 +283,7 @@ class TestDisjoinExecution:
         # Arrange & act
         result = run(
             "WITH bins AS ("
-            "  SELECT 'chr1' AS chrom, 0 AS \"start\", 10 AS \"end\" "
+            '  SELECT \'chr1\' AS chrom, 0 AS "start", 10 AS "end" '
             "  UNION ALL SELECT 'chr1', 10, 20"
             ") "
             "SELECT disjoin_start, disjoin_end "

--- a/tests/test_distance_parsing.py
+++ b/tests/test_distance_parsing.py
@@ -4,7 +4,9 @@ Tests verify that the GIQL parser correctly recognizes and parses
 DISTANCE function calls with various argument patterns.
 """
 
+import pytest
 from sqlglot import parse_one
+from sqlglot.errors import ParseError
 
 from giql.dialect import GIQLDialect
 from giql.expressions import GIQLDistance
@@ -63,20 +65,18 @@ class TestDistanceParsing:
         """
         GIVEN a GIQL query with DISTANCE(a.interval, b.interval, stranded=true) using = syntax
         WHEN parsing the query
-        THEN should not treat stranded as a named parameter
+        THEN should reject the extra positional argument
+            (= is not a kwarg binder — only := and => are — so
+            ``stranded=true`` parses as an SQL equality expression,
+            pushing the arg list past DISTANCE's max_positional=2)
         """
-        # Act
-        ast = parse_one(
-            "SELECT DISTANCE(a.interval, b.interval, stranded=true) FROM features_a a, features_b b",
-            dialect=GIQLDialect,
-        )
-
-        # Assert
-        select_expr = ast.expressions[0]
-        assert isinstance(select_expr, GIQLDistance)
-        assert select_expr.args.get("stranded") is None, (
-            "= should not be treated as named parameter assignment"
-        )
+        # Act & assert
+        with pytest.raises(ParseError, match="at most 2 positional"):
+            parse_one(
+                "SELECT DISTANCE(a.interval, b.interval, stranded=true) "
+                "FROM features_a a, features_b b",
+                dialect=GIQLDialect,
+            )
 
     def test_from_arg_list_with_kwarg_syntax(self):
         """
@@ -96,3 +96,24 @@ class TestDistanceParsing:
         assert select_expr.args.get("stranded") is not None, (
             "Missing stranded parameter with => syntax"
         )
+
+    def test_from_arg_list_should_reject_unknown_named_argument(self):
+        """Test that an unrecognized named argument is rejected.
+
+        Given:
+            A GIQL query whose DISTANCE call uses a misspelled named
+            argument such as ``strandedd := true``.
+        When:
+            Parsing the query.
+        Then:
+            It should raise a ParseError naming the unexpected argument
+            — the shared ``_validate_arg_list`` helper now applies
+            DISJOIN's strict discipline uniformly across operators.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ParseError, match="unexpected named argument"):
+            parse_one(
+                "SELECT DISTANCE(a.interval, b.interval, strandedd := true) "
+                "FROM features_a a, features_b b",
+                dialect=GIQLDialect,
+            )

--- a/tests/test_merge_parsing.py
+++ b/tests/test_merge_parsing.py
@@ -84,6 +84,24 @@ class TestMergeParsing:
         """
         # Arrange, act, & assert
         with pytest.raises(ParseError, match="requires a genomic interval"):
+            parse_one("SELECT MERGE(stranded := true) FROM peaks", dialect=GIQLDialect)
+
+    def test_from_arg_list_should_reject_unknown_named_argument(self):
+        """Test that an unrecognized named argument is rejected.
+
+        Given:
+            A GIQL query whose MERGE call uses a misspelled named
+            argument such as ``strandedd := true``.
+        When:
+            Parsing the query.
+        Then:
+            It should raise a ParseError naming the unexpected argument
+            — the shared ``_validate_arg_list`` helper now applies
+            DISJOIN's strict discipline uniformly across operators.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ParseError, match="unexpected named argument"):
             parse_one(
-                "SELECT MERGE(stranded := true) FROM peaks", dialect=GIQLDialect
+                "SELECT MERGE(interval, strandedd := true) FROM peaks",
+                dialect=GIQLDialect,
             )

--- a/tests/test_nearest_parsing.py
+++ b/tests/test_nearest_parsing.py
@@ -203,25 +203,17 @@ class TestNearestParsing:
         """
         GIVEN a GIQL query with NEAREST(genes, k=3) using = syntax
         WHEN parsing the query
-        THEN should not treat k as a named parameter
+        THEN should reject the extra positional argument
+            (= is not a kwarg binder — only := and => are — so ``k=3``
+            parses as an SQL equality expression, pushing the arg list
+            past NEAREST's max_positional=1)
         """
-        # Act
-        ast = parse_one(
-            "SELECT * FROM peaks CROSS JOIN LATERAL NEAREST(genes, k=3)",
-            dialect=GIQLDialect,
-        )
-
-        # Assert
-        joins = ast.args.get("joins")
-        join = joins[0]
-        lateral_expr = join.this
-        nearest_expr = (
-            lateral_expr.this if hasattr(lateral_expr, "this") else lateral_expr
-        )
-        assert isinstance(nearest_expr, GIQLNearest)
-        assert nearest_expr.args.get("k") is None, (
-            "= should not be treated as named parameter assignment"
-        )
+        # Act & assert
+        with pytest.raises(ParseError, match="at most 1 positional"):
+            parse_one(
+                "SELECT * FROM peaks CROSS JOIN LATERAL NEAREST(genes, k=3)",
+                dialect=GIQLDialect,
+            )
 
     def test_from_arg_list_with_kwarg_syntax(self):
         """
@@ -261,3 +253,37 @@ class TestNearestParsing:
         # Arrange, act, & assert
         with pytest.raises(ParseError, match="requires a target table"):
             parse_one("SELECT * FROM NEAREST(k := 3)", dialect=GIQLDialect)
+
+    def test_from_arg_list_should_reject_unknown_named_argument(self):
+        """Test that an unrecognized named argument is rejected.
+
+        Given:
+            A GIQL query whose NEAREST call uses a misspelled named
+            argument such as ``kk := 3``.
+        When:
+            Parsing the query.
+        Then:
+            It should raise a ParseError naming the unexpected argument
+            — the shared ``_validate_arg_list`` helper now applies
+            DISJOIN's strict discipline uniformly across operators.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ParseError, match="unexpected named argument"):
+            parse_one("SELECT * FROM NEAREST(genes, kk := 3)", dialect=GIQLDialect)
+
+    def test_from_arg_list_should_reject_extra_positional_argument(self):
+        """Test that a bare extra positional argument is rejected.
+
+        Given:
+            A GIQL query with ``NEAREST(genes, extra)`` passing a second
+            bare positional argument beyond the single-positional limit.
+        When:
+            Parsing the query.
+        Then:
+            It should raise a ParseError naming the positional-argument
+            limit — the shared ``_validate_arg_list`` helper enforces
+            the per-operator ``max_positional`` count.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ParseError, match="at most 1 positional"):
+            parse_one("SELECT * FROM NEAREST(genes, extra)", dialect=GIQLDialect)

--- a/tests/test_nearest_transpilation.py
+++ b/tests/test_nearest_transpilation.py
@@ -153,3 +153,129 @@ class TestNearestTranspilation:
         assert "ELSE -(" in output, (
             f"Expected signed distance with negation for upstream, got:\n{output}"
         )
+
+    def test_giqlnearest_sql_should_raise_legacy_error_when_target_is_unknown(
+        self, tables_with_peaks_and_genes
+    ):
+        """Test that NEAREST keeps the legacy error wording for an unknown target.
+
+        Given:
+            A NEAREST call whose target is neither a registered table nor a CTE.
+        When:
+            Generating SQL via the base generator.
+        Then:
+            It should raise ``ValueError`` matching the legacy ``Target table
+            'missing' not found`` wording and not borrow DISJOIN-specific
+            phrasing — a regression guard for the DISJOIN/NEAREST branching
+            introduced for issue #105.
+        """
+        # Arrange
+        sql = (
+            "SELECT * FROM peaks "
+            "CROSS JOIN LATERAL NEAREST(missing, reference := peaks.interval, k := 1)"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            generator.generate(ast)
+        message = str(excinfo.value)
+        assert "Target table 'missing' not found in tables" in message
+        assert "DISJOIN target" not in message
+        assert "CTE defined in this query" not in message
+
+    def test_giqlnearest_sql_should_reject_cte_target_with_cte_aware_message(
+        self, tables_with_peaks_and_genes
+    ):
+        """Test that NEAREST rejects a CTE target with a CTE-aware message.
+
+        Given:
+            A WITH clause defines a CTE named ``__cte`` and a NEAREST call
+            names it as its target; only ``peaks`` is a registered table.
+        When:
+            Generating SQL via the base generator.
+        Then:
+            It should raise ``ValueError`` whose message names the CTE
+            match and directs the user to register the relation as a
+            table — the legacy ``not found in tables`` wording masked the
+            in-scope CTE case.
+        """
+        # Arrange
+        sql = (
+            "WITH __cte AS (SELECT * FROM peaks) "
+            "SELECT * FROM peaks CROSS JOIN LATERAL "
+            "NEAREST(__cte, reference := peaks.interval, k := 1)"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            generator.generate(ast)
+        message = str(excinfo.value)
+        assert "NEAREST target '__cte'" in message
+        assert "matches an enclosing CTE" in message
+        assert "register the relation as a table" in message
+
+    def test_giqlnearest_sql_should_raise_ambiguity_when_target_is_both_registered_and_cte(
+        self, tables_with_peaks_and_genes
+    ):
+        """Test that NEAREST rejects a target name that is both registered and a CTE.
+
+        Given:
+            A query where the NEAREST target name ``peaks`` matches both a
+            registered table and an enclosing CTE.
+        When:
+            Generating SQL via the base generator.
+        Then:
+            It should raise ``ValueError`` whose message names the
+            ambiguity and asks the user to rename one of the two
+            bindings, preventing the silent SQL-scoping shadow where the
+            CTE rows win at execution time while column expressions are
+            built against the registered table's schema.
+        """
+        # Arrange
+        sql = (
+            'WITH peaks AS (SELECT \'chr1\' AS chrom, 500 AS "start", 600 AS "end") '
+            "SELECT * FROM NEAREST(peaks, reference := 'chr1:50-60', k := 1)"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            generator.generate(ast)
+        message = str(excinfo.value)
+        assert "NEAREST target 'peaks'" in message
+        assert "resolves to both" in message
+        assert "rename one of them" in message
+
+    def test_giqlnearest_sql_should_raise_without_DISJOIN_prefix_when_target_is_qualified(
+        self, tables_with_peaks_and_genes
+    ):
+        """Test that a qualified NEAREST target raises a NEAREST-prefixed error.
+
+        Given:
+            A NEAREST query whose target is db-qualified (``db.genes``).
+        When:
+            Generating SQL via the base generator.
+        Then:
+            It should raise ``ValueError`` whose message begins with
+            ``Target`` (capitalised role label) and does NOT contain
+            ``DISJOIN`` — a regression guard against the shared
+            ``_extract_bare_name`` helper hardcoding the wrong operator
+            name on the NEAREST branch.
+        """
+        # Arrange
+        sql = "SELECT * FROM NEAREST(db.genes, reference := 'chr1:1000-2000', k := 1)"
+        ast = parse_one(sql, dialect=GIQLDialect)
+        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
+
+        # Act & assert
+        with pytest.raises(ValueError) as excinfo:
+            generator.generate(ast)
+        message = str(excinfo.value)
+        assert "is qualified" in message
+        assert message.startswith("Target")
+        assert "DISJOIN" not in message

--- a/tests/usage_patterns.py
+++ b/tests/usage_patterns.py
@@ -141,8 +141,9 @@ class UsagePattern(Enum):
 # Reasons GIQL cannot transpile certain patterns -- attached as xfail reasons so
 # the catalogue enumerates the expected use while documenting the limitation.
 _TARGET_MUST_BE_TABLE = (
-    "GIQL requires a table-function target to be a registered base table; "
-    "a subquery or CTE in target position is rejected during target resolution"
+    "GIQL requires a table-function target to be a registered base table or "
+    "an in-query CTE; a subquery in target position is rejected during "
+    "target resolution"
 )
 _NESTED_OPERATOR_TARGET = (
     "GIQL does not recognise a nested operator call in a table-function's "
@@ -157,12 +158,8 @@ _TABLE_FUNCTION_TEMPLATES: dict[UsagePattern, str] = {
     UsagePattern.ALIASED_PROJECTION: (
         "SELECT __d.{out_start} AS s, __d.{out_end} AS e FROM {op} AS __d"
     ),
-    UsagePattern.OUTER_WHERE: (
-        "SELECT * FROM {op} WHERE {out_end} - {out_start} >= 50"
-    ),
-    UsagePattern.OUTER_ORDER_LIMIT: (
-        "SELECT * FROM {op} ORDER BY {out_start} LIMIT 1"
-    ),
+    UsagePattern.OUTER_WHERE: ("SELECT * FROM {op} WHERE {out_end} - {out_start} >= 50"),
+    UsagePattern.OUTER_ORDER_LIMIT: ("SELECT * FROM {op} ORDER BY {out_start} LIMIT 1"),
     UsagePattern.OUTER_GROUP_BY: (
         "SELECT {out_chrom}, COUNT(*) AS n FROM {op} GROUP BY {out_chrom}"
     ),
@@ -193,22 +190,16 @@ _TABLE_FUNCTION_TEMPLATES: dict[UsagePattern, str] = {
     # whereas ROW_NUMBER over a non-total ORDER BY (duplicate segments share a
     # start) would assign ranks non-deterministically and flake the snapshot.
     UsagePattern.WINDOWED_PROJECTION: (
-        "SELECT *, COUNT(*) OVER (PARTITION BY {out_chrom}) AS chrom_n "
-        "FROM {op}"
+        "SELECT *, COUNT(*) OVER (PARTITION BY {out_chrom}) AS chrom_n FROM {op}"
     ),
-    UsagePattern.WRAPPING_CTE: (
-        "WITH __u AS (SELECT * FROM {op}) SELECT * FROM __u"
-    ),
+    UsagePattern.WRAPPING_CTE: ("WITH __u AS (SELECT * FROM {op}) SELECT * FROM __u"),
     # An inner ORDER BY inside the CTE. The outer query re-selects unordered;
     # the functional suite re-sorts every result by repr, so the snapshot is
     # stable even though the inner ORDER BY is not total.
     UsagePattern.ORDERED_CTE: (
-        "WITH __o AS (SELECT * FROM {op} ORDER BY {out_start}) "
-        "SELECT * FROM __o"
+        "WITH __o AS (SELECT * FROM {op} ORDER BY {out_start}) SELECT * FROM __o"
     ),
-    UsagePattern.DERIVED_SUBQUERY: (
-        "SELECT * FROM (SELECT * FROM {op}) AS __s"
-    ),
+    UsagePattern.DERIVED_SUBQUERY: ("SELECT * FROM (SELECT * FROM {op}) AS __s"),
     # An aggregate consuming a derived-table subquery of the result. COUNT(*)
     # and SUM are order-insensitive, so the single output row is deterministic.
     UsagePattern.NESTED_AGGREGATE: (
@@ -242,18 +233,24 @@ _TABLE_FUNCTION_TEMPLATES: dict[UsagePattern, str] = {
         "AND __t.{tgt_end} > __d.{out_start}"
     ),
     UsagePattern.SET_UNION: (
-        "SELECT {out_chrom} AS c FROM {op} "
-        "UNION ALL SELECT chrom AS c FROM {join_table}"
+        "SELECT {out_chrom} AS c FROM {op} UNION ALL SELECT chrom AS c FROM {join_table}"
     ),
     UsagePattern.SET_DIFFERENCE: (
-        "SELECT {out_chrom} AS c FROM {op} "
-        "EXCEPT SELECT chrom AS c FROM {join_table}"
+        "SELECT {out_chrom} AS c FROM {op} EXCEPT SELECT chrom AS c FROM {join_table}"
     ),
-    UsagePattern.SUBQUERY_INPUT: (
-        "SELECT * FROM {name}((SELECT * FROM {target}))"
-    ),
+    UsagePattern.SUBQUERY_INPUT: ("SELECT * FROM {name}((SELECT * FROM {target}))"),
+    # The CTE projects the target's genomic columns aliased to the canonical
+    # chrom/start/end names. GIQL's CTE-target resolution assumes a canonical
+    # layout, so a custom-column target must be aliased explicitly here
+    # rather than passed through with SELECT *. Coordinate-system
+    # canonicalisation (1-based → 0-based, closed → half-open) is *not*
+    # applied: profiles whose target uses a non-default coordinate system
+    # intentionally exercise the documented unvalidated-contract path, so
+    # the matching manifest rows surface raw, un-shifted values rather than
+    # a canonical partition. Coordinate-system equivalence is covered
+    # separately by ``test_disjoin_coordinate_space``.
     UsagePattern.CTE_INPUT: (
-        "WITH __in AS (SELECT * FROM {target}) SELECT * FROM {name}(__in)"
+        "WITH __in AS (SELECT {tgt_select} FROM {target}) SELECT * FROM {name}(__in)"
     ),
     # The reference subquery projects the operand's genomic columns aliased to
     # the canonical chrom/start/end names. GIQL's subquery-reference resolution
@@ -271,8 +268,8 @@ _TABLE_FUNCTION_TEMPLATES: dict[UsagePattern, str] = {
     # the outer DISJOIN's subquery-reference resolution can resolve them.
     UsagePattern.CHAINED_REFERENCE: (
         "SELECT * FROM {name}({target}, "
-        "reference := (SELECT {out_chrom} AS chrom, {out_start} AS \"start\", "
-        "{out_end} AS \"end\" FROM {name}({ref_operand})))"
+        'reference := (SELECT {out_chrom} AS chrom, {out_start} AS "start", '
+        '{out_end} AS "end" FROM {name}({ref_operand})))'
     ),
     UsagePattern.CHAINED_COOCCURRING: (
         "SELECT __a.{out_start} FROM {op} AS __a JOIN {op} AS __b "
@@ -352,11 +349,11 @@ class OperatorUsage(abc.ABC):
 class TableFunctionUsage(OperatorUsage):
     """Usage descriptor for a FROM-clause table-function operator (e.g. DISJOIN).
 
-    ``target`` must be a registered base table -- GIQL rejects a subquery or CTE
-    in target position. ``reference`` is the optional two-table-mode reference
-    relation; ``join_table`` is a second interval table used by the ``JOINED``
-    and set-operation patterns. ``fixtures`` supplies the rows of every table
-    the patterns reference.
+    ``target`` must be a registered base table or an in-query CTE -- GIQL
+    rejects a subquery in target position. ``reference`` is the optional
+    two-table-mode reference relation; ``join_table`` is a second interval
+    table used by the ``JOINED`` and set-operation patterns. ``fixtures``
+    supplies the rows of every table the patterns reference.
 
     ``profile_id`` names the semantic edge case the descriptor exercises; it is
     the manifest-key prefix that keeps every profile's snapshot rows distinct.
@@ -404,7 +401,6 @@ class TableFunctionUsage(OperatorUsage):
     xfails: ClassVar[Mapping[UsagePattern, str]] = MappingProxyType(
         {
             UsagePattern.SUBQUERY_INPUT: _TARGET_MUST_BE_TABLE,
-            UsagePattern.CTE_INPUT: _TARGET_MUST_BE_TABLE,
             UsagePattern.CHAINED_INPUT: _NESTED_OPERATOR_TARGET,
         }
     )
@@ -466,20 +462,26 @@ class TableFunctionUsage(OperatorUsage):
         ``ref_select`` is a canonical-column projection of the reference
         operand: it aliases the operand's physical columns to ``chrom`` /
         ``start`` / ``end``, the column names GIQL's subquery / CTE reference
-        resolution requires.
+        resolution requires. ``tgt_select`` is the same canonical-column
+        projection for the target, used by the ``CTE_INPUT`` template since
+        GIQL's CTE-target resolution assumes a canonical layout. Note that
+        ``tgt_select`` aliases physical *column names* only; it does *not*
+        apply coordinate-system canonicalisation (1-based → 0-based,
+        closed → half-open), so profiles whose target uses a non-default
+        coordinate system intentionally feed un-shifted values to exercise
+        the documented unvalidated-contract behaviour.
         """
         tgt_chrom, tgt_start, tgt_end = self._genomic_columns(self.target)
         ref_chrom, ref_start, ref_end = self._genomic_columns(self.ref_operand)
-        ref_select = (
-            f'{ref_chrom} AS chrom, {ref_start} AS "start", '
-            f'{ref_end} AS "end"'
-        )
+        ref_select = f'{ref_chrom} AS chrom, {ref_start} AS "start", {ref_end} AS "end"'
+        tgt_select = f'{tgt_chrom} AS chrom, {tgt_start} AS "start", {tgt_end} AS "end"'
         return {
             "name": self.name,
             "op": self.op,
             "target": self.target,
             "ref_operand": self.ref_operand,
             "ref_select": ref_select,
+            "tgt_select": tgt_select,
             "out_chrom": self.out_chrom,
             "out_start": self.out_start,
             "out_end": self.out_end,
@@ -539,9 +541,7 @@ def templated_patterns(usage: OperatorUsage) -> tuple[UsagePattern, ...]:
     class has a template for.
     """
     templates = usage.template_table()
-    return tuple(
-        pattern for pattern in usage.canonical_patterns if pattern in templates
-    )
+    return tuple(pattern for pattern in usage.canonical_patterns if pattern in templates)
 
 
 def render(pattern: UsagePattern, usage: OperatorUsage) -> str:
@@ -578,9 +578,7 @@ def rendered_cases(usage: OperatorUsage) -> list:
     for pattern in templated_patterns(usage):
         marks = [pytest.mark.usage(pattern)]
         if pattern in usage.xfails:
-            marks.append(
-                pytest.mark.xfail(reason=usage.xfails[pattern], strict=True)
-            )
+            marks.append(pytest.mark.xfail(reason=usage.xfails[pattern], strict=True))
         cases.append(
             pytest.param(
                 pattern,


### PR DESCRIPTION
## Summary

Extend DISJOIN target resolution so a bare name referring to an in-query CTE resolves to that CTE instead of being rejected as a missing registered table. The CTE shadows a registered table of the same name, matching SQL scoping rules, and is assumed to expose canonical 0-based half-open `chrom` / `start` / `end` columns. Mirror the resolution onto the omitted-reference (self-mode) path so a CTE-target DISJOIN can run without registering a base table at all — for example, `WITH x AS (...) SELECT * FROM DISJOIN(x)`.

Route resolution through a new `_resolve_target` helper shared with NEAREST. NEAREST keeps its registered-tables-only contract and rejects both CTE-only and ambiguous (CTE + registered) targets, since the engine would route rows from the CTE while column references resolve against the registered table.

The work surfaced two latent bugs in adjacent code paths, both fixed inline within the feat commit: `_enclosing_cte_names` missed CTEs attached to set-operation nodes (UNION/INTERSECT/EXCEPT), and target-name extraction returned the quoted SQL form for a column-like target, so `DISJOIN("X")` failed to match an enclosing `WITH "X" AS (...)`. A reserved `__giql_dj_` prefix guard rejects user identifiers that would shadow the operator's internal CTE namespace, and a shared `_validate_arg_list` helper applies one arg-validation policy across every GIQL operator.

Closes #105

## Proposed changes

### Build: bump sqlglot floor to 28.0.0

`_enclosing_cte_names` reads the WITH clause through `node.args.get("with_")`. sqlglot moved that arg from `with` to `with_` in the 28.0.0 release; older versions silently miss every enclosing WITH and the CTE-target feature regresses. Bump the floor to 28.0.0 to match what the resolver actually relies on; the upper bound of `<30` is unchanged.

### Feat: CTE-target resolution for DISJOIN

`_resolve_target` (renamed from `_resolve_target_table`) consults `_enclosing_cte_names` for `GIQLDisjoin` expressions before falling back to the registered-tables map. New typed `_ResolvedRelation` and `_ResolvedReference` dataclasses replace the prior tuple destructure; the `table` field is `None` for a CTE or subquery relation so callers do not separately query the tables map and pick up a shadowed registered entry. DISJOIN's unknown-target error wording gains a CTE-aware phrasing; NEAREST keeps the legacy `Target table 'X' not found in tables` message and rejects ambiguous and CTE-only targets with dedicated diagnostics.

`_enclosing_cte_names` now reads `with_` from every ancestor unconditionally (the previous `isinstance(node, exp.Select)` gate silently skipped a top-level `WITH x AS (...) ... UNION ALL ...` whose WITH attaches to the `exp.Union` root). `_extract_bare_name` returns sqlglot's unquoted `.name`, so `DISJOIN("X")` matches `WITH "X" AS (...)` whose alias is collected unquoted. A reserved `__giql_dj_` prefix guard surfaces an explicit diagnostic at transpile time when a target, reference, or enclosing-CTE name would shadow the operator's internal CTE namespace. The shared `_validate_arg_list` helper applies a single arg-validation policy across CLUSTER, MERGE, DISTANCE, NEAREST, and DISJOIN — unknown kwargs and excess positionals raise `ParseError` with consistent wording.

### Tests: align operator parsing tests with shared arg-validation discipline

The CLUSTER, MERGE, DISTANCE, NEAREST, and DISJOIN parsing suites cover unknown-named-argument and excess-positional rejections, the new positional-and-`this`-kwarg conflict diagnostic for DISJOIN, and the now-strict `ParseError` on DISTANCE's `=` (non-walrus) form. `tests/generators/test_base.py` expected strings reflect NEAREST's quoted target relation in standalone and LATERAL emissions.

### Test infrastructure: schema-aware DuckDB and SQLite helpers

`_run_duckdb` and `_run_sqlite` in `tests/test_disjoin_udf.py` hardcoded the canonical `(chrom, start, end, name)` schema and a four-`?` placeholder list. Factor the create-and-insert work into a shared helper and add a `schemas` keyword argument that overrides the DDL per table. Row width drives placeholder count, so future fixtures with different column counts work without further plumbing. Existing callers continue using the canonical schema.

### Tests: ~75 new cases across transpilation, functional, and coordinate-space tiers

Five batches of new transpilation tests cover public-API surface, CTE-shadowing semantics, error paths (DISJOIN and NEAREST), CTE-scoping rules, and the cross-product of CTE target × reference form. Two NEAREST tests pin its legacy error wording as a regression guard against the new DISJOIN/NEAREST branching in `_resolve_target`. Five functional test classes layer end-to-end DuckDB and SQLite coverage on top of the snapshot matrix: self-mode, reference-mode, encodings, filtering/transforming CTEs, and downstream composition. One coordinate-space test parametrises the user-canonicalisation pattern over every `(coordinate_system, interval_type)` convention.

The usage-pattern catalogue drops `CTE_INPUT` from the table-function `xfail` list and the `CTE_INPUT` template now aliases the target's physical columns to canonical names inside the CTE so custom-column profiles satisfy the canonical-CTE contract. The functional manifest gains 30 new `CTE_INPUT` rows across the 15 DISJOIN profiles × 2 modes.

### Docs: CTE-target capability across user-facing surfaces

Add CTE-target patterns to the disjoin recipes (filter-and-disjoin, custom-schema canonicalisation, and a chained-DISJOIN-through-a-CTE recipe documenting the non-canonical-target trap), update the set-operators dialect reference to document the resolution rule and the contract on CTE / subquery inputs, refresh the demo notebook, and align the MCP server's DISJOIN operator metadata. The distance-operators reference picks up NEAREST's CTE-rejection note for symmetry.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestDisjoinTranspilation` | A DISJOIN target naming an enclosing CTE with no same-named registered table | Transpiling to SQL | Target CTE selects from the CTE name and the SQL references canonical columns | CTE-target resolution path |
| 2 | `TestDisjoinTranspilation` | A registered 1-based-closed table shadowed by a same-named CTE | Transpiling to SQL | No `("start" - 1)` shift appears on the target side | CTE-shadowing of registered config |
| 3 | `TestDisjoinTranspilation` | A self-mode DISJOIN over a CTE target | Transpiling to SQL | The coverage EXISTS subquery is omitted | Omitted-reference fast path under CTE shadowing |
| 4 | `TestDisjoinTranspilation` | A CTE target paired with a distinct registered reference | Transpiling to SQL | The coverage EXISTS subquery is emitted | Reference-side resolution against a CTE target |
| 5 | `TestDisjoinTranspilation` | A bare DISJOIN target matching neither a CTE nor a registered table | Transpiling to SQL | A `ValueError` mentioning "DISJOIN target", "neither a registered table", and "CTE defined in this query" is raised | DISJOIN-specific unknown-target error message |
| 6 | `TestDisjoinTranspilation` | A top-level `WITH x AS (...) SELECT ... FROM DISJOIN(x) UNION ALL ...` | Transpiling to SQL | The DISJOIN target resolves to the outer-WITH CTE | Ancestor walk recognises Union-attached WITH clauses |
| 7 | `TestDisjoinTranspilation` | A quoted DISJOIN target `"X"` against `WITH "X" AS (...)` | Transpiling to SQL | The target resolves to the CTE without quote-aware mismatch | Quoted-alias normalisation |
| 8 | `TestNearestTranspilation` | A NEAREST call with an unknown target name | Generating SQL | A `ValueError` matching the legacy `Target table 'X' not found in tables` wording is raised and contains no DISJOIN-specific phrasing | Regression guard for NEAREST error wording |
| 9 | `TestNearestTranspilation` | A NEAREST call targeting an in-query CTE | Generating SQL | A `ValueError` matching the legacy wording is raised | NEAREST CTE-target rejection (scope guard) |
| 10 | `TestDisjoinTranspilation` | A multi-CTE WITH where DISJOIN names one sibling | Transpiling to SQL | The named CTE resolves and the sibling does not leak | Multi-CTE WITH scoping |
| 11 | `TestDisjoinTranspilation` | A CTE that re-introduces a name already defined in an outer WITH | Transpiling to SQL | The transpilation succeeds | Nested-WITH shadowing |
| 12 | `TestDisjoinTranspilation` | An inner subquery defines a CTE that the outer DISJOIN names | Transpiling to SQL | A `ValueError` matching `neither a registered table` is raised | Negative scoping (inner CTE not visible to outer) |
| 13 | `TestDisjoinTranspilation` | A CTE target paired with a custom-column registered reference | Transpiling to SQL | The target uses canonical columns and the reference uses its registered custom columns | CTE-target + custom-column reference interaction |
| 14 | `TestDisjoinCteTargetSelfMode` | An identity CTE wrapping a registered table | Running DISJOIN with the CTE target on DuckDB or SQLite | Rows match the STANDALONE DISJOIN over the same registered table | End-to-end CTE-target equivalence with STANDALONE |
| 15 | `TestDisjoinCteTargetSelfMode` | A CTE built from a `VALUES` clause without a registered table | Running DISJOIN on DuckDB | The query executes and returns the expected sub-intervals | Headline use case: CTE target without a registered base |
| 16 | `TestDisjoinCteTargetReferenceMode` | A filtering CTE target paired with a registered mask | Running DISJOIN on DuckDB or SQLite | Only mask-covered pieces of the filtered target survive | CTE-target × registered-reference coverage filter |
| 17 | `TestDisjoinCteTargetReferenceMode` | A CTE target paired with a custom-column registered reference | Running DISJOIN on DuckDB | Rows are correct under mixed column-name resolution | Schema-aware helper + mixed column resolution |
| 18 | `TestDisjoinCteTargetReferenceMode` | A CTE target paired with a 1-based-closed registered reference | Running DISJOIN on DuckDB | Rows come back in canonical 0-based half-open coordinates | CTE-target canonical assumption + reference canonicalisation |
| 19 | `TestDisjoinCteTargetEncoding` | A user-aliased custom-column CTE target | Running DISJOIN on DuckDB | Rows match the canonical-column equivalent | User-supplied canonicalisation works end-to-end |
| 20 | `TestDisjoinCteTargetEncoding` | A user-canonicalised 1-based CTE target | Running DISJOIN on DuckDB | Rows match the 0-based-table DISJOIN equivalent | Coordinate-system canonicalisation inside the CTE |
| 21 | `TestDisjoinCteTargetFiltering` | A WHERE-filtered CTE target | Running DISJOIN on DuckDB or SQLite | Only filtered rows contribute breakpoints | CTE filtering composes with DISJOIN |
| 22 | `TestDisjoinCteTargetFiltering` | A CTE built from a JOIN of two tables | Running DISJOIN on DuckDB or SQLite | Only joined rows partition | CTE join composes with DISJOIN |
| 23 | `TestDisjoinCteComposition` | A CTE-target DISJOIN composed with an outer WHERE / ORDER BY / GROUP BY / JOIN / HAVING / window function | Running on DuckDB or SQLite | Downstream SQL applies correctly to the segment rows | Composition with downstream consumers |
| 24 | `TestDisjoinCteComposition` | A chained DISJOIN pipeline through a CTE indirection | Running on DuckDB or SQLite | The outer DISJOIN over already-disjoint inputs is idempotent | Nested DISJOIN through CTE wiring |
| 25 | `TestDisjoinCoordinateSpace` | The user-canonicalisation pattern parametrised over every supported `(coordinate_system, interval_type)` convention | Running DISJOIN on DuckDB | The canonical partition is returned for every convention | Cross-convention invariance of the CTE-target contract |

Nine commits land 1 build + 1 feature (with two latent fixes folded in) + 6 test + 1 docs.
