### PR TITLE
Build the ResolveOperatorRefs scaffolding for operator slot resolution — Closes #116

### DIFF
--- a/src/giql/expressions.py
+++ b/src/giql/expressions.py
@@ -1,10 +1,78 @@
 """Custom AST expression nodes for genomic operations.
 
 This module defines custom SQLGlot expression nodes for GIQL spatial operators.
+
+It also declares the per-operator :class:`SlotSpec` descriptors that the
+``ResolveOperatorRefs`` normalization pass (:mod:`giql.resolver`) consumes. Each
+operator class carries a ``GIQL_SLOTS`` tuple naming the slots the operator
+resolves (``this`` / ``reference`` / ``expression`` / ``ranges``) together with
+the AST shapes that slot accepts. Keeping the acceptance rules declarative on the
+expression class — rather than duplicated across resolver code — is the structural
+change epic #114 is built around.
 """
+
+from dataclasses import dataclass
+from typing import Literal
 
 from sqlglot import exp
 from sqlglot.errors import ParseError
+
+# The shapes an operator slot may accept. The first three form the
+# "registered table / CTE / subquery" trichotomy that ``sqlglot``'s scope
+# machinery distinguishes natively and that :class:`giql.resolver.ResolvedRef`
+# models; the remaining three describe the column / literal / implicit-outer
+# forms used by NEAREST, DISTANCE, and the spatial predicates.
+SlotShape = Literal[
+    "registered_table",
+    "cte",
+    "subquery",
+    "literal_range",
+    "column",
+    "implicit_outer",
+]
+
+# The subset of slot shapes that resolve to a table-shaped relation and are
+# therefore representable as a :class:`giql.resolver.ResolvedRef`. A slot whose
+# accepted shapes are a subset of these is a "reference slot" that the
+# ``ResolveOperatorRefs`` pass resolves and attaches metadata for.
+TABLE_SHAPES: frozenset[SlotShape] = frozenset({"registered_table", "cte", "subquery"})
+
+
+@dataclass(frozen=True, slots=True)
+class SlotSpec:
+    """Declarative description of one resolvable operator slot.
+
+    Parameters
+    ----------
+    arg : str
+        The :attr:`arg_types` key naming the slot on the operator expression
+        (e.g. ``"this"``, ``"reference"``, ``"expression"``, ``"ranges"``).
+    accepts : frozenset[SlotShape]
+        The AST shapes the slot accepts.
+    required : bool
+        Whether the slot must be present on a well-formed operator.
+    is_sequence : bool
+        Whether the slot holds a list of expressions (e.g. the ``ranges`` slot
+        of :class:`SpatialSetPredicate`) rather than a single expression.
+    """
+
+    arg: str
+    accepts: frozenset[SlotShape]
+    required: bool = False
+    is_sequence: bool = False
+
+    @property
+    def is_ref_slot(self) -> bool:
+        """Whether this slot resolves to a table-shaped :class:`ResolvedRef`.
+
+        A reference slot is one whose accepted shapes are all drawn from the
+        registered-table / CTE / subquery trichotomy. These are the slots for
+        which the ``ResolveOperatorRefs`` pass resolves and attaches a
+        :class:`giql.resolver.ResolvedRef`; column / literal / implicit
+        slots are declared but their resolution is deferred to later epic #114
+        migration steps.
+        """
+        return bool(self.accepts) and self.accepts <= TABLE_SHAPES
 
 
 class GenomicRange(exp.Expression):
@@ -37,7 +105,10 @@ class Intersects(SpatialPredicate):
     Example: column INTERSECTS 'chr1:1000-2000'
     """
 
-    pass
+    GIQL_SLOTS = (
+        SlotSpec("this", frozenset({"column"}), required=True),
+        SlotSpec("expression", frozenset({"literal_range", "column"}), required=True),
+    )
 
 
 class Contains(SpatialPredicate):
@@ -46,7 +117,10 @@ class Contains(SpatialPredicate):
     Example: column CONTAINS 'chr1:1500'
     """
 
-    pass
+    GIQL_SLOTS = (
+        SlotSpec("this", frozenset({"column"}), required=True),
+        SlotSpec("expression", frozenset({"literal_range", "column"}), required=True),
+    )
 
 
 class Within(SpatialPredicate):
@@ -55,7 +129,10 @@ class Within(SpatialPredicate):
     Example: column WITHIN 'chr1:1000-5000'
     """
 
-    pass
+    GIQL_SLOTS = (
+        SlotSpec("this", frozenset({"column"}), required=True),
+        SlotSpec("expression", frozenset({"literal_range", "column"}), required=True),
+    )
 
 
 class SpatialSetPredicate(exp.Expression):
@@ -72,6 +149,16 @@ class SpatialSetPredicate(exp.Expression):
         "quantifier": True,
         "ranges": True,
     }
+
+    GIQL_SLOTS = (
+        SlotSpec("this", frozenset({"column"}), required=True),
+        SlotSpec(
+            "ranges",
+            frozenset({"literal_range"}),
+            required=True,
+            is_sequence=True,
+        ),
+    )
 
 
 def _split_named_and_positional(args):
@@ -114,8 +201,7 @@ class GIQLCluster(exp.Func):
             kwargs["distance"] = positional_args[1]
         if "this" not in kwargs:
             raise ParseError(
-                "CLUSTER requires a genomic interval column as its first "
-                "argument."
+                "CLUSTER requires a genomic interval column as its first argument."
             )
         return cls(**kwargs)
 
@@ -147,8 +233,7 @@ class GIQLMerge(exp.Func):
             kwargs["distance"] = positional_args[1]
         if "this" not in kwargs:
             raise ParseError(
-                "MERGE requires a genomic interval column as its first "
-                "argument."
+                "MERGE requires a genomic interval column as its first argument."
             )
         return cls(**kwargs)
 
@@ -173,6 +258,11 @@ class GIQLDistance(exp.Func):
         "stranded": False,  # Optional: boolean for strand-specific distance
         "signed": False,  # Optional: boolean for directional distance
     }
+
+    GIQL_SLOTS = (
+        SlotSpec("this", frozenset({"column"}), required=True),
+        SlotSpec("expression", frozenset({"column"}), required=True),
+    )
 
     @classmethod
     def from_arg_list(cls, args):
@@ -206,15 +296,21 @@ class GIQLNearest(exp.Func):
         "signed": False,  # Optional: directional distance
     }
 
+    GIQL_SLOTS = (
+        SlotSpec("this", frozenset({"registered_table"}), required=True),
+        SlotSpec(
+            "reference",
+            frozenset({"literal_range", "column", "implicit_outer"}),
+        ),
+    )
+
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
         if len(positional_args) >= 1:
             kwargs["this"] = positional_args[0]
         if "this" not in kwargs:
-            raise ParseError(
-                "NEAREST requires a target table as its first argument."
-            )
+            raise ParseError("NEAREST requires a target table as its first argument.")
         return cls(**kwargs)
 
 
@@ -240,6 +336,14 @@ class GIQLDisjoin(exp.Func):
         "reference": False,  # Optional: reference table/CTE name or subquery
     }
 
+    GIQL_SLOTS = (
+        SlotSpec("this", frozenset({"registered_table"}), required=True),
+        SlotSpec(
+            "reference",
+            frozenset({"registered_table", "cte", "subquery"}),
+        ),
+    )
+
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
@@ -258,7 +362,5 @@ class GIQLDisjoin(exp.Func):
         if len(positional_args) >= 1:
             kwargs["this"] = positional_args[0]
         if "this" not in kwargs:
-            raise ParseError(
-                "DISJOIN requires a target table as its first argument."
-            )
+            raise ParseError("DISJOIN requires a target table as its first argument.")
         return cls(**kwargs)

--- a/src/giql/resolver.py
+++ b/src/giql/resolver.py
@@ -1,0 +1,449 @@
+"""Pass 1 of the GIQL normalization pipeline: ``ResolveOperatorRefs``.
+
+This module implements the first normalization pass described in epic #114. It
+runs between the transformer chain and the generator and attaches resolution
+metadata to every GIQL operator node so that later epic steps can turn the
+generator into a pure formatter.
+
+The pass is built on ``sqlglot``'s scope machinery
+(:func:`sqlglot.optimizer.scope.traverse_scope`), which yields scopes
+leaves-first so CTE and derived-table sources are registered before their
+consumers, and whose ``cte_sources`` natively distinguishes an in-query CTE from
+a registered table — exactly the registered-table / CTE / subquery trichotomy
+each operator reference slot must resolve against.
+
+For every GIQL operator node the pass resolves each declared *reference slot*
+(see :class:`giql.expressions.SlotSpec`) against the enclosing scope plus the
+registered :class:`giql.table.Tables` container and attaches a frozen
+:class:`ResolvedRef` to the node through a single namespaced
+``node.meta["giql"]`` key — ``sqlglot``'s established metadata channel, which is
+deep-copied by ``Expression.copy()`` so resolution survives tree copies. The
+pass closes with a validation boundary (:func:`validate_operator_refs`) that
+asserts every operator slot carries well-formed resolution metadata, mirroring
+``sqlglot``'s ``validate_qualify_columns`` and Spark's ``CheckAnalysis``.
+
+Scope note (epic #114, step 1)
+------------------------------
+This is *scaffolding*: it lands with **zero behavior change**. The generator
+still uses its existing resolver paths and ignores everything attached here. The
+resolution semantics computed for the table-shaped reference slots mirror the
+generator's existing ``_resolve_target_table`` / ``_resolve_disjoin_reference``
+/ ``_enclosing_cte_names`` behavior exactly.
+
+Two consequences of the zero-behavior-change constraint shape the
+implementation:
+
+* The pass never raises a *user-facing* diagnostic. When a slot cannot be
+  resolved (unregistered target, unknown reference name, reserved ``__giql_dj_``
+  prefix, unsupported reference shape) the pass simply leaves that slot
+  unresolved and the generator raises its existing error exactly as before.
+  Promoting these into GIQL-level diagnostics is a later epic step.
+* Only *reference slots* — slots whose accepted shapes are the table
+  trichotomy (DISJOIN ``this``/``reference`` and NEAREST ``this``) — are
+  resolved to a :class:`ResolvedRef` here. The column / literal /
+  implicit-outer slots of NEAREST, DISTANCE, and the spatial predicates are
+  declared on the expression classes but their resolution metadata type is
+  designed by the per-operator port issues (#118, #119, #120).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import replace
+from typing import Literal
+
+from sqlglot import exp
+from sqlglot.optimizer.scope import Scope
+from sqlglot.optimizer.scope import traverse_scope
+
+from giql.constants import DEFAULT_CHROM_COL
+from giql.constants import DEFAULT_END_COL
+from giql.constants import DEFAULT_START_COL
+from giql.expressions import Contains
+from giql.expressions import GIQLDisjoin
+from giql.expressions import GIQLDistance
+from giql.expressions import GIQLNearest
+from giql.expressions import Intersects
+from giql.expressions import SlotSpec
+from giql.expressions import SpatialSetPredicate
+from giql.expressions import Within
+from giql.table import Table
+from giql.table import Tables
+
+__all__ = [
+    "META_KEY",
+    "RefKind",
+    "ResolvedRef",
+    "OperatorResolution",
+    "ResolutionError",
+    "resolve_operator_refs",
+    "validate_operator_refs",
+]
+
+#: The single namespaced key under which resolution metadata is stored on a
+#: node's ``.meta`` mapping. All GIQL metadata lives under this one key so the
+#: channel stays a single, greppable namespace.
+META_KEY = "giql"
+
+#: The kinds a resolved reference slot can take — the registered-table / CTE /
+#: subquery trichotomy that ``sqlglot``'s ``scope.sources`` distinguishes.
+RefKind = Literal["registered_table", "cte", "subquery"]
+
+#: Canonical default genomic column names. A CTE or subquery reference is
+#: assumed (in the existing generator and here) to expose canonical
+#: ``chrom`` / ``start`` / ``end`` columns; validating that contract is a later
+#: epic step.
+_DEFAULT_COLS: tuple[str, str, str] = (
+    DEFAULT_CHROM_COL,
+    DEFAULT_START_COL,
+    DEFAULT_END_COL,
+)
+
+#: The GIQL operator expression classes the pass inspects.
+_OPERATORS: tuple[type[exp.Expression], ...] = (
+    GIQLDisjoin,
+    GIQLNearest,
+    GIQLDistance,
+    Intersects,
+    Contains,
+    Within,
+    SpatialSetPredicate,
+)
+
+
+class ResolutionError(Exception):
+    """Raised when attached resolution metadata is malformed.
+
+    This is an internal invariant check fired by :func:`validate_operator_refs`,
+    not a user-facing GIQL diagnostic. It indicates a bug in the resolver pass —
+    a slot carrying metadata that does not satisfy its declared
+    :class:`~giql.expressions.SlotSpec` — rather than an invalid user query.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedRef:
+    """Resolved metadata for one table-shaped operator reference slot.
+
+    Attributes
+    ----------
+    kind : RefKind
+        Whether the slot resolved to a registered table, an in-query CTE, or a
+        subquery.
+    name : str | None
+        The relation name for a registered-table or CTE reference; ``None`` for
+        an (anonymous) subquery reference.
+    cols : tuple[str, str, str]
+        The ``(chrom, start, end)`` physical column names. For a registered
+        table these come from its :class:`~giql.table.Table` config; for a CTE
+        or subquery they are the canonical defaults the relation is assumed to
+        expose.
+    table : Table | None
+        The :class:`~giql.table.Table` config backing a registered-table
+        reference (carrying its coordinate system); ``None`` for CTE and
+        subquery references, which are assumed canonical.
+    coverage_skippable : bool
+        Whether this reference is provably the same relation as the operator's
+        target set — i.e. a self-reference — which lets DISJOIN omit its
+        coverage ``EXISTS`` filter. Always ``False`` for non-reference (target)
+        slots.
+    """
+
+    kind: RefKind
+    name: str | None
+    cols: tuple[str, str, str]
+    table: Table | None
+    coverage_skippable: bool
+
+
+@dataclass(frozen=True, slots=True)
+class OperatorResolution:
+    """Resolution metadata attached to a single GIQL operator node.
+
+    Attributes
+    ----------
+    operator : str
+        The operator expression class name (e.g. ``"GIQLDisjoin"``).
+    slots : dict[str, ResolvedRef]
+        Mapping from a slot's :attr:`~giql.expressions.SlotSpec.arg` key to its
+        resolved :class:`ResolvedRef`. Only successfully resolved reference
+        slots appear; a slot left out was either not a reference slot or could
+        not be resolved (and the generator will raise its existing error).
+    """
+
+    operator: str
+    slots: dict[str, ResolvedRef]
+
+    def slot(self, arg: str) -> ResolvedRef | None:
+        """Return the resolved reference for slot *arg*, or ``None``."""
+        return self.slots.get(arg)
+
+
+def resolve_operator_refs(expression: exp.Expression, tables: Tables) -> exp.Expression:
+    """Attach resolution metadata to every GIQL operator in *expression*.
+
+    Walks the tree's scopes leaves-first, resolves each operator's declared
+    reference slots against the enclosing scope's visible CTEs plus *tables*,
+    attaches an :class:`OperatorResolution` under ``node.meta["giql"]``, and
+    closes with :func:`validate_operator_refs`.
+
+    The pass mutates and returns *expression* in place. It is behavior-
+    preserving: the attached metadata is additive and the generator ignores it.
+
+    Parameters
+    ----------
+    expression : exp.Expression
+        The (post-transformer) AST to annotate.
+    tables : Tables
+        The registered table configurations.
+
+    Returns
+    -------
+    exp.Expression
+        The same *expression*, with metadata attached.
+    """
+    seen: set[int] = set()
+
+    for scope in _safe_traverse_scope(expression):
+        cte_names = frozenset(scope.cte_sources)
+        for node in scope.walk():
+            if isinstance(node, _OPERATORS) and id(node) not in seen:
+                seen.add(id(node))
+                _resolve_operator(node, tables, cte_names)
+
+    # Fallback for any operator a scope walk did not reach (e.g. if scope
+    # construction failed). Resolving with no visible CTE names keeps the pass
+    # behavior-preserving: a missed CTE reference simply stays unresolved and
+    # the generator handles it on its existing path.
+    for node in expression.walk():
+        if isinstance(node, _OPERATORS) and id(node) not in seen:
+            seen.add(id(node))
+            _resolve_operator(node, tables, frozenset())
+
+    validate_operator_refs(expression)
+    return expression
+
+
+def _safe_traverse_scope(expression: exp.Expression) -> list[Scope]:
+    """Return the leaves-first scopes of *expression*, or ``[]`` on failure.
+
+    ``traverse_scope`` raises on a handful of exotic constructs. Swallowing the
+    failure keeps the pass behavior-preserving: the fallback walk in
+    :func:`resolve_operator_refs` still annotates every operator, just without
+    scoped CTE visibility.
+    """
+    try:
+        return traverse_scope(expression)
+    except Exception:
+        return []
+
+
+def _resolve_operator(
+    node: exp.Expression, tables: Tables, cte_names: frozenset[str]
+) -> None:
+    """Resolve *node*'s reference slots and attach an :class:`OperatorResolution`."""
+    slots: dict[str, ResolvedRef] = {}
+
+    if isinstance(node, GIQLDisjoin):
+        target_ref = _resolve_target(node.this, tables)
+        if target_ref is not None:
+            slots["this"] = target_ref
+            reference = node.args.get("reference")
+            ref = _resolve_disjoin_reference(reference, target_ref, cte_names, tables)
+            if ref is not None:
+                slots["reference"] = ref
+    elif isinstance(node, GIQLNearest):
+        target_ref = _resolve_target(node.this, tables)
+        if target_ref is not None:
+            slots["this"] = target_ref
+    # DISTANCE and the spatial predicates declare only column / literal slots,
+    # whose resolution metadata is designed by their port issues; the pass
+    # attaches an (empty-slot) resolution so every operator carries metadata.
+
+    node.meta[META_KEY] = OperatorResolution(type(node).__name__, slots)
+
+
+def _target_name(target: exp.Expression) -> str:
+    """Extract the target table name from an operator's ``this`` slot.
+
+    Mirrors ``BaseGIQLGenerator._resolve_target_table`` exactly.
+    """
+    if isinstance(target, exp.Table):
+        return target.name
+    if isinstance(target, exp.Column):
+        return target.table if target.table else str(target.this)
+    return str(target)
+
+
+def _resolve_target(target: exp.Expression, tables: Tables) -> ResolvedRef | None:
+    """Resolve a target (``this``) slot to a registered-table :class:`ResolvedRef`.
+
+    Returns ``None`` when the target is not a registered table, in which case the
+    generator raises its existing "not found in tables" error.
+    """
+    name = _target_name(target)
+    table = tables.get(name)
+    if table is None:
+        return None
+    return ResolvedRef(
+        kind="registered_table",
+        name=name,
+        cols=(table.chrom_col, table.start_col, table.end_col),
+        table=table,
+        coverage_skippable=False,
+    )
+
+
+def _resolve_disjoin_reference(
+    reference: exp.Expression | None,
+    target_ref: ResolvedRef,
+    cte_names: frozenset[str],
+    tables: Tables,
+) -> ResolvedRef | None:
+    """Resolve a DISJOIN ``reference`` slot.
+
+    Mirrors ``BaseGIQLGenerator._resolve_disjoin_reference`` exactly, with one
+    deliberate difference: CTE visibility comes from the operator's scope
+    (``scope.cte_sources``) rather than the hand-rolled ``_enclosing_cte_names``
+    ancestor walk, as epic #114 specifies. The two agree on every supported
+    shape; any divergence on exotic constructs is invisible in step 1 because
+    the generator ignores this metadata.
+
+    Returns ``None`` for the unresolvable shapes (reserved prefix, unknown
+    name, unsupported node type); the generator raises its existing error.
+    """
+    # No reference: default to the target set — a self-reference whose coverage
+    # EXISTS is provably always true.
+    if reference is None:
+        return replace(target_ref, coverage_skippable=True)
+
+    # Subquery reference: a distinct relation assumed to expose canonical
+    # default columns. Proving equivalence with the target is out of scope, so
+    # it is never a self-reference.
+    if isinstance(reference, (exp.Subquery, exp.Select, exp.Union)):
+        return ResolvedRef(
+            kind="subquery",
+            name=None,
+            cols=_DEFAULT_COLS,
+            table=None,
+            coverage_skippable=False,
+        )
+
+    # Anything that is not a bare table/CTE name is unsupported.
+    if not isinstance(reference, (exp.Table, exp.Column, exp.Identifier)):
+        return None
+
+    ref_name = reference.name
+
+    # The __giql_dj_ prefix names the operator's internal CTEs.
+    if ref_name.startswith("__giql_dj_"):
+        return None
+
+    # A CTE from an enclosing WITH shadows a registered table of the same name
+    # and is assumed to expose canonical default columns. A CTE may hold rows
+    # distinct from a same-named registered table, so it is never a
+    # self-reference.
+    if ref_name in cte_names:
+        return ResolvedRef(
+            kind="cte",
+            name=ref_name,
+            cols=_DEFAULT_COLS,
+            table=None,
+            coverage_skippable=False,
+        )
+
+    ref_table = tables.get(ref_name)
+    if ref_table is not None:
+        is_self = ref_name == target_ref.name and ref_table is target_ref.table
+        return ResolvedRef(
+            kind="registered_table",
+            name=ref_name,
+            cols=(ref_table.chrom_col, ref_table.start_col, ref_table.end_col),
+            table=ref_table,
+            coverage_skippable=is_self,
+        )
+
+    return None
+
+
+def validate_operator_refs(expression: exp.Expression) -> None:
+    """Assert every GIQL operator carries well-formed resolution metadata.
+
+    The closing validation boundary of pass 1, modeled on ``sqlglot``'s
+    ``validate_qualify_columns`` and Spark's ``CheckAnalysis``: a pure check
+    over the annotated tree. For each GIQL operator it asserts that the node
+    carries an :class:`OperatorResolution`, and that every reference slot which
+    *was* resolved carries a :class:`ResolvedRef` whose ``kind`` is permitted by
+    the slot's declared :class:`~giql.expressions.SlotSpec`.
+
+    Consistent with the step-1 zero-behavior-change constraint, an unresolved
+    reference slot is **not** an error here — that diagnostic is deferred to the
+    generator (and, in later epic steps, promoted to a GIQL-level message). This
+    function raises only :class:`ResolutionError`, signalling an internal bug in
+    the resolver rather than an invalid user query.
+
+    Parameters
+    ----------
+    expression : exp.Expression
+        The annotated AST to validate.
+
+    Raises
+    ------
+    ResolutionError
+        If an operator is missing its resolution metadata or a resolved slot is
+        malformed.
+    """
+    for node in expression.walk():
+        if not isinstance(node, _OPERATORS):
+            continue
+
+        resolution = node.meta.get(META_KEY)
+        if not isinstance(resolution, OperatorResolution):
+            raise ResolutionError(
+                f"{type(node).__name__} is missing resolution metadata; "
+                "the ResolveOperatorRefs pass did not annotate it."
+            )
+
+        specs: tuple[SlotSpec, ...] = getattr(node, "GIQL_SLOTS", ())
+        for spec in specs:
+            if not spec.is_ref_slot:
+                continue
+            ref = resolution.slots.get(spec.arg)
+            if ref is None:
+                # Deferred: unresolved reference slots are handled by the
+                # generator on its existing path in step 1.
+                continue
+            _validate_ref(ref, spec, type(node).__name__)
+
+
+def _validate_ref(ref: object, spec: SlotSpec, operator: str) -> None:
+    """Assert a single resolved reference is well-formed against its slot spec."""
+    if not isinstance(ref, ResolvedRef):
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} carries {type(ref).__name__}, "
+            "expected ResolvedRef."
+        )
+    if ref.kind not in spec.accepts:
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} resolved to kind {ref.kind!r}, "
+            f"which is not accepted by the slot (accepts {sorted(spec.accepts)})."
+        )
+    if not (
+        isinstance(ref.cols, tuple)
+        and len(ref.cols) == 3
+        and all(isinstance(col, str) for col in ref.cols)
+    ):
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} has malformed cols {ref.cols!r}; "
+            "expected a 3-tuple of column names."
+        )
+    if ref.kind == "registered_table" and ref.table is None:
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} resolved to a registered table but "
+            "carries no Table config."
+        )
+    if ref.kind in ("cte", "subquery") and ref.table is not None:
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} resolved to a {ref.kind} but carries "
+            "a Table config; CTE and subquery references are assumed canonical."
+        )

--- a/src/giql/transpile.py
+++ b/src/giql/transpile.py
@@ -13,6 +13,7 @@ from sqlglot import parse_one
 
 from giql.dialect import GIQLDialect
 from giql.generators import BaseGIQLGenerator
+from giql.resolver import resolve_operator_refs
 from giql.table import Table
 from giql.table import Tables
 from giql.transformer import ClusterTransformer
@@ -170,6 +171,13 @@ def transpile(
         ast = intersects_transformer.transform(ast)
         ast = merge_transformer.transform(ast)
         ast = cluster_transformer.transform(ast)
+
+    # Pass 1 of the normalization pipeline (epic #114): attach resolution
+    # metadata to every GIQL operator slot ahead of generation. Behavior-
+    # preserving in step 1 — the generator still uses its existing resolver
+    # paths and ignores this metadata.
+    with _reraise_as_value_error("Resolution error"):
+        ast = resolve_operator_refs(ast, tables_container)
 
     with _reraise_as_value_error("Transpilation error"):
         sql = generator.generate(ast)

--- a/tests/test_expressions.py
+++ b/tests/test_expressions.py
@@ -1,0 +1,111 @@
+"""Unit tests for the GIQL expression-node slot descriptors.
+
+Tests pin the declarative ``SlotSpec`` contract on the operator expression
+classes: which slots each operator declares and which of them are table-shaped
+reference slots that the ``ResolveOperatorRefs`` pass resolves.
+"""
+
+from giql.expressions import Contains
+from giql.expressions import GIQLDisjoin
+from giql.expressions import GIQLDistance
+from giql.expressions import GIQLNearest
+from giql.expressions import Intersects
+from giql.expressions import SlotSpec
+from giql.expressions import SpatialSetPredicate
+from giql.expressions import Within
+
+OPERATOR_CLASSES = (
+    GIQLDisjoin,
+    GIQLNearest,
+    GIQLDistance,
+    Intersects,
+    Contains,
+    Within,
+    SpatialSetPredicate,
+)
+
+
+class TestSlotSpec:
+    """Tests for the SlotSpec slot descriptor."""
+
+    def test_is_ref_slot_with_table_trichotomy_shapes(self):
+        """Test is_ref_slot for a slot accepting only table shapes.
+
+        Given:
+            A SlotSpec whose accepted shapes are the registered-table / CTE /
+            subquery trichotomy.
+        When:
+            Reading its is_ref_slot property.
+        Then:
+            It should be True.
+        """
+        # Arrange
+        spec = SlotSpec("reference", frozenset({"registered_table", "cte", "subquery"}))
+
+        # Act & assert
+        assert spec.is_ref_slot is True
+
+    def test_is_ref_slot_with_column_shape(self):
+        """Test is_ref_slot for a slot accepting a non-table shape.
+
+        Given:
+            A SlotSpec whose accepted shapes include a column reference.
+        When:
+            Reading its is_ref_slot property.
+        Then:
+            It should be False.
+        """
+        # Arrange
+        spec = SlotSpec("expression", frozenset({"literal_range", "column"}))
+
+        # Act & assert
+        assert spec.is_ref_slot is False
+
+    def test_is_ref_slot_with_empty_accepts(self):
+        """Test is_ref_slot for a slot accepting no shapes.
+
+        Given:
+            A SlotSpec with an empty accepted-shapes set.
+        When:
+            Reading its is_ref_slot property.
+        Then:
+            It should be False.
+        """
+        # Arrange
+        spec = SlotSpec("this", frozenset())
+
+        # Act & assert
+        assert spec.is_ref_slot is False
+
+    def test_giql_slots_declared_on_every_operator_class(self):
+        """Test the declarative slot contract across the operator classes.
+
+        Given:
+            The seven GIQL operator expression classes.
+        When:
+            Reading each class's GIQL_SLOTS declaration.
+        Then:
+            It should declare a tuple of SlotSpecs on every operator, with
+            exactly DISJOIN's this/reference and NEAREST's this as the
+            table-shaped reference slots.
+        """
+        # Arrange
+        expected_ref_slots = {
+            (GIQLDisjoin, "this"),
+            (GIQLDisjoin, "reference"),
+            (GIQLNearest, "this"),
+        }
+
+        # Act
+        declared_ref_slots = {
+            (cls, spec.arg)
+            for cls in OPERATOR_CLASSES
+            for spec in cls.GIQL_SLOTS
+            if spec.is_ref_slot
+        }
+
+        # Assert
+        for cls in OPERATOR_CLASSES:
+            assert isinstance(cls.GIQL_SLOTS, tuple)
+            assert all(isinstance(spec, SlotSpec) for spec in cls.GIQL_SLOTS)
+        assert declared_ref_slots == expected_ref_slots

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,617 @@
+"""Tests for the ResolveOperatorRefs normalization pass.
+
+Tests verify that pass 1 attaches well-formed resolution metadata to every GIQL
+operator slot, that its resolution of the table-shaped reference slots mirrors
+the generator's existing behavior, and that the closing validation boundary
+accepts well-formed metadata while rejecting malformed metadata.
+"""
+
+import pytest
+from sqlglot import exp
+from sqlglot import parse_one
+
+from giql.dialect import GIQLDialect
+from giql.expressions import GIQLDisjoin
+from giql.expressions import GIQLDistance
+from giql.expressions import GIQLNearest
+from giql.expressions import SpatialSetPredicate
+from giql.resolver import META_KEY
+from giql.resolver import OperatorResolution
+from giql.resolver import ResolutionError
+from giql.resolver import ResolvedRef
+from giql.resolver import resolve_operator_refs
+from giql.resolver import validate_operator_refs
+from giql.table import Table
+from giql.table import Tables
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given  # noqa: E402
+from hypothesis import settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+# The g_ prefix keeps generated identifiers clear of SQL keywords, which would
+# otherwise break parsing when interpolated as a table name.
+_identifiers = st.from_regex(r"g_[a-z0-9_]{0,8}", fullmatch=True)
+
+
+def _tables(*names: str) -> Tables:
+    """Build a Tables container registering each name with default columns."""
+    container = Tables()
+    for name in names:
+        container.register(name, Table(name))
+    return container
+
+
+def _disjoin_node(ast: exp.Expression) -> GIQLDisjoin:
+    """Return the single GIQLDisjoin node reachable from an annotated AST."""
+    return next(n for n in ast.walk() if isinstance(n, GIQLDisjoin))
+
+
+class TestResolveOperatorRefs:
+    """Tests for the resolve_operator_refs pass."""
+
+    def test_resolve_operator_refs_attaches_metadata_to_every_operator(self):
+        """Test that every GIQL operator receives resolution metadata.
+
+        Given:
+            A query whose WHERE clause carries a spatial predicate.
+        When:
+            Running the resolve pass over the parsed AST.
+        Then:
+            It should attach an OperatorResolution under the giql meta key.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1000-2000'",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("peaks"))
+
+        # Assert
+        predicate = next(n for n in ast.walk() if type(n).__name__ == "Intersects")
+        assert isinstance(predicate.meta.get(META_KEY), OperatorResolution)
+
+    def test_resolve_operator_refs_resolves_disjoin_target(self):
+        """Test that a DISJOIN target resolves to its registered table.
+
+        Given:
+            A DISJOIN over a registered table with custom genomic columns.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach a registered-table ResolvedRef carrying the
+            table's physical column names.
+        """
+        # Arrange
+        tables = Tables()
+        tables.register(
+            "features",
+            Table("features", chrom_col="chr", start_col="lo", end_col="hi"),
+        )
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+
+        # Act
+        resolve_operator_refs(ast, tables)
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("this")
+        assert ref == ResolvedRef(
+            kind="registered_table",
+            name="features",
+            cols=("chr", "lo", "hi"),
+            table=tables.get("features"),
+            coverage_skippable=False,
+        )
+
+    def test_resolve_operator_refs_omitted_reference_is_self_reference(self):
+        """Test that an omitted DISJOIN reference is a coverage-skippable self-reference.
+
+        Given:
+            A DISJOIN with no reference argument.
+        When:
+            Running the resolve pass.
+        Then:
+            It should resolve the reference slot to the target relation with
+            coverage_skippable set.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+
+        # Act
+        resolve_operator_refs(ast, _tables("features"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "registered_table"
+        assert ref.name == "features"
+        assert ref.coverage_skippable is True
+
+    def test_resolve_operator_refs_distinct_registered_reference(self):
+        """Test that a distinct registered DISJOIN reference is not coverage-skippable.
+
+        Given:
+            A DISJOIN whose reference is a different registered table.
+        When:
+            Running the resolve pass.
+        Then:
+            It should resolve to a registered-table reference that is not a
+            self-reference.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM DISJOIN(features, reference := other)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features", "other"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "registered_table"
+        assert ref.name == "other"
+        assert ref.coverage_skippable is False
+
+    def test_resolve_operator_refs_cte_reference_shadows_table(self):
+        """Test that an enclosing CTE reference resolves to a CTE.
+
+        Given:
+            A DISJOIN reference naming a CTE that shadows a registered table of
+            the same name.
+        When:
+            Running the resolve pass.
+        Then:
+            It should resolve to a canonical CTE reference carrying no Table
+            config.
+        """
+        # Arrange
+        ast = parse_one(
+            "WITH other AS (SELECT 1) SELECT * FROM DISJOIN(features, reference := other)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features", "other"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "cte"
+        assert ref.name == "other"
+        assert ref.table is None
+        assert ref.cols == ("chrom", "start", "end")
+
+    def test_resolve_operator_refs_subquery_reference(self):
+        """Test that a subquery DISJOIN reference resolves to a subquery ref.
+
+        Given:
+            A DISJOIN whose reference is a parenthesized SELECT.
+        When:
+            Running the resolve pass.
+        Then:
+            It should resolve to an anonymous canonical subquery reference.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM DISJOIN(features, reference := (SELECT * FROM other))",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "subquery"
+        assert ref.name is None
+        assert ref.table is None
+
+    def test_resolve_operator_refs_unregistered_target_left_unresolved(self):
+        """Test that an unregistered target leaves the slot unresolved.
+
+        Given:
+            A DISJOIN whose target table is not registered.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach an OperatorResolution with no resolved slots,
+            deferring the error to the generator.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(missing)", dialect=GIQLDialect)
+
+        # Act
+        resolve_operator_refs(ast, Tables())
+
+        # Assert
+        resolution = _disjoin_node(ast).meta[META_KEY]
+        assert resolution.slots == {}
+
+    def test_resolve_operator_refs_reserved_prefix_reference_left_unresolved(self):
+        """Test that a reserved-prefix reference name leaves the slot unresolved.
+
+        Given:
+            A DISJOIN reference whose name uses the reserved __giql_dj_ prefix.
+        When:
+            Running the resolve pass.
+        Then:
+            It should leave the reference slot unresolved, deferring the error
+            to the generator.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM DISJOIN(features, reference := __giql_dj_ref)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features"))
+
+        # Assert
+        resolution = _disjoin_node(ast).meta[META_KEY]
+        assert resolution.slot("this") is not None
+        assert resolution.slot("reference") is None
+
+    def test_resolve_operator_refs_resolves_nearest_target(self):
+        """Test that a NEAREST target resolves to its registered table.
+
+        Given:
+            A standalone NEAREST over a registered table.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach a registered-table ResolvedRef for the target slot.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(genes, reference := 'chr1:1-2', k := 3)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("genes"))
+
+        # Assert
+        nearest = next(n for n in ast.walk() if isinstance(n, GIQLNearest))
+        ref = nearest.meta[META_KEY].slot("this")
+        assert ref.kind == "registered_table"
+        assert ref.name == "genes"
+
+    def test_resolve_operator_refs_returns_same_expression(self):
+        """Test that the pass annotates and returns the same AST in place.
+
+        Given:
+            A parsed GIQL query.
+        When:
+            Running the resolve pass.
+        Then:
+            It should return the identical expression object it was given.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+
+        # Act
+        result = resolve_operator_refs(ast, _tables("features"))
+
+        # Assert
+        assert result is ast
+
+    def test_resolve_operator_refs_outer_cte_visible_in_derived_table(self):
+        """Test that an enclosing WITH's CTE is visible to a nested DISJOIN.
+
+        Given:
+            A DISJOIN nested in a derived table whose reference names a CTE
+            defined by the enclosing outer WITH clause.
+        When:
+            Running the resolve pass.
+        Then:
+            It should resolve the reference to a CTE.
+        """
+        # Arrange
+        ast = parse_one(
+            "WITH mask AS (SELECT 1) "
+            "SELECT * FROM (SELECT * FROM DISJOIN(features, reference := mask)) AS d",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "cte"
+        assert ref.name == "mask"
+
+    def test_resolve_operator_refs_metadata_survives_copy(self):
+        """Test that attached resolution metadata survives a tree copy.
+
+        Given:
+            An AST annotated by the resolve pass.
+        When:
+            Copying the AST with Expression.copy().
+        Then:
+            It should carry an equal OperatorResolution on the copied operator.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+        resolve_operator_refs(ast, _tables("features"))
+
+        # Act
+        copied = ast.copy()
+
+        # Assert
+        assert _disjoin_node(copied).meta[META_KEY] == _disjoin_node(ast).meta[META_KEY]
+
+    def test_resolve_operator_refs_annotates_distance_and_set_predicate(self):
+        """Test that non-reference-slot operators still receive metadata.
+
+        Given:
+            A query using DISTANCE in the projection and a spatial set
+            predicate in the WHERE clause.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach an empty-slot OperatorResolution to both
+            operators.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT DISTANCE(a.interval, b.interval) FROM a, b "
+            "WHERE a.interval INTERSECTS ANY('chr1:1-2', 'chr2:3-4')",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("a", "b"))
+
+        # Assert
+        distance = next(n for n in ast.walk() if isinstance(n, GIQLDistance))
+        predicate = next(n for n in ast.walk() if isinstance(n, SpatialSetPredicate))
+        assert distance.meta[META_KEY].slots == {}
+        assert predicate.meta[META_KEY].slots == {}
+
+    def test_resolve_operator_refs_unregistered_nearest_target_left_unresolved(self):
+        """Test that an unregistered NEAREST target leaves the slot unresolved.
+
+        Given:
+            A NEAREST whose target table is not registered.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach an OperatorResolution with no resolved slots,
+            deferring the error to the generator.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(missing, reference := 'chr1:1-2')",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, Tables())
+
+        # Assert
+        nearest = next(n for n in ast.walk() if isinstance(n, GIQLNearest))
+        assert nearest.meta[META_KEY].slots == {}
+
+    @settings(max_examples=50)
+    @given(names=st.lists(_identifiers, min_size=4, max_size=4, unique=True))
+    def test_resolve_operator_refs_with_arbitrary_table_config(self, names):
+        """Test resolution against arbitrary table and column names.
+
+        Given:
+            Any registered Table with generated identifier-safe table and
+            chrom/start/end column names.
+        When:
+            Resolving a DISJOIN over that table.
+        Then:
+            The target ref should carry exactly the configured column names
+            and validation should pass.
+        """
+        # Arrange
+        table_name, chrom, start, end = names
+        tables = Tables()
+        tables.register(
+            table_name,
+            Table(table_name, chrom_col=chrom, start_col=start, end_col=end),
+        )
+        ast = parse_one(f"SELECT * FROM DISJOIN({table_name})", dialect=GIQLDialect)
+
+        # Act
+        resolve_operator_refs(ast, tables)
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("this")
+        assert ref.cols == (chrom, start, end)
+        validate_operator_refs(ast)
+
+
+class TestValidateOperatorRefs:
+    """Tests for the validate_operator_refs validation boundary."""
+
+    def test_validate_operator_refs_accepts_resolved_tree(self):
+        """Test that validation accepts a well-formed annotated tree.
+
+        Given:
+            An AST already annotated by the resolve pass.
+        When:
+            Running validation over it.
+        Then:
+            It should not raise.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM DISJOIN(features, reference := other)",
+            dialect=GIQLDialect,
+        )
+        resolve_operator_refs(ast, _tables("features", "other"))
+
+        # Act & assert
+        validate_operator_refs(ast)
+
+    def test_validate_operator_refs_rejects_missing_metadata(self):
+        """Test that validation rejects an operator with no metadata.
+
+        Given:
+            A DISJOIN node that was never annotated by the resolve pass.
+        When:
+            Running validation over the tree.
+        Then:
+            It should raise a ResolutionError naming the missing metadata.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+
+        # Act & assert
+        with pytest.raises(ResolutionError, match="missing resolution metadata"):
+            validate_operator_refs(ast)
+
+    def test_validate_operator_refs_rejects_disallowed_kind(self):
+        """Test that validation rejects a slot resolved to a disallowed kind.
+
+        Given:
+            A DISJOIN target slot annotated with a subquery ResolvedRef, a kind
+            the target slot does not accept.
+        When:
+            Running validation over the tree.
+        Then:
+            It should raise a ResolutionError naming the rejected kind.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+        node = _disjoin_node(ast)
+        node.meta[META_KEY] = OperatorResolution(
+            "GIQLDisjoin",
+            {
+                "this": ResolvedRef(
+                    kind="subquery",
+                    name=None,
+                    cols=("chrom", "start", "end"),
+                    table=None,
+                    coverage_skippable=False,
+                )
+            },
+        )
+
+        # Act & assert
+        with pytest.raises(ResolutionError, match="not accepted"):
+            validate_operator_refs(ast)
+
+    def test_validate_operator_refs_rejects_registered_table_without_config(self):
+        """Test that validation rejects a registered-table ref with no Table.
+
+        Given:
+            A DISJOIN target annotated as a registered table but carrying no
+            Table config.
+        When:
+            Running validation over the tree.
+        Then:
+            It should raise a ResolutionError naming the missing config.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+        node = _disjoin_node(ast)
+        node.meta[META_KEY] = OperatorResolution(
+            "GIQLDisjoin",
+            {
+                "this": ResolvedRef(
+                    kind="registered_table",
+                    name="features",
+                    cols=("chrom", "start", "end"),
+                    table=None,
+                    coverage_skippable=False,
+                )
+            },
+        )
+
+        # Act & assert
+        with pytest.raises(ResolutionError, match="no Table config"):
+            validate_operator_refs(ast)
+
+    def test_validate_operator_refs_rejects_cte_with_table_config(self):
+        """Test that validation rejects a CTE ref carrying a Table config.
+
+        Given:
+            A DISJOIN reference annotated as a CTE but carrying a Table
+            config, contradicting the canonical assumption for CTEs.
+        When:
+            Running validation over the tree.
+        Then:
+            It should raise a ResolutionError naming the canonical assumption.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+        node = _disjoin_node(ast)
+        table = Table("features")
+        node.meta[META_KEY] = OperatorResolution(
+            "GIQLDisjoin",
+            {
+                "reference": ResolvedRef(
+                    kind="cte",
+                    name="features",
+                    cols=("chrom", "start", "end"),
+                    table=table,
+                    coverage_skippable=False,
+                )
+            },
+        )
+
+        # Act & assert
+        with pytest.raises(ResolutionError, match="assumed canonical"):
+            validate_operator_refs(ast)
+
+    def test_validate_operator_refs_rejects_malformed_cols(self):
+        """Test that validation rejects a ref with malformed cols.
+
+        Given:
+            A DISJOIN target annotated with a ResolvedRef whose cols is not a
+            3-tuple of column names.
+        When:
+            Running validation over the tree.
+        Then:
+            It should raise a ResolutionError naming the malformed cols.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+        node = _disjoin_node(ast)
+        table = Table("features")
+        node.meta[META_KEY] = OperatorResolution(
+            "GIQLDisjoin",
+            {
+                "this": ResolvedRef(
+                    kind="registered_table",
+                    name="features",
+                    cols=("chrom", "start"),
+                    table=table,
+                    coverage_skippable=False,
+                )
+            },
+        )
+
+        # Act & assert
+        with pytest.raises(ResolutionError, match="malformed cols"):
+            validate_operator_refs(ast)
+
+    def test_validate_operator_refs_rejects_non_resolvedref_slot_value(self):
+        """Test that validation rejects a slot holding a non-ResolvedRef value.
+
+        Given:
+            A DISJOIN target slot whose resolution metadata holds a plain
+            string instead of a ResolvedRef.
+        When:
+            Running validation over the tree.
+        Then:
+            It should raise a ResolutionError naming the expected type.
+        """
+        # Arrange
+        ast = parse_one("SELECT * FROM DISJOIN(features)", dialect=GIQLDialect)
+        node = _disjoin_node(ast)
+        node.meta[META_KEY] = OperatorResolution(
+            "GIQLDisjoin",
+            {"this": "features"},
+        )
+
+        # Act & assert
+        with pytest.raises(ResolutionError, match="expected ResolvedRef"):
+            validate_operator_refs(ast)


### PR DESCRIPTION
## Summary

Add the first normalization pass of epic #114's transpile pipeline restructuring. `ResolveOperatorRefs` runs between the transformer chain and the generator: it walks sqlglot scopes leaves-first, resolves each operator's table-shaped reference slots against in-query CTEs and registered tables, attaches a frozen `ResolvedRef` to each operator node under the namespaced `node.meta["giql"]` key, and closes with a validation boundary asserting the attached metadata is well-formed. Slot acceptance rules are declared per operator as `SlotSpec` descriptors on the expression classes. The step lands with zero behavior change — the generator keeps its existing resolver paths and ignores the new metadata, and unresolvable slots are deferred so existing diagnostics fire verbatim. All 1,281 pre-existing tests pass unmodified. Closes #116

## Proposed changes

**Slot descriptors (`src/giql/expressions.py`)** — Add the `SlotShape` vocabulary, the frozen `SlotSpec` dataclass with its `is_ref_slot` property, and `TABLE_SHAPES`. Declare `GIQL_SLOTS` on all seven operator classes; exactly DISJOIN `this`/`reference` and NEAREST `this` are table-shaped reference slots in this step.

**Resolution pass (`src/giql/resolver.py`, new)** — Add `ResolvedRef`, `OperatorResolution`, `ResolutionError`, `resolve_operator_refs`, and `validate_operator_refs`. Resolution mirrors the generator's `_resolve_target_table` / `_resolve_disjoin_reference` semantics exactly, with CTE visibility from `scope.cte_sources` replacing the hand-rolled ancestor walk. A guarded `traverse_scope` with a plain-walk fallback keeps the pass total over exotic ASTs.

**Pipeline wiring (`src/giql/transpile.py`)** — Run the pass after the transformers and before generation, wrapped in the existing error-boundary context manager.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestSlotSpec` | A slot accepting only the table trichotomy | Reading `is_ref_slot` | True | Ref-slot classification |
| 2 | `TestSlotSpec` | A slot accepting a column shape | Reading `is_ref_slot` | False | Ref-slot classification |
| 3 | `TestSlotSpec` | A slot accepting no shapes | Reading `is_ref_slot` | False | Empty-accepts edge |
| 4 | `TestSlotSpec` | The seven operator classes | Reading `GIQL_SLOTS` | Exactly DISJOIN `this`/`reference` and NEAREST `this` are ref slots | Declarative slot contract |
| 5 | `TestResolveOperatorRefs` | A query with a spatial predicate | Running the pass | An `OperatorResolution` is attached | Universal annotation |
| 6 | `TestResolveOperatorRefs` | A DISJOIN over a table with custom columns | Running the pass | The target ref carries the physical column names | Target resolution |
| 7 | `TestResolveOperatorRefs` | A DISJOIN with no reference | Running the pass | The reference is a coverage-skippable self-reference | Self-reference detection |
| 8 | `TestResolveOperatorRefs` | A DISJOIN referencing a distinct table | Running the pass | The reference is not coverage-skippable | Distinct-reference handling |
| 9 | `TestResolveOperatorRefs` | A reference naming a CTE shadowing a table | Running the pass | The reference resolves to a canonical CTE | CTE shadowing |
| 10 | `TestResolveOperatorRefs` | A subquery reference | Running the pass | An anonymous canonical subquery ref | Subquery resolution |
| 11 | `TestResolveOperatorRefs` | An unregistered DISJOIN target | Running the pass | The slot stays unresolved, metadata attached | Deferral to generator |
| 12 | `TestResolveOperatorRefs` | A reserved-prefix reference name | Running the pass | The slot stays unresolved | Reserved-prefix deferral |
| 13 | `TestResolveOperatorRefs` | A standalone NEAREST | Running the pass | The target resolves to its registered table | NEAREST target |
| 14 | `TestResolveOperatorRefs` | A parsed query | Running the pass | The same expression object returns | In-place annotation |
| 15 | `TestResolveOperatorRefs` | A DISJOIN in a derived table with an outer WITH | Running the pass | The outer CTE is visible and resolves | Scope visibility propagation |
| 16 | `TestResolveOperatorRefs` | An annotated AST | Copying via `Expression.copy()` | The copy carries equal metadata | Copy survival |
| 17 | `TestResolveOperatorRefs` | DISTANCE and a set predicate in one query | Running the pass | Both carry empty-slot resolutions | Non-ref-slot operators |
| 18 | `TestResolveOperatorRefs` | An unregistered NEAREST target | Running the pass | The slot stays unresolved | NEAREST deferral |
| 19 | `TestResolveOperatorRefs` | Any generated Table config (Hypothesis) | Resolving a DISJOIN over it | Cols round-trip and validation passes | Config round-trip invariant |
| 20 | `TestValidateOperatorRefs` | A tree annotated by the pass | Running validation | No error | Well-formed acceptance |
| 21 | `TestValidateOperatorRefs` | An unannotated operator | Running validation | `ResolutionError` | Missing-metadata arm |
| 22 | `TestValidateOperatorRefs` | A target resolved to a disallowed kind | Running validation | `ResolutionError` | Kind-acceptance arm |
| 23 | `TestValidateOperatorRefs` | A registered-table ref without Table config | Running validation | `ResolutionError` | Config-presence arm |
| 24 | `TestValidateOperatorRefs` | A CTE ref carrying a Table config | Running validation | `ResolutionError` | Canonical-assumption arm |
| 25 | `TestValidateOperatorRefs` | A ref with malformed cols | Running validation | `ResolutionError` | Cols-shape arm |
| 26 | `TestValidateOperatorRefs` | A slot holding a non-ResolvedRef value | Running validation | `ResolutionError` | Type arm |