### PR TITLE
Port DISJOIN to consume ResolvedRef metadata from ResolveOperatorRefs — Closes #117

### DIFF
--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -18,6 +18,9 @@ from giql.expressions import SpatialSetPredicate
 from giql.expressions import Within
 from giql.range_parser import ParsedRange
 from giql.range_parser import RangeParser
+from giql.resolver import META_KEY
+from giql.resolver import OperatorResolution
+from giql.resolver import ResolvedRef
 from giql.table import Table
 from giql.table import Tables
 
@@ -283,30 +286,14 @@ class BaseGIQLGenerator(Generator):
         :return:
             SQL string (a parenthesized WITH-CTE subquery) for the DISJOIN table
         """
-        # Resolve the target table and its genomic columns.
-        target_name, (target_chrom, target_start, target_end) = (
-            self._resolve_target_table(expression)
-        )
-        target_table = self.tables.get(target_name)
-
-        # The __giql_dj_ prefix names the operator's internal CTEs; a target
-        # table using it would collide with them.
-        if target_name.startswith("__giql_dj_"):
-            raise ValueError(
-                f"DISJOIN target {target_name!r} uses the reserved "
-                "'__giql_dj_' prefix, which names the operator's internal "
-                "CTEs. Rename the table."
-            )
-
-        # Resolve the reference relation (defaults to the target set).
-        ref_from, ref_chrom, ref_start, ref_end, ref_table, is_self_reference = (
-            self._resolve_disjoin_reference(
-                expression,
-                target_name,
-                (target_chrom, target_start, target_end),
-                target_table,
-            )
-        )
+        # Unpack the resolution metadata attached by ResolveOperatorRefs (pass 1).
+        target_ref, ref, ref_from = self._disjoin_resolution(expression)
+        target_name = target_ref.name
+        target_chrom, target_start, target_end = target_ref.cols
+        target_table = target_ref.table
+        ref_chrom, ref_start, ref_end = ref.cols
+        ref_table = ref.table
+        is_self_reference = ref.coverage_skippable
 
         # Canonical target endpoints, qualified by the __giql_dj_tgt alias.
         t_chrom = f't."{target_chrom}"'
@@ -886,12 +873,16 @@ class BaseGIQLGenerator(Generator):
                 )
 
     def _resolve_target_table(
-        self, expression: GIQLNearest | GIQLDisjoin
+        self, expression: GIQLNearest
     ) -> tuple[str, tuple[str, str, str]]:
         """Resolve the target table name and its genomic column references.
 
+        DISJOIN reads its target from the ResolveOperatorRefs metadata instead
+        (see :meth:`_disjoin_resolution`); this helper remains for NEAREST
+        until its port (epic #114, step 3).
+
         :param expression:
-            GIQLNearest or GIQLDisjoin expression node
+            GIQLNearest expression node
         :return:
             Tuple of (table_name, (chromosome_col, start_col, end_col))
         :raises ValueError:
@@ -919,112 +910,85 @@ class BaseGIQLGenerator(Generator):
         # Get physical column names from table config
         return table_name, (table.chrom_col, table.start_col, table.end_col)
 
-    def _resolve_disjoin_reference(
-        self,
-        expression: GIQLDisjoin,
-        target_name: str,
-        target_cols: tuple[str, str, str],
-        target_table: Table | None,
-    ) -> tuple[str, str, str, str, Table | None, bool]:
-        """Resolve the reference relation for a DISJOIN query.
+    def _disjoin_resolution(
+        self, expression: GIQLDisjoin
+    ) -> tuple[ResolvedRef, ResolvedRef, str]:
+        """Unpack the DISJOIN resolution attached by ResolveOperatorRefs (pass 1).
 
-        The reference contributes the breakpoints at which target intervals are
-        cut. When ``reference`` is omitted it defaults to the target set.
+        Reads the :class:`~giql.resolver.OperatorResolution` from
+        ``expression.meta`` and returns ``(target_ref, ref, ref_from)`` where
+        ``ref_from`` is the text following ``FROM`` inside the ``__giql_dj_ref``
+        CTE. A subquery reference carries no name, so it is rendered from the
+        AST node as an aliased derived table; registered tables and CTEs are
+        selected from by name.
 
-        A bare reference name is resolved against the query's CTEs first: a
-        name defined by an enclosing ``WITH`` clause shadows a registered table
-        of the same name (matching SQL scoping) and is assumed to expose
-        canonical 0-based half-open ``chrom`` / ``start`` / ``end`` columns. A
-        name with no such CTE but a registered table contributes that table's
-        column names and coordinate system. A name that is neither is an error.
+        The resolver pass deliberately leaves unresolvable slots unresolved
+        (unregistered target; unsupported reference node type; reference name
+        using the reserved ``__giql_dj_`` prefix or matching neither a
+        registered table nor an in-query CTE). For those, and for a target name
+        using the reserved prefix (which the resolver does resolve), this
+        re-raises the generator's historical diagnostics verbatim.
 
         :param expression:
             GIQLDisjoin expression node
-        :param target_name:
-            Resolved target table name (the default reference)
-        :param target_cols:
-            ``(chrom, start, end)`` column names of the target table
-        :param target_table:
-            Table config of the target (the default reference config)
         :return:
-            Tuple of ``(from_clause, chrom_col, start_col, end_col, table,
-            is_self_reference)`` where ``from_clause`` is the text following
-            ``FROM`` inside the ``__giql_dj_ref`` CTE. A subquery or CTE
-            reference is assumed to expose canonical 0-based half-open
-            ``chrom`` / ``start`` / ``end`` columns, so ``table`` is ``None``
-            for those. ``is_self_reference`` is ``True`` only when the
-            reference provably resolves to the same registered relation as the
-            target (omitted reference, or a bare name equal to the target name
-            that is not shadowed by an enclosing CTE and maps to the same
-            registered table). It is ``False`` in all other cases, including
-            subquery and CTE references that may textually duplicate the
-            target.
+            Tuple of ``(target_ref, ref, ref_from)``
         :raises ValueError:
-            If the reference is not a table name, a CTE, or a subquery, or if
-            a bare name resolves to neither a registered table nor a CTE.
+            If the target or reference slot is unresolved, or a resolved name
+            uses the reserved ``__giql_dj_`` prefix.
         """
-        reference = expression.args.get("reference")
-        tc, ts, te = target_cols
+        resolution = expression.meta.get(META_KEY)
+        target_ref = (
+            resolution.slot("this")
+            if isinstance(resolution, OperatorResolution)
+            else None
+        )
 
-        # No reference: default to the target set (single-mode).
-        if reference is None:
-            return target_name, tc, ts, te, target_table, True
-
-        # Subquery reference: inline it as an aliased derived table. The
-        # subquery may textually duplicate the target, but proving equivalence
-        # is out of scope, so treat it as a distinct relation.
-        if isinstance(reference, (exp.Subquery, exp.Select, exp.Union)):
-            from_clause = f"{self.sql(reference)} AS __giql_dj_rs"
-            return (
-                from_clause,
-                DEFAULT_CHROM_COL,
-                DEFAULT_START_COL,
-                DEFAULT_END_COL,
-                None,
-                False,
+        # An unresolved target means it is not a registered table.
+        if target_ref is None:
+            target = expression.this
+            if isinstance(target, exp.Table):
+                target_name = target.name
+            elif isinstance(target, exp.Column):
+                target_name = target.table if target.table else str(target.this)
+            else:
+                target_name = str(target)
+            raise ValueError(
+                f"Target table '{target_name}' not found in tables. "
+                "Register the table before transpiling."
             )
 
-        # Anything that is not a bare table/CTE name is unsupported.
+        # The __giql_dj_ prefix names the operator's internal CTEs; a target
+        # table using it would collide with them.
+        if target_ref.name.startswith("__giql_dj_"):
+            raise ValueError(
+                f"DISJOIN target {target_ref.name!r} uses the reserved "
+                "'__giql_dj_' prefix, which names the operator's internal "
+                "CTEs. Rename the table."
+            )
+
+        reference = expression.args.get("reference")
+        ref = resolution.slot("reference")
+        if ref is not None:
+            if ref.kind == "subquery":
+                return target_ref, ref, f"{self.sql(reference)} AS __giql_dj_rs"
+            return target_ref, ref, ref.name
+
+        # Unresolved reference: re-classify it and raise the matching
+        # historical diagnostic. An omitted reference always resolves (to the
+        # target set), so reference is non-None here.
         if not isinstance(reference, (exp.Table, exp.Column, exp.Identifier)):
             raise ValueError(
                 "DISJOIN reference must be a table name, a CTE, or a "
                 f"(SELECT ...) subquery; got {type(reference).__name__}: "
                 f"{reference}"
             )
-
         ref_name = reference.name
-
-        # The __giql_dj_ prefix names the operator's internal CTEs.
         if ref_name.startswith("__giql_dj_"):
             raise ValueError(
                 f"DISJOIN reference {ref_name!r} uses the reserved "
                 "'__giql_dj_' prefix, which names the operator's internal "
                 "CTEs. Rename the reference relation."
-            )
-
-        # A CTE from an enclosing WITH shadows a registered table of the same
-        # name; it is assumed to expose canonical default columns. A CTE may
-        # contain rows distinct from any same-named registered table, so it is
-        # never treated as a self-reference.
-        if ref_name in self._enclosing_cte_names(expression):
-            return (
-                ref_name,
-                DEFAULT_CHROM_COL,
-                DEFAULT_START_COL,
-                DEFAULT_END_COL,
-                None,
-                False,
-            )
-
-        ref_table = self.tables.get(ref_name)
-        if ref_table:
-            return (
-                ref_name,
-                ref_table.chrom_col,
-                ref_table.start_col,
-                ref_table.end_col,
-                ref_table,
-                ref_name == target_name and ref_table is target_table,
             )
         raise ValueError(
             f"DISJOIN reference {ref_name!r} is neither a registered table "
@@ -1045,26 +1009,6 @@ class BaseGIQLGenerator(Generator):
             return param_expr.this
         else:
             return str(param_expr).upper() in ("TRUE", "1", "YES")
-
-    @staticmethod
-    def _enclosing_cte_names(expression: exp.Expression) -> set[str]:
-        """Collect CTE names visible to an expression from enclosing WITH clauses.
-
-        Walks the ancestor chain and gathers the aliases of every ``WITH``-clause
-        CTE, so a DISJOIN reference can be recognized as an in-query CTE rather
-        than a registered table.
-        """
-        names: set[str] = set()
-        node: exp.Expression | None = expression
-        while node is not None:
-            if isinstance(node, exp.Select):
-                with_clause = node.args.get("with_") or node.args.get("with")
-                if with_clause is not None:
-                    for cte in with_clause.expressions:
-                        if cte.alias:
-                            names.add(cte.alias)
-            node = node.parent
-        return names
 
     def _get_column_refs(
         self,

--- a/src/giql/resolver.py
+++ b/src/giql/resolver.py
@@ -22,13 +22,15 @@ pass closes with a validation boundary (:func:`validate_operator_refs`) that
 asserts every operator slot carries well-formed resolution metadata, mirroring
 ``sqlglot``'s ``validate_qualify_columns`` and Spark's ``CheckAnalysis``.
 
-Scope note (epic #114, step 1)
-------------------------------
-This is *scaffolding*: it lands with **zero behavior change**. The generator
-still uses its existing resolver paths and ignores everything attached here. The
-resolution semantics computed for the table-shaped reference slots mirror the
-generator's existing ``_resolve_target_table`` / ``_resolve_disjoin_reference``
-/ ``_enclosing_cte_names`` behavior exactly.
+Scope note (epic #114, steps 1-2)
+---------------------------------
+The pass is behavior-preserving. DISJOIN's emitter
+(``BaseGIQLGenerator.giqldisjoin_sql``) consumes the attached metadata (step 2);
+the remaining operators still use the generator's legacy resolver paths and
+ignore everything attached here until their port issues land. The resolution
+semantics computed for the table-shaped reference slots mirror the generator's
+historical ``_resolve_target_table`` / ``_resolve_disjoin_reference`` /
+``_enclosing_cte_names`` behavior exactly (the latter two now live only here).
 
 Two consequences of the zero-behavior-change constraint shape the
 implementation:
@@ -302,12 +304,11 @@ def _resolve_disjoin_reference(
 ) -> ResolvedRef | None:
     """Resolve a DISJOIN ``reference`` slot.
 
-    Mirrors ``BaseGIQLGenerator._resolve_disjoin_reference`` exactly, with one
-    deliberate difference: CTE visibility comes from the operator's scope
-    (``scope.cte_sources``) rather than the hand-rolled ``_enclosing_cte_names``
-    ancestor walk, as epic #114 specifies. The two agree on every supported
-    shape; any divergence on exotic constructs is invisible in step 1 because
-    the generator ignores this metadata.
+    Mirrors the generator's historical ``_resolve_disjoin_reference`` exactly
+    (ported here in epic #114, step 2), with one deliberate difference: CTE
+    visibility comes from the operator's scope (``scope.cte_sources``) rather
+    than the hand-rolled ``_enclosing_cte_names`` ancestor walk, as epic #114
+    specifies. The two agree on every supported shape.
 
     Returns ``None`` for the unresolvable shapes (reserved prefix, unknown
     name, unsupported node type); the generator raises its existing error.

--- a/src/giql/transpile.py
+++ b/src/giql/transpile.py
@@ -173,9 +173,9 @@ def transpile(
         ast = cluster_transformer.transform(ast)
 
     # Pass 1 of the normalization pipeline (epic #114): attach resolution
-    # metadata to every GIQL operator slot ahead of generation. Behavior-
-    # preserving in step 1 — the generator still uses its existing resolver
-    # paths and ignores this metadata.
+    # metadata to every GIQL operator slot ahead of generation. DISJOIN's
+    # emitter consumes this metadata (step 2); the remaining operators still
+    # use the generator's legacy resolver paths until their ports land.
     with _reraise_as_value_error("Resolution error"):
         ast = resolve_operator_refs(ast, tables_container)
 

--- a/tests/test_disjoin_transpilation.py
+++ b/tests/test_disjoin_transpilation.py
@@ -505,6 +505,63 @@ class TestDisjoinTranspilation:
         # Assert
         assert sql.count("EXISTS (") == 1
 
+    @pytest.mark.parametrize(
+        ("query", "tables", "skips_exists"),
+        [
+            ("SELECT * FROM DISJOIN(features)", ["features"], True),
+            (
+                "SELECT * FROM DISJOIN(features, reference := features)",
+                ["features"],
+                True,
+            ),
+            (
+                "SELECT * FROM DISJOIN(features, reference := refs)",
+                ["features", "refs"],
+                False,
+            ),
+            (
+                "WITH refs AS (SELECT 1) "
+                "SELECT * FROM DISJOIN(features, reference := refs)",
+                ["features"],
+                False,
+            ),
+            (
+                "SELECT * FROM DISJOIN(features, reference := (SELECT * FROM refs))",
+                ["features", "refs"],
+                False,
+            ),
+        ],
+        ids=[
+            "omitted-reference",
+            "same-name-registered-table",
+            "distinct-registered-table",
+            "in-query-cte",
+            "subquery",
+        ],
+    )
+    def test_giqldisjoin_sql_should_pin_coverage_skippable_across_reference_shapes(
+        self, query, tables, skips_exists
+    ):
+        """Test that the coverage EXISTS skip-vs-keep is preserved per shape.
+
+        Given:
+            A DISJOIN call across each reference shape — omitted, same-name
+            registered table, distinct registered table, in-query CTE, and
+            subquery — whose ResolvedRef.coverage_skippable drives the EXISTS
+            decision.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should omit the coverage EXISTS subquery exactly for the
+            provable self-reference shapes and emit it for every shape that may
+            hold rows distinct from the target.
+        """
+        # Arrange & act
+        sql = transpile(query, tables=tables)
+
+        # Assert
+        assert ("EXISTS (" not in sql) is skips_exists
+
     def test_giqldisjoin_sql_should_emit_exists_clause_when_enclosing_cte_shadows_target_from_outer_scope(
         self,
     ):
@@ -532,3 +589,109 @@ class TestDisjoinTranspilation:
 
         # Assert
         assert sql.count("EXISTS (") == 1
+
+    def test_giqldisjoin_sql_should_resolve_recursive_cte_reference(self):
+        """Test that a WITH RECURSIVE CTE reference resolves to the CTE.
+
+        Given:
+            A DISJOIN reference naming a CTE declared by WITH RECURSIVE, with
+            a same-named registered table whose 1-based closed encoding would
+            shift coordinates if the table were (wrongly) selected.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should resolve the reference to the CTE — selecting from it by
+            name, keeping the coverage EXISTS, and applying no coordinate
+            shift.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH RECURSIVE refs AS (SELECT 1 UNION ALL SELECT 2) "
+            "SELECT * FROM DISJOIN(features, reference := refs)",
+            tables=[
+                "features",
+                Table("refs", coordinate_system="1based", interval_type="closed"),
+            ],
+        )
+
+        # Assert
+        assert "__giql_dj_ref AS (SELECT * FROM refs)" in sql
+        assert "EXISTS (" in sql
+        assert '("start" - 1)' not in sql
+
+    def test_giqldisjoin_sql_should_resolve_set_operation_attached_cte_reference(self):
+        """Test that a WITH attached to a set operation is visible to DISJOIN.
+
+        Given:
+            A UNION ALL query whose WITH clause hangs on the set-operation
+            node and whose first branch passes the CTE name as a DISJOIN
+            reference, with no same-named registered table.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should resolve the reference to the CTE per SQL scoping — the
+            scope-based resolver sees set-operation-attached WITH clauses,
+            matching how the engine resolves the emitted name at execution
+            time.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH refs AS (SELECT 1) "
+            "SELECT * FROM DISJOIN(features, reference := refs) "
+            "UNION ALL "
+            "SELECT * FROM DISJOIN(features)",
+            tables=["features"],
+        )
+
+        # Assert
+        assert "__giql_dj_ref AS (SELECT * FROM refs)" in sql
+        assert sql.count("EXISTS (") == 1
+
+    def test_giqldisjoin_sql_should_resolve_redeclared_inner_cte_reference(self):
+        """Test that an inner WITH redeclaring an outer CTE name still resolves.
+
+        Given:
+            A nested query where both the outer query and the inner derived
+            table declare a CTE named ``refs``, and the DISJOIN inside the
+            inner scope passes ``refs`` as its reference.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should resolve the reference to the (shadowing) CTE — selecting
+            from it by name and keeping the coverage EXISTS.
+        """
+        # Arrange & act
+        sql = transpile(
+            "WITH refs AS (SELECT 1) "
+            "SELECT * FROM ("
+            "WITH refs AS (SELECT 2) "
+            "SELECT * FROM DISJOIN(features, reference := refs)"
+            ") AS sub",
+            tables=["features"],
+        )
+
+        # Assert
+        assert "__giql_dj_ref AS (SELECT * FROM refs)" in sql
+        assert sql.count("EXISTS (") == 1
+
+    def test_giqldisjoin_sql_should_not_see_cte_declared_in_sibling_derived_table(
+        self,
+    ):
+        """Test that a CTE declared inside a sibling derived table stays invisible.
+
+        Given:
+            An outer DISJOIN whose reference names a CTE declared only inside
+            a sibling derived table, with no registered table of that name.
+        When:
+            Transpiling to SQL.
+        Then:
+            It should raise the unknown-reference ValueError — inner WITH
+            clauses are not in scope for the outer query.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match="neither a registered table"):
+            transpile(
+                "SELECT * FROM DISJOIN(features, reference := refs), "
+                "(WITH refs AS (SELECT 1) SELECT * FROM refs) AS sub",
+                tables=["features"],
+            )


### PR DESCRIPTION
## Summary

Implement step 2 of epic #114's staged migration plan — port DISJOIN to consume `ResolvedRef` metadata: `giqldisjoin_sql` now reads its target and reference relations from the metadata attached by the `ResolveOperatorRefs` pass (#116) instead of resolving names at emission time. Delete the generator's `_resolve_disjoin_reference` and `_enclosing_cte_names` helpers — their semantics live in the resolver pass, with CTE visibility drawn from sqlglot scope sources rather than the hand-rolled ancestor walk. The coverage-`EXISTS` skip keys off the resolved `coverage_skippable` flag, unresolvable slots raise the historical diagnostics verbatim, and generated SQL is byte-identical.

Closes #117

## Proposed changes

**DISJOIN emitter (`src/giql/generators/base.py`):** Read `target_ref`/`ref` via `expression.meta[META_KEY]`; render subquery references from the AST node (the resolver carries no SQL text); keep the reserved-prefix target guard; raise the legacy "not found in tables" / "neither a registered table" / reserved-prefix errors through two small reclassification helpers (`_disjoin_target_name`, `_raise_disjoin_reference_error`) so `match=` assertions in the suite stay valid. `_resolve_target_table` remains because NEAREST still calls it (its removal belongs to #118, the NEAREST port).

**Scope-note updates (`src/giql/resolver.py`, `src/giql/transpile.py`):** Docstring and comment updates only, reframing the pass as consumed by DISJOIN while the remaining operators stay on legacy paths until their ports land.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestDisjoinTranspilation` | Each of the five reference shapes — omitted, same-name table, distinct table, in-query CTE, subquery (parametrized) | Transpiling to SQL | The coverage `EXISTS` is omitted exactly for the provable self-reference shapes | Skip-vs-keep preservation across `coverage_skippable` |
| 2 | `TestDisjoinTranspilation` | A WITH RECURSIVE CTE used as the DISJOIN reference | Transpiling to SQL | The reference resolves as a CTE | Recursive-WITH visibility inherited from the deleted ancestor walk |
| 3 | `TestDisjoinTranspilation` | A set-operation-attached WITH clause defining the reference CTE | Transpiling to SQL | The reference resolves as a CTE | Set-op WITH visibility |
| 4 | `TestDisjoinTranspilation` | An inner WITH redeclaring a name from an outer WITH | Transpiling to SQL | The inner declaration wins for the nested DISJOIN | Redeclaration shadowing |
| 5 | `TestDisjoinTranspilation` | A CTE declared inside a sibling derived table | Transpiling to SQL | The DISJOIN does not see it and falls back to the registered table | Scope isolation between siblings |