### PR TITLE
Build the CanonicalizeCoordinates pass with wrapper-CTE synthesis — Closes #121

### DIFF
--- a/src/giql/canonicalizer.py
+++ b/src/giql/canonicalizer.py
@@ -1,0 +1,355 @@
+"""Pass 2 of the GIQL normalization pipeline: ``CanonicalizeCoordinates``.
+
+This module implements the second normalization pass described in epic #114. It
+runs after :func:`giql.resolver.resolve_operator_refs` (pass 1) and consumes the
+:class:`~giql.resolver.ResolvedRef` metadata that pass attached to every GIQL
+operator slot. For every interval-bearing relation reachable from an operator
+slot whose ``ResolvedRef`` carries a :class:`~giql.table.Table` config declaring
+a *non-canonical* encoding (``coordinate_system`` / ``interval_type`` other than
+``0based`` / ``half_open``), the pass synthesizes a hidden ``__giql_canon_*``
+WITH-CTE that projects the relation to canonical 0-based half-open coordinates
+(replicating the :mod:`giql.canonical` arithmetic as SQL in the CTE projection)
+and rewrites the operator slot — both the AST node and its ``ResolvedRef``
+metadata — to point at the canonical CTE.
+
+The synthesis follows ``sqlglot``'s ``eliminate_subqueries`` mechanics
+(:mod:`sqlglot.optimizer.eliminate_subqueries`):
+
+* **Collision-safe aliases.** Candidate names come from
+  :func:`sqlglot.helper.name_sequence` with the ``__giql_canon_`` prefix, checked
+  against a taken-set collected across every scope's table sources and CTE
+  aliases; :func:`sqlglot.helper.find_new_name` resolves any residual collision
+  against a user identifier.
+* **Wrapper-body deduplication.** Two operator slots referencing the same source
+  under the same encoding share a single canonical CTE — one source is wrapped at
+  most once per query, keyed on the rendered wrapper body.
+* **DAG-ordered insertion.** Canonical CTEs depend only on base (registered)
+  tables, never on other CTEs, so they are prepended to the outermost ``WITH``;
+  any existing CTE or main-body operator that now references a canonical CTE
+  therefore sees it defined first.
+
+Identity-encoded relations pass through **unwrapped**: a relation already in
+0-based half-open form, or one with no ``Table`` config (a CTE or subquery
+reference, assumed canonical), is left untouched — the readability-vs-volume
+tradeoff the epic calls out (only synthesize a wrapper when canonicalization
+actually changes columns).
+
+Gating (epic #114, step 6)
+--------------------------
+The pass is gated per operator by a ``GIQL_CANONICALIZE`` class attribute on the
+operator's expression class. An operator opts in by setting
+``GIQL_CANONICALIZE = True``; absent or ``False`` (the default for every operator
+as of this issue) the pass ignores it entirely. The operator port issues — #122
+(DISJOIN) and #123 (NEAREST / DISTANCE / predicates) — flip these flags as each
+operator's emitter is moved off in-emitter canonicalization
+(:mod:`giql.canonical`) and onto this pass's output. **With every flag off the
+pass is a strict no-op and the emitted SQL is byte-identical**, so the existing
+suite is the migration oracle.
+
+De-canonicalization hook
+-------------------------
+The outermost ``SELECT`` projection receives a de-canonicalization rewrite for
+any output column that a migrated operator emitted in canonical form but that
+must land in the user's preferred encoding. With no operator migrated in this
+issue that rewrite has nothing to act on; :func:`_decanonicalize_outputs` is the
+designed-but-inert hook the port issues will fill in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from sqlglot import exp
+from sqlglot.helper import find_new_name
+from sqlglot.helper import name_sequence
+from sqlglot.optimizer.scope import traverse_scope
+
+from giql.expressions import Contains
+from giql.expressions import GIQLDisjoin
+from giql.expressions import GIQLDistance
+from giql.expressions import GIQLNearest
+from giql.expressions import Intersects
+from giql.expressions import SlotSpec
+from giql.expressions import SpatialSetPredicate
+from giql.expressions import Within
+from giql.resolver import META_KEY
+from giql.resolver import OperatorResolution
+from giql.resolver import ResolvedRef
+from giql.table import Table
+
+__all__ = [
+    "CANON_PREFIX",
+    "canonicalize_coordinates",
+]
+
+#: The alias prefix for every synthesized canonical wrapper CTE. Mirrors the
+#: ``__giql_dj_`` reserved prefix the DISJOIN emitter already uses; the leading
+#: double underscore keeps the namespace clear of user identifiers.
+CANON_PREFIX = "__giql_canon_"
+
+#: The GIQL operator expression classes the pass inspects — the same set pass 1
+#: annotates. Membership alone does not opt an operator in; the per-class
+#: ``GIQL_CANONICALIZE`` flag does (see module docstring).
+_OPERATORS: tuple[type[exp.Expression], ...] = (
+    GIQLDisjoin,
+    GIQLNearest,
+    GIQLDistance,
+    Intersects,
+    Contains,
+    Within,
+    SpatialSetPredicate,
+)
+
+
+def canonicalize_coordinates(expression: exp.Expression) -> exp.Expression:
+    """Synthesize canonical wrapper CTEs for non-canonical operator operands.
+
+    Walks *expression* for opted-in GIQL operators (those whose expression class
+    sets ``GIQL_CANONICALIZE = True``), and for each reference slot that resolved
+    to a registered table with a non-canonical encoding, synthesizes a
+    ``__giql_canon_*`` WITH-CTE projecting that table to canonical 0-based
+    half-open coordinates and rewrites the slot (AST node + ``ResolvedRef``
+    metadata) to point at the canonical CTE.
+
+    The pass mutates and returns *expression* in place. **When no operator opts
+    in — the state as of issue #121 — it is a strict no-op: no node is touched
+    and the emitted SQL is byte-identical.**
+
+    Parameters
+    ----------
+    expression : exp.Expression
+        The pass-1-annotated AST.
+
+    Returns
+    -------
+    exp.Expression
+        The same *expression*, with canonical wrapper CTEs inserted and migrated
+        operator slots rewritten (none, while every flag is off).
+    """
+    targets = _collect_targets(expression)
+    if not targets:
+        # No opted-in operator carries a non-canonical operand: strict no-op.
+        return expression
+
+    taken = _collect_taken_names(expression)
+    next_name = name_sequence(CANON_PREFIX)
+    body_to_name: dict[str, str] = {}
+    new_ctes: list[exp.CTE] = []
+
+    for node, arg, ref in targets:
+        body = _canonical_projection(ref)
+        body_sql = body.sql()
+        name = body_to_name.get(body_sql)
+        if name is None:
+            # First time this exact wrapper body is needed: mint a fresh,
+            # collision-safe alias and emit one CTE for it.
+            name = _fresh_name(next_name, taken)
+            taken.add(name)
+            body_to_name[body_sql] = name
+            new_ctes.append(_make_cte(name, body))
+        # Subsequent slots with an identical body reuse the same CTE (dedup).
+        _rewrite_slot(node, arg, ref, name)
+
+    _insert_ctes(expression, new_ctes)
+    _decanonicalize_outputs(expression, targets)
+    return expression
+
+
+def _collect_targets(
+    expression: exp.Expression,
+) -> list[tuple[exp.Expression, str, ResolvedRef]]:
+    """Return ``(node, slot_arg, ref)`` triples needing canonicalization.
+
+    A slot qualifies when its operator opts in (``GIQL_CANONICALIZE``), the slot
+    is a reference slot that resolved to a registered table, and that table's
+    declared encoding is non-canonical. CTE / subquery references (assumed
+    canonical) and identity-encoded tables are skipped — they pass through
+    unwrapped.
+    """
+    targets: list[tuple[exp.Expression, str, ResolvedRef]] = []
+    for node in expression.walk():
+        if not isinstance(node, _OPERATORS):
+            continue
+        if not getattr(node, "GIQL_CANONICALIZE", False):
+            continue
+        resolution = node.meta.get(META_KEY)
+        if not isinstance(resolution, OperatorResolution):
+            continue
+        specs: tuple[SlotSpec, ...] = getattr(node, "GIQL_SLOTS", ())
+        for spec in specs:
+            if not spec.is_ref_slot:
+                continue
+            ref = resolution.slots.get(spec.arg)
+            if ref is None:
+                continue
+            # Only registered tables carry a declared encoding; CTE / subquery
+            # references are assumed canonical and pass through unwrapped.
+            if ref.kind != "registered_table":
+                continue
+            if _is_canonical(ref.table):
+                continue
+            targets.append((node, spec.arg, ref))
+    return targets
+
+
+def _is_canonical(table: Table | None) -> bool:
+    """Whether *table*'s declared encoding is already canonical 0-based half-open.
+
+    ``None`` (an unregistered relation) is treated as canonical, matching the
+    :mod:`giql.canonical` convention.
+    """
+    if table is None:
+        return True
+    return table.coordinate_system == "0based" and table.interval_type == "half_open"
+
+
+def _collect_taken_names(expression: exp.Expression) -> set[str]:
+    """Collect every relation name already in use across all scopes.
+
+    Mirrors ``eliminate_subqueries``'s taken-set: every registered-table source
+    name plus every CTE alias, so a freshly minted ``__giql_canon_*`` alias can
+    be proven collision-free. A scope-traversal failure falls back to a plain
+    tree walk so the set is never under-populated.
+    """
+    taken: set[str] = set()
+    try:
+        scopes = traverse_scope(expression)
+    except Exception:
+        scopes = []
+    for scope in scopes:
+        for source in scope.sources.values():
+            if isinstance(source, exp.Table):
+                taken.add(source.name)
+        taken.update(scope.cte_sources)
+    # Belt-and-suspenders: a raw walk catches any name the scope machinery did
+    # not surface (e.g. when traverse_scope bailed on an exotic construct).
+    for table in expression.find_all(exp.Table):
+        taken.add(table.name)
+    for cte in expression.find_all(exp.CTE):
+        taken.add(cte.alias)
+    return taken
+
+
+def _fresh_name(next_name, taken: set[str]) -> str:
+    """Return a ``__giql_canon_*`` alias not present in *taken*.
+
+    Draws sequential candidates from the ``name_sequence`` generator and, on the
+    rare collision with a user identifier, defers to ``find_new_name`` for a
+    suffixed variant — the same two-step ``eliminate_subqueries`` uses.
+    """
+    candidate = next_name()
+    if candidate in taken:
+        candidate = find_new_name(taken, candidate)
+    return candidate
+
+
+def _canonical_projection(ref: ResolvedRef) -> exp.Select:
+    """Build the ``SELECT`` body that projects *ref*'s table to canonical form.
+
+    The projection exposes the canonical ``chrom`` / ``start`` / ``end`` columns
+    under their original physical names, with ``start`` / ``end`` rewritten by
+    the :mod:`giql.canonical` arithmetic for the table's declared encoding. This
+    is the interval contract every CTE / subquery reference is assumed to satisfy
+    (canonical 0-based half-open ``chrom`` / ``start`` / ``end``); operator port
+    issues #122 / #123 may extend it with pass-through columns as their emitters
+    require.
+    """
+    chrom, start, end = ref.cols
+    table = ref.table
+    relation = ref.name
+    return exp.select(
+        exp.alias_(exp.column(chrom), chrom),
+        exp.alias_(_canonical_start_expr(start, table), start),
+        exp.alias_(_canonical_end_expr(end, table), end),
+    ).from_(exp.to_table(relation))
+
+
+def _canonical_start_expr(start: str, table: Table | None) -> exp.Expression:
+    """Canonical 0-based half-open start expression for a raw start column.
+
+    SQL analog of :func:`giql.canonical.canonical_start`:
+
+    - ``0based``: ``start`` (identity)
+    - ``1based``: ``start - 1``
+    """
+    col = exp.column(start)
+    if table is None or table.coordinate_system == "0based":
+        return col
+    return exp.paren(exp.Sub(this=col, expression=exp.Literal.number(1)))
+
+
+def _canonical_end_expr(end: str, table: Table | None) -> exp.Expression:
+    """Canonical 0-based half-open end expression for a raw end column.
+
+    SQL analog of :func:`giql.canonical.canonical_end`:
+
+    - ``0based`` / ``half_open``: ``end`` (identity)
+    - ``0based`` / ``closed``:    ``end + 1``
+    - ``1based`` / ``half_open``: ``end - 1``
+    - ``1based`` / ``closed``:    ``end`` (identity)
+    """
+    col = exp.column(end)
+    if table is None:
+        return col
+    key = (table.coordinate_system, table.interval_type)
+    if key == ("0based", "closed"):
+        return exp.paren(exp.Add(this=col, expression=exp.Literal.number(1)))
+    if key == ("1based", "half_open"):
+        return exp.paren(exp.Sub(this=col, expression=exp.Literal.number(1)))
+    return col
+
+
+def _make_cte(name: str, body: exp.Select) -> exp.CTE:
+    """Wrap a projection *body* as a named CTE."""
+    return exp.CTE(
+        this=body,
+        alias=exp.TableAlias(this=exp.to_identifier(name)),
+    )
+
+
+def _rewrite_slot(node: exp.Expression, arg: str, ref: ResolvedRef, name: str) -> None:
+    """Point operator slot *arg* at the canonical CTE *name*.
+
+    Rewrites both the AST slot (to a bare table reference naming the CTE) and the
+    attached :class:`~giql.resolver.OperatorResolution` (a fresh
+    :class:`~giql.resolver.ResolvedRef` of kind ``"cte"`` carrying no ``Table``
+    config — the CTE is canonical by construction). The physical column names are
+    preserved because the CTE re-exposes them under their original names.
+    """
+    new_ref = replace(ref, kind="cte", name=name, table=None)
+    resolution = node.meta[META_KEY]
+    resolution.slots[arg] = new_ref
+    node.set(arg, exp.to_table(name))
+
+
+def _insert_ctes(expression: exp.Expression, new_ctes: list[exp.CTE]) -> None:
+    """Prepend *new_ctes* to the outermost ``WITH`` in DAG order.
+
+    Canonical CTEs depend only on base tables, so prepending them guarantees any
+    existing CTE or main-body reference resolves them. An existing ``WITH`` is
+    extended in place; otherwise a fresh one is attached to the root query.
+    """
+    if not new_ctes:
+        return
+    query = expression.expression if isinstance(expression, exp.DDL) else expression
+    existing = query.args.get("with_")
+    if existing is not None:
+        existing.set("expressions", new_ctes + list(existing.expressions))
+    else:
+        query.set("with_", exp.With(expressions=new_ctes))
+
+
+def _decanonicalize_outputs(
+    expression: exp.Expression,
+    targets: list[tuple[exp.Expression, str, ResolvedRef]],
+) -> None:
+    """De-canonicalize migrated operator outputs in the outermost projection.
+
+    Inert hook (epic #114, step 6). The outermost ``SELECT`` projection list
+    should rewrite any output column a migrated operator emitted in canonical
+    form back into the user's preferred encoding. No operator is migrated in
+    issue #121, so there is nothing to rewrite; the operator port issues (#122,
+    #123) fill this in alongside flipping their ``GIQL_CANONICALIZE`` flags.
+    """
+    # Intentionally empty until an operator opts in (see module docstring).
+    return None

--- a/src/giql/transpile.py
+++ b/src/giql/transpile.py
@@ -11,6 +11,7 @@ from typing import overload
 
 from sqlglot import parse_one
 
+from giql.canonicalizer import canonicalize_coordinates
 from giql.dialect import GIQLDialect
 from giql.generators import BaseGIQLGenerator
 from giql.resolver import resolve_operator_refs
@@ -178,6 +179,13 @@ def transpile(
     # use the generator's legacy resolver paths until their ports land.
     with _reraise_as_value_error("Resolution error"):
         ast = resolve_operator_refs(ast, tables_container)
+
+    # Pass 2 of the normalization pipeline (epic #114): synthesize canonical
+    # __giql_canon_* wrapper CTEs for non-canonical interval operands of
+    # opted-in operators (GIQL_CANONICALIZE). No operator opts in yet, so this
+    # is a strict no-op until the per-operator port issues (#122, #123) land.
+    with _reraise_as_value_error("Canonicalization error"):
+        ast = canonicalize_coordinates(ast)
 
     with _reraise_as_value_error("Transpilation error"):
         sql = generator.generate(ast)

--- a/tests/test_canonicalizer.py
+++ b/tests/test_canonicalizer.py
@@ -1,0 +1,618 @@
+"""Tests for the CanonicalizeCoordinates normalization pass (pass 2).
+
+These tests pin three guarantees of :mod:`giql.canonicalizer`:
+
+* With every operator's ``GIQL_CANONICALIZE`` flag off (the state as of issue
+  #121) the pass is a strict no-op and the emitted SQL is byte-identical for
+  both canonical and non-canonical tables.
+* With an operator opted in, the synthesized ``__giql_canon_*`` wrapper CTE
+  projects each declared encoding to canonical 0-based half-open with the correct
+  arithmetic, identity encodings pass through unwrapped, generated aliases avoid
+  user-name collisions, identical wrapper bodies deduplicate to one CTE, and the
+  CTEs are inserted in DAG order on the outermost ``WITH``.
+"""
+
+import itertools
+
+import pytest
+from sqlglot import exp
+from sqlglot import parse_one
+
+from giql.canonicalizer import CANON_PREFIX
+from giql.canonicalizer import canonicalize_coordinates
+from giql.dialect import GIQLDialect
+from giql.expressions import GIQLDisjoin
+from giql.generators import BaseGIQLGenerator
+from giql.resolver import META_KEY
+from giql.resolver import resolve_operator_refs
+from giql.table import Table
+from giql.table import Tables
+from giql.transpile import transpile
+
+hypothesis = pytest.importorskip("hypothesis")
+from hypothesis import given  # noqa: E402
+from hypothesis import settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+_COORD_SYSTEMS = ("0based", "1based")
+_INTERVAL_TYPES = ("half_open", "closed")
+
+
+def _tables(encoding=("0based", "half_open"), names=("variants",)) -> Tables:
+    """Build a Tables container registering each name with the given encoding."""
+    coordinate_system, interval_type = encoding
+    container = Tables()
+    for name in names:
+        container.register(
+            name,
+            Table(
+                name,
+                coordinate_system=coordinate_system,
+                interval_type=interval_type,
+            ),
+        )
+    return container
+
+
+def _prepare(query: str, tables: Tables) -> exp.Expression:
+    """Parse *query* and run passes 1 and 2 over the resulting AST."""
+    ast = parse_one(query, dialect=GIQLDialect)
+    ast = resolve_operator_refs(ast, tables)
+    return canonicalize_coordinates(ast)
+
+
+def _canon_ctes(ast: exp.Expression) -> list[exp.CTE]:
+    """Return every synthesized canonical CTE in *ast*, in declaration order."""
+    with_ = ast.args.get("with_")
+    if with_ is None:
+        return []
+    return [c for c in with_.expressions if c.alias.startswith(CANON_PREFIX)]
+
+
+def _disjoin(ast: exp.Expression) -> GIQLDisjoin:
+    """Return the single GIQLDisjoin node reachable from *ast*."""
+    return next(n for n in ast.walk() if isinstance(n, GIQLDisjoin))
+
+
+@pytest.fixture
+def disjoin_opted_in(monkeypatch):
+    """Opt GIQLDisjoin into canonicalization for the duration of a test."""
+    monkeypatch.setattr(GIQLDisjoin, "GIQL_CANONICALIZE", True, raising=False)
+    return GIQLDisjoin
+
+
+class TestNoOpWhenFlagsOff:
+    """The pass touches nothing while every GIQL_CANONICALIZE flag is off."""
+
+    def test_canonical_table_sql_unchanged(self):
+        """Test that a canonical table's SQL is byte-identical through the pass.
+
+        Given:
+            A DISJOIN over a canonical (0based/half_open) registered table and no
+            operator opted into canonicalization.
+        When:
+            Transpiling the query.
+        Then:
+            The pass is inert and the SQL matches a run with the pass bypassed.
+        """
+        # Arrange
+        query = "SELECT * FROM DISJOIN(variants)"
+        tables = _tables(("0based", "half_open"))
+        ast = resolve_operator_refs(parse_one(query, dialect=GIQLDialect), tables)
+        expected = BaseGIQLGenerator(tables=tables).generate(ast)
+
+        # Act
+        actual = transpile(query, tables=[Table("variants")])
+
+        # Assert
+        assert actual == expected
+        assert CANON_PREFIX not in actual
+
+    def test_non_canonical_table_sql_unchanged(self):
+        """Test that a non-canonical table's SQL is byte-identical through the pass.
+
+        Given:
+            A DISJOIN over a non-canonical (1based/closed) registered table and no
+            operator opted into canonicalization.
+        When:
+            Transpiling the query and comparing against a pass-bypassed run.
+        Then:
+            No wrapper CTE is synthesized and the SQL is unchanged.
+        """
+        # Arrange
+        query = "SELECT * FROM DISJOIN(variants)"
+        variants = Table("variants", coordinate_system="1based", interval_type="closed")
+        tables = Tables()
+        tables.register("variants", variants)
+        ast = resolve_operator_refs(parse_one(query, dialect=GIQLDialect), tables)
+        expected = BaseGIQLGenerator(tables=tables).generate(ast)
+
+        # Act
+        actual = transpile(query, tables=[variants])
+
+        # Assert
+        assert actual == expected
+        assert CANON_PREFIX not in actual
+
+    def test_pass_returns_expression_with_no_with_added(self):
+        """Test that the no-op pass adds no WITH clause to the AST.
+
+        Given:
+            A non-canonical DISJOIN AST and no operator opted in.
+        When:
+            Running canonicalize_coordinates directly.
+        Then:
+            No canonical CTE is present on the returned tree.
+        """
+        # Arrange
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        assert _canon_ctes(ast) == []
+
+
+class TestProjectionArithmetic:
+    """The wrapper CTE replicates canonical_start/canonical_end per encoding."""
+
+    def test_zero_based_closed_projection(self, disjoin_opted_in):
+        """Test the canonical projection for a 0based/closed table.
+
+        Given:
+            A DISJOIN over a 0based/closed table with an operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            The wrapper projects start unchanged and end + 1.
+        """
+        # Arrange
+        tables = _tables(("0based", "closed"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        body = _canon_ctes(ast)[0].this.sql()
+        assert "start AS start" in body
+        assert "(end + 1) AS end" in body
+
+    def test_one_based_half_open_projection(self, disjoin_opted_in):
+        """Test the canonical projection for a 1based/half_open table.
+
+        Given:
+            A DISJOIN over a 1based/half_open table with an operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            The wrapper projects start - 1 and end - 1.
+        """
+        # Arrange
+        tables = _tables(("1based", "half_open"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        body = _canon_ctes(ast)[0].this.sql()
+        assert "(start - 1) AS start" in body
+        assert "(end - 1) AS end" in body
+
+    def test_one_based_closed_projection(self, disjoin_opted_in):
+        """Test the canonical projection for a 1based/closed table.
+
+        Given:
+            A DISJOIN over a 1based/closed table with an operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            The wrapper projects start - 1 and end unchanged.
+        """
+        # Arrange
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        body = _canon_ctes(ast)[0].this.sql()
+        assert "(start - 1) AS start" in body
+        assert "end AS end" in body
+
+    def test_projection_preserves_custom_column_names(self, disjoin_opted_in):
+        """Test the projection uses a table's physical column names.
+
+        Given:
+            A 1based/closed table with custom chrom/start/end column names.
+        When:
+            Running pass 2.
+        Then:
+            The wrapper exposes the canonical interval under those same names.
+        """
+        # Arrange
+        variants = Table(
+            "variants",
+            chrom_col="chr",
+            start_col="lo",
+            end_col="hi",
+            coordinate_system="1based",
+            interval_type="closed",
+        )
+        tables = Tables()
+        tables.register("variants", variants)
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        body = _canon_ctes(ast)[0].this.sql()
+        assert "chr AS chr" in body
+        assert "(lo - 1) AS lo" in body
+        assert "hi AS hi" in body
+
+
+class TestPassThrough:
+    """Identity-encoded and non-table references pass through unwrapped."""
+
+    def test_identity_encoding_not_wrapped(self, disjoin_opted_in):
+        """Test that a canonical table is not wrapped even when opted in.
+
+        Given:
+            A DISJOIN over a canonical (0based/half_open) table with the operator
+            opted into canonicalization.
+        When:
+            Running pass 2.
+        Then:
+            No wrapper CTE is synthesized and the slot metadata is unchanged.
+        """
+        # Arrange
+        tables = _tables(("0based", "half_open"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        assert _canon_ctes(ast) == []
+        ref = _disjoin(ast).meta[META_KEY].slot("this")
+        assert ref.kind == "registered_table"
+
+    def test_cte_reference_not_wrapped(self, disjoin_opted_in):
+        """Test that a CTE reference passes through unwrapped.
+
+        Given:
+            A DISJOIN whose reference resolves to an enclosing CTE while its
+            target is a non-canonical registered table.
+        When:
+            Running pass 2.
+        Then:
+            Only the target is wrapped; the CTE reference is left as a CTE ref.
+        """
+        # Arrange
+        query = (
+            "WITH foo AS (SELECT * FROM other) "
+            "SELECT * FROM DISJOIN(variants, reference := foo)"
+        )
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare(query, tables)
+
+        # Assert
+        slots = _disjoin(ast).meta[META_KEY]
+        assert slots.slot("this").kind == "cte"  # target rewritten to canon CTE
+        assert slots.slot("this").name.startswith(CANON_PREFIX)
+        assert slots.slot("reference").name == "foo"  # user CTE untouched
+
+    def test_subquery_reference_not_wrapped(self, disjoin_opted_in):
+        """Test that a subquery reference passes through unwrapped.
+
+        Given:
+            A DISJOIN whose reference is a subquery and whose target is a
+            non-canonical registered table.
+        When:
+            Running pass 2.
+        Then:
+            The subquery reference stays a subquery ref carrying no Table config.
+        """
+        # Arrange
+        query = "SELECT * FROM DISJOIN(variants, reference := (SELECT * FROM other))"
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare(query, tables)
+
+        # Assert
+        ref = _disjoin(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "subquery"
+        assert ref.table is None
+
+
+class TestSlotRewrite:
+    """A wrapped slot is rewritten in both the AST and its metadata."""
+
+    def test_metadata_rewritten_to_canonical_cte(self, disjoin_opted_in):
+        """Test that a wrapped slot's ResolvedRef points at the canonical CTE.
+
+        Given:
+            A DISJOIN over a non-canonical table with the operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            The slot's ResolvedRef becomes a CTE ref naming the canon CTE and
+            carrying no Table config.
+        """
+        # Arrange
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        ref = _disjoin(ast).meta[META_KEY].slot("this")
+        assert ref.kind == "cte"
+        assert ref.name.startswith(CANON_PREFIX)
+        assert ref.table is None
+        assert ref.cols == ("chrom", "start", "end")
+
+    def test_ast_slot_points_at_canonical_cte(self, disjoin_opted_in):
+        """Test that a wrapped slot's AST node names the canonical CTE.
+
+        Given:
+            A DISJOIN over a non-canonical table with the operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            The operator's target AST node references the canon CTE by name.
+        """
+        # Arrange
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        target = _disjoin(ast).this
+        assert isinstance(target, exp.Table)
+        assert target.name.startswith(CANON_PREFIX)
+
+
+class TestDeduplication:
+    """Identical wrapper bodies collapse to a single canonical CTE."""
+
+    def test_same_table_two_slots_dedup_to_one_cte(self, disjoin_opted_in):
+        """Test that two slots over the same table share one canonical CTE.
+
+        Given:
+            A self-referencing DISJOIN over a non-canonical table (both target
+            and reference resolve to the same table) with the operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            Exactly one canonical CTE is synthesized and both slots point at it.
+        """
+        # Arrange
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        ctes = _canon_ctes(ast)
+        assert len(ctes) == 1
+        slots = _disjoin(ast).meta[META_KEY]
+        assert slots.slot("this").name == slots.slot("reference").name == ctes[0].alias
+
+    def test_distinct_tables_get_distinct_ctes(self, disjoin_opted_in):
+        """Test that two distinct non-canonical tables get distinct CTEs.
+
+        Given:
+            A DISJOIN whose target and reference are two distinct non-canonical
+            registered tables, with the operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            Two distinct canonical CTEs are synthesized.
+        """
+        # Arrange
+        tables = _tables(("1based", "closed"), names=("variants", "genes"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants, reference := genes)", tables)
+
+        # Assert
+        ctes = _canon_ctes(ast)
+        assert len(ctes) == 2
+        slots = _disjoin(ast).meta[META_KEY]
+        assert slots.slot("this").name != slots.slot("reference").name
+
+
+class TestAliasCollision:
+    """Generated aliases avoid colliding with user identifiers."""
+
+    def test_alias_avoids_user_cte_collision(self, disjoin_opted_in):
+        """Test that a generated alias dodges a same-named user CTE.
+
+        Given:
+            A query containing a user CTE literally named __giql_canon_0 and a
+            non-canonical DISJOIN, with the operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            The synthesized CTE takes a distinct, non-colliding alias.
+        """
+        # Arrange
+        query = (
+            f"WITH {CANON_PREFIX}0 AS (SELECT * FROM other) "
+            "SELECT * FROM DISJOIN(variants)"
+        )
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare(query, tables)
+
+        # Assert
+        synthesized = _disjoin(ast).meta[META_KEY].slot("this").name
+        assert synthesized.startswith(CANON_PREFIX)
+        assert synthesized != f"{CANON_PREFIX}0"
+
+    def test_alias_avoids_user_table_collision(self, disjoin_opted_in):
+        """Test that a generated alias dodges a same-named user table.
+
+        Given:
+            A query joining a user table literally named __giql_canon_0 alongside
+            a non-canonical DISJOIN, with the operator opted in.
+        When:
+            Running pass 2.
+        Then:
+            The synthesized CTE alias does not collide with that table name.
+        """
+        # Arrange
+        query = (
+            f"SELECT * FROM DISJOIN(variants) AS d JOIN {CANON_PREFIX}0 AS u ON 1 = 1"
+        )
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare(query, tables)
+
+        # Assert
+        synthesized = _disjoin(ast).meta[META_KEY].slot("this").name
+        assert synthesized != f"{CANON_PREFIX}0"
+
+
+class TestDagOrdering:
+    """Canonical CTEs are inserted before the user CTEs that may reference them."""
+
+    def test_canon_cte_prepended_before_existing_cte(self, disjoin_opted_in):
+        """Test that a synthesized CTE precedes existing user CTEs in the WITH.
+
+        Given:
+            A query with a user CTE and a non-canonical DISJOIN, opted in.
+        When:
+            Running pass 2.
+        Then:
+            The canonical CTE is the first entry in the outermost WITH clause.
+        """
+        # Arrange
+        query = "WITH userfoo AS (SELECT * FROM other) SELECT * FROM DISJOIN(variants)"
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare(query, tables)
+
+        # Assert
+        with_exprs = ast.args["with_"].expressions
+        assert with_exprs[0].alias.startswith(CANON_PREFIX)
+        assert "userfoo" in {c.alias for c in with_exprs}
+
+    def test_canon_cte_created_when_no_existing_with(self, disjoin_opted_in):
+        """Test that a fresh WITH clause is created when none exists.
+
+        Given:
+            A non-canonical DISJOIN with no enclosing WITH, opted in.
+        When:
+            Running pass 2.
+        Then:
+            A WITH clause is attached carrying the canonical CTE.
+        """
+        # Arrange
+        tables = _tables(("1based", "closed"))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        assert ast.args.get("with_") is not None
+        assert len(_canon_ctes(ast)) == 1
+
+
+class TestEncodingInvariants:
+    """Property-based coverage over the full encoding domain."""
+
+    @settings(max_examples=25, deadline=None)
+    @given(
+        coordinate_system=st.sampled_from(_COORD_SYSTEMS),
+        interval_type=st.sampled_from(_INTERVAL_TYPES),
+    )
+    def test_wrap_iff_non_canonical(self, coordinate_system, interval_type):
+        """Test that a table is wrapped exactly when its encoding is non-canonical.
+
+        Given:
+            A DISJOIN over a registered table with any encoding combination, with
+            the operator opted into canonicalization.
+        When:
+            Running passes 1 and 2.
+        Then:
+            A canonical CTE exists iff the encoding is not 0based/half_open, and a
+            wrapped slot always becomes a Table-free CTE ref.
+        """
+        # Arrange
+        # A plain try/finally toggles the class flag: @given re-runs the body
+        # many times under one function-scoped fixture, so monkeypatch is unsafe.
+        GIQLDisjoin.GIQL_CANONICALIZE = True
+        tables = _tables((coordinate_system, interval_type))
+        is_canonical = coordinate_system == "0based" and interval_type == "half_open"
+
+        # Act
+        try:
+            ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        finally:
+            del GIQLDisjoin.GIQL_CANONICALIZE
+
+        # Assert
+        ctes = _canon_ctes(ast)
+        ref = _disjoin(ast).meta[META_KEY].slot("this")
+        if is_canonical:
+            assert ctes == []
+            assert ref.kind == "registered_table"
+        else:
+            assert len(ctes) == 1
+            assert ref.kind == "cte"
+            assert ref.table is None
+
+    @settings(max_examples=25, deadline=None)
+    @given(
+        coordinate_system=st.sampled_from(_COORD_SYSTEMS),
+        interval_type=st.sampled_from(_INTERVAL_TYPES),
+    )
+    def test_flags_off_is_always_noop(self, coordinate_system, interval_type):
+        """Test that the pass never mutates the tree while flags are off.
+
+        Given:
+            A DISJOIN over a registered table with any encoding and no operator
+            opted in.
+        When:
+            Running passes 1 and 2.
+        Then:
+            No canonical CTE is ever synthesized.
+        """
+        # Arrange
+        tables = _tables((coordinate_system, interval_type))
+
+        # Act
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Assert
+        assert _canon_ctes(ast) == []
+
+
+def test_all_encoding_pairs_covered():
+    """Test that the sampled encoding domain spans every coordinate/type pair.
+
+    Given:
+        The coordinate-system and interval-type domains under test.
+    When:
+        Enumerating their product.
+    Then:
+        Exactly four encoding combinations exist, one of them canonical.
+    """
+    # Arrange
+    pairs = list(itertools.product(_COORD_SYSTEMS, _INTERVAL_TYPES))
+
+    # Act
+    canonical = [p for p in pairs if p == ("0based", "half_open")]
+
+    # Assert
+    assert len(pairs) == 4
+    assert len(canonical) == 1


### PR DESCRIPTION
## Summary

Implement step 6 of epic #114's staged migration plan — build the `CanonicalizeCoordinates` pass with wrapper-CTE synthesis. The new `src/giql/canonicalizer.py` pass runs after `ResolveOperatorRefs` (#116): for every opted-in operator reference slot resolving to a registered table with a non-canonical interval encoding, it synthesizes a hidden `__giql_canon_*` WITH-CTE projecting the relation to canonical 0-based half-open form and repoints both the AST slot and its `ResolvedRef` metadata at the canonical CTE. Synthesis follows sqlglot's `eliminate_subqueries` mechanics: taken-name collection across all scopes, `name_sequence`/`find_new_name` collision-safe aliasing, wrapper-body deduplication, and insertion ahead of any consumer on the outermost WITH. Operators opt in via a `GIQL_CANONICALIZE` class flag; none do yet, so the pass is a verified byte-identical no-op — #122 (DISJOIN) and #123 (NEAREST/DISTANCE/predicates) flip the flags and retire the in-emitter canonical arithmetic.

Closes #121

## Proposed changes

**Canonicalizer pass (`src/giql/canonicalizer.py`, new):** `canonicalize_coordinates(expression)` entry point (self-contained: encoding and column data ride on the pass-1 `ResolvedRef`, so no `tables` argument). Canonical projection arithmetic mirrors `src/giql/canonical.py` built as sqlglot expression nodes. The wrapper CTE projects the interval columns (`chrom`/`start`/`end` under their physical names); `_canonical_projection` is the isolated extension point for full-row passthrough when #122 needs `SELECT t.*` semantics. The outermost-projection de-canonicalization hook (`_decanonicalize_outputs`) is wired but inert until an operator migrates. `coverage_skippable` survives the slot rewrite.

**Pipeline wiring (`src/giql/transpile.py`):** Run the pass after `resolve_operator_refs` behind a `"Canonicalization error"` boundary.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestCanonicalizeCoordinates` | Canonical and non-canonical tables with all flags off | Transpiling | SQL is byte-identical to the pre-pass output | No-op gating |
| 2 | `TestCanonicalizeCoordinates` | A flag-enabled operator over 0based/closed, 1based/half_open, and 1based/closed tables | Running the pass | The wrapper CTE applies the correct endpoint arithmetic per encoding | Canonical projection arithmetic |
| 3 | `TestCanonicalizeCoordinates` | A flag-enabled operator over an identity-encoded table | Running the pass | No wrapper is synthesized | Identity pass-through |
| 4 | `TestCanonicalizeCoordinates` | CTE and subquery reference slots | Running the pass | They pass through unwrapped | Assumed-canonical relations |
| 5 | `TestCanonicalizeCoordinates` | A rewritten slot | Inspecting AST and metadata | Both point at the canonical CTE with `kind="cte"` and preserved cols | Slot and metadata repointing |
| 6 | `TestCanonicalizeCoordinates` | Two slots over the same non-canonical table | Running the pass | One shared wrapper CTE | Body deduplication |
| 7 | `TestCanonicalizeCoordinates` | A user CTE and a user table named `__giql_canon_0` | Running the pass | A non-colliding alias is chosen | Collision avoidance |
| 8 | `TestCanonicalizeCoordinates` | Queries with and without an existing WITH clause | Running the pass | Canonical CTEs are inserted ahead of consumers | DAG-ordered insertion |
| 9 | `TestCanonicalizeCoordinates` | Any encoding pair (Hypothesis) | Running the pass | A wrapper exists iff the encoding is non-canonical; flags-off is always a no-op | Encoding-domain invariants |