### PR TITLE
Port NEAREST to ResolveOperatorRefs resolution with declarative slot shapes — Closes #118

### DIFF
--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -20,7 +20,9 @@ from giql.range_parser import ParsedRange
 from giql.range_parser import RangeParser
 from giql.resolver import META_KEY
 from giql.resolver import OperatorResolution
+from giql.resolver import ResolvedInterval
 from giql.resolver import ResolvedRef
+from giql.resolver import resolve_operator_refs
 from giql.table import Table
 from giql.table import Tables
 
@@ -135,13 +137,42 @@ class BaseGIQLGenerator(Generator):
         # Detect mode
         mode = self._detect_nearest_mode(expression)
 
-        # Resolve target table
-        table_name, (target_chrom, target_start, target_end) = (
-            self._resolve_target_table(expression)
-        )
+        # Unpack the resolution metadata attached by ResolveOperatorRefs (pass 1).
+        resolution = self._nearest_resolution(expression)
 
-        # Resolve reference
-        ref_chrom, ref_start, ref_end = self._resolve_nearest_reference(expression, mode)
+        # Target (already a registered-table ResolvedRef from the pass). An
+        # unresolved target means it is not a registered table; raise the
+        # historical diagnostic.
+        target_ref = resolution.slot("this") if resolution is not None else None
+        if not isinstance(target_ref, ResolvedRef):
+            target = expression.this
+            if isinstance(target, exp.Table):
+                target_name = target.name
+            elif isinstance(target, exp.Column):
+                target_name = target.table if target.table else str(target.this)
+            else:
+                target_name = str(target)
+            raise ValueError(
+                f"Target table '{target_name}' not found in tables. "
+                "Register the table before transpiling."
+            )
+        table_name = target_ref.name
+        target_chrom, target_start, target_end = target_ref.cols
+        target_table = target_ref.table
+
+        # Reference interval (a ResolvedInterval from the pass). An unresolved
+        # reference re-raises the generator's historical diagnostic.
+        ref = resolution.slot("reference")
+        if not isinstance(ref, ResolvedInterval):
+            self._raise_nearest_reference_error(expression, mode, resolution)
+        if ref.kind == "literal_range":
+            # Literal endpoints are already canonical 0-based half-open.
+            ref_chrom, ref_start, ref_end = ref.chrom, ref.start, ref.end
+        else:
+            # Column / implicit-outer endpoints are raw; canonicalize here.
+            ref_chrom = ref.chrom
+            ref_start = canonical_start(ref.start, ref.table)
+            ref_end = canonical_end(ref.end, ref.table)
 
         # Extract parameters
         k = expression.args.get("k")
@@ -153,43 +184,14 @@ class BaseGIQLGenerator(Generator):
         is_stranded = self._extract_bool_param(expression.args.get("stranded"))
         is_signed = self._extract_bool_param(expression.args.get("signed"))
 
-        target_table = self.tables.get(table_name) if self.tables else None
-
-        # Resolve strand columns if stranded mode
+        # Resolve strand columns if stranded mode. The reference strand is
+        # carried on the resolved interval (a literal's strand, an explicit
+        # column's strand, or the outer table's strand for an implicit
+        # reference — already gated to preserve the historical divergence).
         ref_strand = None
         target_strand = None
         if is_stranded:
-            # Get strand column for reference
-            reference = expression.args.get("reference")
-            if reference:
-                reference_sql = self.sql(reference)
-
-                # Check if reference is a literal string or column reference
-                if reference_sql.startswith("'") or reference_sql.startswith('"'):
-                    # Literal reference - parse for strand
-                    range_str = reference_sql.strip("'\"")
-                    from giql.range_parser import RangeParser
-
-                    parsed_range = RangeParser.parse(range_str).to_zero_based_half_open()
-                    if parsed_range.strand:
-                        ref_strand = f"'{parsed_range.strand}'"
-                else:
-                    # Column reference - get strand column
-                    ref_cols = self._get_column_refs(
-                        reference_sql, None, include_strand=True
-                    )
-                    if len(ref_cols) == 4:
-                        ref_strand = ref_cols[3]
-            else:
-                # Implicit reference in correlated mode - get strand from outer table
-                outer_table = self._find_outer_table_in_lateral_join(expression)
-                if outer_table and self.tables:
-                    actual_table = self._alias_to_table.get(outer_table, outer_table)
-                    table = self.tables.get(actual_table)
-                    if table and table.strand_col:
-                        ref_strand = f'{outer_table}."{table.strand_col}"'
-
-            # Get strand column for target table
+            ref_strand = ref.strand
             if target_table and target_table.strand_col:
                 target_strand = f'{table_name}."{target_table.strand_col}"'
 
@@ -729,186 +731,86 @@ class BaseGIQLGenerator(Generator):
         # (validation will catch missing reference errors later)
         return "correlated"
 
-    def _find_outer_table_in_lateral_join(self, expression: GIQLNearest) -> str | None:
-        """Find the outer table name in a LATERAL join context.
+    def _nearest_resolution(self, expression: GIQLNearest) -> OperatorResolution | None:
+        """Return the NEAREST resolution attached by ResolveOperatorRefs (pass 1).
 
-        Walks up the AST to find the JOIN clause and extracts the outer table
-        that the LATERAL subquery is correlated with.
+        The transpile pipeline attaches an
+        :class:`~giql.resolver.OperatorResolution` before generation, and it
+        survives the generator's defensive tree copy. Direct callers that invoke
+        ``generate`` / ``giqlnearest_sql`` without running the pass (notably unit
+        tests) get the metadata resolved lazily here against this generator's
+        registered tables, so the emit path always reads resolved metadata.
 
         :param expression:
             GIQLNearest expression node
         :return:
-            Table name or alias of the outer table, or None if not found
+            The attached :class:`~giql.resolver.OperatorResolution`, or ``None``
+            if resolution did not produce one.
         """
-        # Walk up the AST to find the JOIN
-        current = expression
-        while current:
-            parent = current.parent
-            if not parent:
-                break
+        resolution = expression.meta.get(META_KEY)
+        if not isinstance(resolution, OperatorResolution):
+            resolve_operator_refs(expression.root(), self.tables)
+            resolution = expression.meta.get(META_KEY)
+        return resolution if isinstance(resolution, OperatorResolution) else None
 
-            # Check if parent is a Lateral expression
-            if isinstance(parent, exp.Lateral):
-                # Continue up to find the Join
-                current = parent
-                continue
+    def _raise_nearest_reference_error(
+        self,
+        expression: GIQLNearest,
+        mode: str,
+        resolution: OperatorResolution | None,
+    ) -> None:
+        """Raise the historical diagnostic for an unresolved NEAREST reference.
 
-            # Check if parent is a Join
-            if isinstance(parent, exp.Join):
-                # The outer table is in the parent Select's FROM clause
-                # or in previous joins
-                select = parent.parent
-                if isinstance(select, exp.Select):
-                    # Get the FROM clause
-                    from_expr = select.args.get("from_")
-                    if from_expr:
-                        # Extract table from FROM
-                        table_expr = from_expr.this
-                        if isinstance(table_expr, exp.Table):
-                            # Return alias if it exists, otherwise table name
-                            return table_expr.alias or table_expr.name
-                        elif isinstance(table_expr, exp.Alias):
-                            return table_expr.alias
-                break
-
-            current = parent
-
-        return None
-
-    def _resolve_nearest_reference(
-        self, expression: GIQLNearest, mode: str
-    ) -> tuple[str, str, str] | tuple[str, str, str, str]:
-        """Resolve the reference position for NEAREST queries.
+        ResolveOperatorRefs (pass 1) defers a reference slot it cannot resolve;
+        this re-raises the generator's pre-pass error verbatim. The implicit-
+        outer failures rely on the :class:`~giql.resolver.SlotDeferral` the pass
+        records (the ancestor walk that distinguished them now lives in the
+        pass); a literal-range parse failure is reproduced by re-parsing.
 
         :param expression:
             GIQLNearest expression node
         :param mode:
             "standalone" or "correlated"
-        :return:
-            Tuple of (chromosome, start, end) or (chromosome, start, end, strand)
-            Returns SQL expressions (column refs for correlated, literals for standalone)
-            Endpoints are canonicalized to 0-based half-open: literal references via
-            :meth:`~giql.range_parser.RangeParser.to_zero_based_half_open`, column
-            references via :func:`giql.canonical.canonical_start` /
-            :func:`giql.canonical.canonical_end`.
+        :param resolution:
+            The attached resolution metadata, if any
         :raises ValueError:
-            If reference is missing in standalone mode or invalid format
+            Always — with the matching historical message
         """
         reference = expression.args.get("reference")
 
-        if mode == "standalone":
-            if not reference:
+        if reference is None:
+            # Implicit-outer reference: standalone mode (unreachable in practice,
+            # since an absent reference is classified as correlated) keeps the
+            # historical message; otherwise consult the recorded deferral.
+            if mode == "standalone":
                 raise ValueError(
                     "NEAREST in standalone mode requires explicit reference parameter"
                 )
-
-            # Get SQL representation of reference
-            reference_sql = self.sql(reference)
-
-            # Check if it's a literal range string
-            if reference_sql.startswith("'") or reference_sql.startswith('"'):
-                # Parse literal genomic range
-                range_str = reference_sql.strip("'\"")
-                try:
-                    parsed_range = RangeParser.parse(range_str).to_zero_based_half_open()
-                    # Return as SQL literals
-                    return (
-                        f"'{parsed_range.chromosome}'",
-                        str(parsed_range.start),
-                        str(parsed_range.end),
-                    )
-                except Exception as e:
-                    raise ValueError(
-                        f"Could not parse reference genomic range: "
-                        f"{range_str}. Error: {e}"
-                    )
-            else:
-                # Column reference - resolve and canonicalize
-                chrom, start, end = self._get_column_refs(reference_sql, None)
-                ref_table = self._resolve_table(reference_sql)
-                return (
-                    chrom,
-                    canonical_start(start, ref_table),
-                    canonical_end(end, ref_table),
+            deferral = (
+                resolution.deferral("reference") if resolution is not None else None
+            )
+            if deferral is not None and deferral.reason == "implicit_outer_unregistered":
+                raise ValueError(
+                    f"Outer table '{deferral.detail}' not found in tables. "
+                    "Please specify reference parameter explicitly."
                 )
-
-        else:  # correlated mode
-            if reference:
-                # Explicit reference in correlated mode (e.g., peaks.interval)
-                reference_sql = self.sql(reference)
-                chrom, start, end = self._get_column_refs(reference_sql, None)
-                ref_table = self._resolve_table(reference_sql)
-                return (
-                    chrom,
-                    canonical_start(start, ref_table),
-                    canonical_end(end, ref_table),
-                )
-            else:
-                # Implicit reference - resolve from outer table in LATERAL join
-                outer_table = self._find_outer_table_in_lateral_join(expression)
-                if not outer_table:
-                    raise ValueError(
-                        "Could not find outer table in LATERAL join context. "
-                        "Please specify reference parameter explicitly."
-                    )
-
-                # Look up the table to find the genomic column
-                # Check if outer_table is an alias
-                actual_table = self._alias_to_table.get(outer_table, outer_table)
-                table = self.tables.get(actual_table)
-
-                if not table:
-                    raise ValueError(
-                        f"Outer table '{outer_table}' not found in tables. "
-                        "Please specify reference parameter explicitly."
-                    )
-
-                # Build column references using the outer table and genomic column
-                reference_sql = f"{outer_table}.{table.genomic_col}"
-                chrom, start, end = self._get_column_refs(reference_sql, None)
-                return (
-                    chrom,
-                    canonical_start(start, table),
-                    canonical_end(end, table),
-                )
-
-    def _resolve_target_table(
-        self, expression: GIQLNearest
-    ) -> tuple[str, tuple[str, str, str]]:
-        """Resolve the target table name and its genomic column references.
-
-        DISJOIN reads its target from the ResolveOperatorRefs metadata instead
-        (see :meth:`_disjoin_resolution`); this helper remains for NEAREST
-        until its port (epic #114, step 3).
-
-        :param expression:
-            GIQLNearest expression node
-        :return:
-            Tuple of (table_name, (chromosome_col, start_col, end_col))
-        :raises ValueError:
-            If target table is not found or doesn't have genomic columns
-        """
-        # Extract target table from 'this' argument
-        target = expression.this
-
-        if isinstance(target, exp.Table):
-            table_name = target.name
-        elif isinstance(target, exp.Column):
-            # If it's a column reference, extract table name
-            table_name = target.table if target.table else str(target.this)
-        else:
-            # Try to extract as string
-            table_name = str(target)
-
-        table = self.tables.get(table_name)
-        if not table:
             raise ValueError(
-                f"Target table '{table_name}' not found in tables. "
-                "Register the table before transpiling."
+                "Could not find outer table in LATERAL join context. "
+                "Please specify reference parameter explicitly."
             )
 
-        # Get physical column names from table config
-        return table_name, (table.chrom_col, table.start_col, table.end_col)
+        # An explicit reference that deferred is a literal range that failed to
+        # parse (column references always resolve). Re-parse to surface the
+        # original parse error in the historical message.
+        reference_sql = self.sql(reference)
+        range_str = reference_sql.strip("'\"")
+        try:
+            RangeParser.parse(range_str).to_zero_based_half_open()
+        except Exception as e:
+            raise ValueError(
+                f"Could not parse reference genomic range: {range_str}. Error: {e}"
+            )
+        raise ValueError(f"Could not parse reference genomic range: {range_str}.")
 
     def _disjoin_resolution(
         self, expression: GIQLDisjoin

--- a/src/giql/resolver.py
+++ b/src/giql/resolver.py
@@ -22,15 +22,18 @@ pass closes with a validation boundary (:func:`validate_operator_refs`) that
 asserts every operator slot carries well-formed resolution metadata, mirroring
 ``sqlglot``'s ``validate_qualify_columns`` and Spark's ``CheckAnalysis``.
 
-Scope note (epic #114, steps 1-2)
+Scope note (epic #114, steps 1-3)
 ---------------------------------
 The pass is behavior-preserving. DISJOIN's emitter
-(``BaseGIQLGenerator.giqldisjoin_sql``) consumes the attached metadata (step 2);
-the remaining operators still use the generator's legacy resolver paths and
-ignore everything attached here until their port issues land. The resolution
-semantics computed for the table-shaped reference slots mirror the generator's
-historical ``_resolve_target_table`` / ``_resolve_disjoin_reference`` /
-``_enclosing_cte_names`` behavior exactly (the latter two now live only here).
+(``BaseGIQLGenerator.giqldisjoin_sql``, step 2) and NEAREST's emitter
+(``BaseGIQLGenerator.giqlnearest_sql``, step 3) consume the attached metadata;
+DISTANCE and the spatial predicates still use the generator's legacy resolver
+paths and ignore everything attached here until their port issues land. The
+resolution semantics computed here mirror the generator's historical
+``_resolve_target_table`` / ``_resolve_disjoin_reference`` /
+``_enclosing_cte_names`` (DISJOIN) and ``_resolve_nearest_reference`` /
+``_find_outer_table_in_lateral_join`` (NEAREST) behavior exactly; all of those
+helpers now live only here.
 
 Two consequences of the zero-behavior-change constraint shape the
 implementation:
@@ -40,17 +43,19 @@ implementation:
   prefix, unsupported reference shape) the pass simply leaves that slot
   unresolved and the generator raises its existing error exactly as before.
   Promoting these into GIQL-level diagnostics is a later epic step.
-* Only *reference slots* — slots whose accepted shapes are the table
-  trichotomy (DISJOIN ``this``/``reference`` and NEAREST ``this``) — are
-  resolved to a :class:`ResolvedRef` here. The column / literal /
-  implicit-outer slots of NEAREST, DISTANCE, and the spatial predicates are
-  declared on the expression classes but their resolution metadata type is
-  designed by the per-operator port issues (#118, #119, #120).
+* Table-shaped *reference slots* (DISJOIN ``this``/``reference`` and NEAREST
+  ``this``) resolve to a :class:`ResolvedRef`. NEAREST's ``reference`` slot —
+  whose accepted shapes are the non-table literal-range / column /
+  implicit-outer forms — resolves to a :class:`ResolvedInterval` (epic #114,
+  step 3). DISTANCE and the spatial predicates still declare their column /
+  literal slots but defer resolution to their port issues (#119, #120), which
+  reuse :class:`ResolvedInterval` and :class:`SlotDeferral`.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field
 from dataclasses import replace
 from typing import Literal
 
@@ -61,6 +66,7 @@ from sqlglot.optimizer.scope import traverse_scope
 from giql.constants import DEFAULT_CHROM_COL
 from giql.constants import DEFAULT_END_COL
 from giql.constants import DEFAULT_START_COL
+from giql.constants import DEFAULT_STRAND_COL
 from giql.expressions import Contains
 from giql.expressions import GIQLDisjoin
 from giql.expressions import GIQLDistance
@@ -69,13 +75,17 @@ from giql.expressions import Intersects
 from giql.expressions import SlotSpec
 from giql.expressions import SpatialSetPredicate
 from giql.expressions import Within
+from giql.range_parser import RangeParser
 from giql.table import Table
 from giql.table import Tables
 
 __all__ = [
     "META_KEY",
     "RefKind",
+    "IntervalKind",
     "ResolvedRef",
+    "ResolvedInterval",
+    "SlotDeferral",
     "OperatorResolution",
     "ResolutionError",
     "resolve_operator_refs",
@@ -90,6 +100,14 @@ META_KEY = "giql"
 #: The kinds a resolved reference slot can take — the registered-table / CTE /
 #: subquery trichotomy that ``sqlglot``'s ``scope.sources`` distinguishes.
 RefKind = Literal["registered_table", "cte", "subquery"]
+
+#: The kinds a resolved *interval* slot can take. Unlike a :data:`RefKind`, an
+#: interval slot does not resolve to a whole relation but to a column-qualified
+#: genomic interval (``column`` / ``implicit_outer``) or a parsed literal range
+#: (``literal_range``). These are the non-table shapes NEAREST's ``reference``
+#: slot accepts; DISTANCE and the spatial predicates (#119/#120) resolve the
+#: same shapes onto the same :class:`ResolvedInterval` type.
+IntervalKind = Literal["literal_range", "column", "implicit_outer"]
 
 #: Canonical default genomic column names. A CTE or subquery reference is
 #: assumed (in the existing generator and here) to expose canonical
@@ -159,6 +177,96 @@ class ResolvedRef:
 
 
 @dataclass(frozen=True, slots=True)
+class ResolvedInterval:
+    """Resolved metadata for one non-table interval operator slot.
+
+    Where :class:`ResolvedRef` resolves a slot to a whole relation, a
+    ``ResolvedInterval`` resolves a slot to a single genomic interval expressed
+    as SQL fragments — either column references qualified by a relation alias
+    (``column`` / ``implicit_outer``) or the literal endpoints of a parsed
+    genomic range (``literal_range``). NEAREST's ``reference`` slot is the first
+    consumer; DISTANCE's two operands and the spatial predicates' column / range
+    slots (#119, #120) resolve onto this same type.
+
+    Coordinate canonicalization deliberately stays in the emitter for now
+    (epic #114 step 8 / #123). The ``start`` / ``end`` fields therefore carry
+    the *raw, un-canonicalized* column SQL for the ``column`` /
+    ``implicit_outer`` kinds — the emitter wraps them with
+    :func:`giql.canonical.canonical_start` / ``canonical_end`` using
+    :attr:`table`. For the ``literal_range`` kind the endpoints are already
+    canonical 0-based half-open integer literals (parsed via
+    :meth:`~giql.range_parser.ParsedRange.to_zero_based_half_open`) and
+    :attr:`table` is ``None``; the emitter uses them verbatim.
+
+    Attributes
+    ----------
+    kind : IntervalKind
+        Whether the interval came from a literal range, an explicit column
+        reference, or an implicit LATERAL outer relation.
+    chrom : str
+        SQL fragment for the chromosome — a quoted literal (``'chr1'``) for a
+        ``literal_range`` or a qualified column (``alias."chrom"``) otherwise.
+    start : str
+        SQL fragment for the start endpoint. Canonical literal for a
+        ``literal_range``; raw column SQL (to be canonicalized by the emitter)
+        otherwise.
+    end : str
+        SQL fragment for the end endpoint, mirroring :attr:`start`.
+    strand : str | None
+        SQL fragment for the strand — a quoted literal for a ``literal_range``
+        (``None`` when the range carries no strand), a qualified column for an
+        explicit ``column`` reference (always present), or a qualified column
+        for an ``implicit_outer`` reference only when the outer table declares a
+        strand column (``None`` otherwise). The emitter reads it only in
+        stranded mode.
+    table : Table | None
+        The :class:`~giql.table.Table` config backing a ``column`` /
+        ``implicit_outer`` interval, carried so the emitter can canonicalize the
+        endpoints; ``None`` for a ``literal_range`` (already canonical) or when
+        the qualifier resolves to no registered table.
+    """
+
+    kind: IntervalKind
+    chrom: str
+    start: str
+    end: str
+    strand: str | None
+    table: Table | None
+
+
+@dataclass(frozen=True, slots=True)
+class SlotDeferral:
+    """Why a slot was left unresolved, so the emitter raises the right error.
+
+    The resolver is behavior-preserving during the epic #114 migration: when a
+    slot cannot be resolved it is *deferred* and the generator re-raises its
+    historical diagnostic. Some of those diagnostics need information the
+    emitter can no longer recompute on its own (the resolver moved the relevant
+    scope/ancestor walk out of the generator). A ``SlotDeferral`` carries that
+    information forward.
+
+    NEAREST's implicit-outer reference is the motivating case: distinguishing
+    "no outer relation found in the LATERAL context" from "outer relation found
+    but not registered" requires the ancestor walk that now lives in this pass,
+    so the resolver records which failure occurred and, for the latter, the
+    offending relation label. DISTANCE and the spatial predicates (#119/#120)
+    reuse this channel for their own deferred-shape diagnostics.
+
+    Attributes
+    ----------
+    reason : str
+        A stable machine token naming the deferral cause (e.g.
+        ``"implicit_outer_missing"``, ``"implicit_outer_unregistered"``).
+    detail : str | None
+        Optional supporting datum for the emitter's message (e.g. the outer
+        relation label for ``"implicit_outer_unregistered"``).
+    """
+
+    reason: str
+    detail: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
 class OperatorResolution:
     """Resolution metadata attached to a single GIQL operator node.
 
@@ -166,19 +274,31 @@ class OperatorResolution:
     ----------
     operator : str
         The operator expression class name (e.g. ``"GIQLDisjoin"``).
-    slots : dict[str, ResolvedRef]
+    slots : dict[str, ResolvedRef | ResolvedInterval]
         Mapping from a slot's :attr:`~giql.expressions.SlotSpec.arg` key to its
-        resolved :class:`ResolvedRef`. Only successfully resolved reference
-        slots appear; a slot left out was either not a reference slot or could
-        not be resolved (and the generator will raise its existing error).
+        resolved metadata — a :class:`ResolvedRef` for a table-shaped reference
+        slot, or a :class:`ResolvedInterval` for an interval slot. Only
+        successfully resolved slots appear; a slot left out was either not a
+        resolvable slot or could not be resolved (and the generator raises its
+        existing error, possibly aided by :attr:`deferrals`).
+    deferrals : dict[str, SlotDeferral]
+        Mapping from a slot key to a :class:`SlotDeferral` recording why the
+        slot was deferred, when the emitter needs that context to raise the
+        historical diagnostic verbatim. Empty for slots that resolved or whose
+        deferral the emitter can reclassify unaided.
     """
 
     operator: str
-    slots: dict[str, ResolvedRef]
+    slots: dict[str, ResolvedRef | ResolvedInterval]
+    deferrals: dict[str, SlotDeferral] = field(default_factory=dict)
 
-    def slot(self, arg: str) -> ResolvedRef | None:
-        """Return the resolved reference for slot *arg*, or ``None``."""
+    def slot(self, arg: str) -> ResolvedRef | ResolvedInterval | None:
+        """Return the resolved metadata for slot *arg*, or ``None``."""
         return self.slots.get(arg)
+
+    def deferral(self, arg: str) -> SlotDeferral | None:
+        """Return the deferral recorded for slot *arg*, or ``None``."""
+        return self.deferrals.get(arg)
 
 
 def resolve_operator_refs(expression: exp.Expression, tables: Tables) -> exp.Expression:
@@ -244,7 +364,8 @@ def _resolve_operator(
     node: exp.Expression, tables: Tables, cte_names: frozenset[str]
 ) -> None:
     """Resolve *node*'s reference slots and attach an :class:`OperatorResolution`."""
-    slots: dict[str, ResolvedRef] = {}
+    slots: dict[str, ResolvedRef | ResolvedInterval] = {}
+    deferrals: dict[str, SlotDeferral] = {}
 
     if isinstance(node, GIQLDisjoin):
         target_ref = _resolve_target(node.this, tables)
@@ -258,11 +379,20 @@ def _resolve_operator(
         target_ref = _resolve_target(node.this, tables)
         if target_ref is not None:
             slots["this"] = target_ref
+        # The reference slot resolves independently of the target — a literal
+        # range parses without any registered table, and an implicit-outer
+        # reference resolves against the enclosing scope. The interval and the
+        # deferral are mutually exclusive (one is always ``None``).
+        interval, deferral = _resolve_nearest_reference(node, tables)
+        if interval is not None:
+            slots["reference"] = interval
+        if deferral is not None:
+            deferrals["reference"] = deferral
     # DISTANCE and the spatial predicates declare only column / literal slots,
     # whose resolution metadata is designed by their port issues; the pass
     # attaches an (empty-slot) resolution so every operator carries metadata.
 
-    node.meta[META_KEY] = OperatorResolution(type(node).__name__, slots)
+    node.meta[META_KEY] = OperatorResolution(type(node).__name__, slots, deferrals)
 
 
 def _target_name(target: exp.Expression) -> str:
@@ -367,6 +497,237 @@ def _resolve_disjoin_reference(
     return None
 
 
+def _resolve_nearest_reference(
+    node: GIQLNearest, tables: Tables
+) -> tuple[ResolvedInterval | None, SlotDeferral | None]:
+    """Resolve a NEAREST ``reference`` slot to a :class:`ResolvedInterval`.
+
+    Ported here (epic #114, step 3) from the generator's historical
+    ``_resolve_nearest_reference`` / ``_find_outer_table_in_lateral_join``. The
+    accepted shapes are declarative on :class:`giql.expressions.GIQLNearest`:
+
+    * **literal range** — a quoted genomic-range string, parsed to canonical
+      0-based half-open literal endpoints.
+    * **column reference** — an explicit ``alias.col`` interval, resolved
+      against the enclosing SELECT's ``FROM`` / ``JOIN`` aliases exactly as the
+      generator's ``select_sql`` builds ``_alias_to_table`` / ``_current_table``.
+    * **implicit LATERAL outer** — no reference given, resolved to the outer
+      relation of the enclosing ``CROSS JOIN LATERAL`` via the same ancestor
+      walk the generator used.
+
+    Returns ``(interval, None)`` on success or ``(None, deferral)`` when the
+    slot cannot be resolved; the generator then re-raises its historical error
+    (a ``None`` deferral means the emitter reclassifies the failure unaided, as
+    for a literal range that fails to parse).
+    """
+    reference = node.args.get("reference")
+
+    if reference is None:
+        return _resolve_implicit_outer(node, tables)
+
+    # Literal genomic-range string (e.g. 'chr1:1000-2000'). sqlglot parses it as
+    # a string Literal; the generator detected it by the leading quote on the
+    # rendered SQL.
+    if isinstance(reference, exp.Literal) and reference.is_string:
+        return _resolve_literal_range(reference.name)
+
+    # Explicit column reference (e.g. peaks.interval).
+    if isinstance(reference, exp.Column):
+        return _resolve_column_interval(node, reference.table or None, tables)
+
+    # Fallback for any other shape: mirror the generator's string-level
+    # classification on the rendered reference (quote prefix => literal,
+    # otherwise a possibly-qualified column).
+    rendered = reference.sql()
+    if rendered.startswith("'") or rendered.startswith('"'):
+        return _resolve_literal_range(rendered.strip("'\""))
+    qualifier = rendered.rsplit(".", 1)[0] if "." in rendered else None
+    return _resolve_column_interval(node, qualifier, tables)
+
+
+def _resolve_literal_range(
+    range_str: str,
+) -> tuple[ResolvedInterval | None, SlotDeferral | None]:
+    """Resolve a literal genomic-range reference to canonical literal endpoints.
+
+    Defers (``(None, None)``) when the range fails to parse; the generator
+    re-parses and raises the historical "Could not parse reference genomic
+    range" diagnostic with the original exception text.
+    """
+    try:
+        parsed = RangeParser.parse(range_str).to_zero_based_half_open()
+    except Exception:
+        return None, None
+    strand = f"'{parsed.strand}'" if parsed.strand else None
+    return (
+        ResolvedInterval(
+            kind="literal_range",
+            chrom=f"'{parsed.chromosome}'",
+            start=str(parsed.start),
+            end=str(parsed.end),
+            strand=strand,
+            table=None,
+        ),
+        None,
+    )
+
+
+def _resolve_column_interval(
+    node: GIQLNearest, qualifier: str | None, tables: Tables
+) -> tuple[ResolvedInterval, None]:
+    """Resolve an explicit column reference to a column :class:`ResolvedInterval`.
+
+    Mirrors the generator's ``_get_column_refs`` / ``_resolve_table`` for an
+    explicit reference: the *qualifier* (the column's relation alias) is kept
+    verbatim for output, while the backing :class:`~giql.table.Table` — and thus
+    the physical column names and coordinate system — is looked up by resolving
+    that alias through the enclosing SELECT's alias map. An unresolved qualifier
+    falls back to default column names and no table (so the emitter applies no
+    canonicalization), exactly as the generator did. The strand column is always
+    emitted for an explicit reference, matching ``include_strand=True``.
+    """
+    table = _lookup_aliased_table(node, qualifier, tables)
+    chrom_col = table.chrom_col if table else DEFAULT_CHROM_COL
+    start_col = table.start_col if table else DEFAULT_START_COL
+    end_col = table.end_col if table else DEFAULT_END_COL
+    strand_col = table.strand_col if (table and table.strand_col) else DEFAULT_STRAND_COL
+    prefix = f"{qualifier}." if qualifier else ""
+    return (
+        ResolvedInterval(
+            kind="column",
+            chrom=f'{prefix}"{chrom_col}"',
+            start=f'{prefix}"{start_col}"',
+            end=f'{prefix}"{end_col}"',
+            strand=f'{prefix}"{strand_col}"',
+            table=table,
+        ),
+        None,
+    )
+
+
+def _resolve_implicit_outer(
+    node: GIQLNearest, tables: Tables
+) -> tuple[ResolvedInterval | None, SlotDeferral | None]:
+    """Resolve an implicit-outer reference from the enclosing LATERAL join.
+
+    Mirrors the generator's ``_find_outer_table_in_lateral_join`` followed by
+    its outer-table column resolution: the outer relation's label (alias or
+    name) qualifies the emitted columns, while the backing table is resolved by
+    mapping that label through the enclosing SELECT's alias map. Unlike an
+    explicit reference, the strand column is emitted only when the outer table
+    declares one — preserving the generator's divergent strand handling between
+    the two paths.
+
+    Defers with a :class:`SlotDeferral` when no outer relation is found
+    (``implicit_outer_missing``) or the outer relation is unregistered
+    (``implicit_outer_unregistered``, carrying the offending label); the
+    generator raises the matching historical diagnostic.
+    """
+    outer_label = _find_outer_table(node)
+    if outer_label is None:
+        return None, SlotDeferral("implicit_outer_missing")
+
+    alias_map, _current = _enclosing_alias_map(node)
+    actual_name = alias_map.get(outer_label, outer_label)
+    table = tables.get(actual_name)
+    if table is None:
+        return None, SlotDeferral("implicit_outer_unregistered", outer_label)
+
+    strand = f'{outer_label}."{table.strand_col}"' if table.strand_col else None
+    return (
+        ResolvedInterval(
+            kind="implicit_outer",
+            chrom=f'{outer_label}."{table.chrom_col}"',
+            start=f'{outer_label}."{table.start_col}"',
+            end=f'{outer_label}."{table.end_col}"',
+            strand=strand,
+            table=table,
+        ),
+        None,
+    )
+
+
+def _lookup_aliased_table(
+    node: GIQLNearest, qualifier: str | None, tables: Tables
+) -> Table | None:
+    """Resolve the :class:`~giql.table.Table` backing a qualified column.
+
+    Replicates the generator's ``_resolve_table`` / ``_resolve_table_name``: a
+    dotted reference's *qualifier* is mapped to a registered-table name through
+    the enclosing SELECT's alias map (with ``_current_table`` as the FROM-clause
+    fallback); an unqualified reference resolves to no table.
+    """
+    if not qualifier:
+        return None
+    alias_map, current_table = _enclosing_alias_map(node)
+    table_name = alias_map.get(qualifier, current_table)
+    return tables.get(table_name) if table_name else None
+
+
+def _enclosing_alias_map(node: exp.Expression) -> tuple[dict[str, str], str | None]:
+    """Build the alias->table map of *node*'s enclosing SELECT.
+
+    Mirrors ``BaseGIQLGenerator.select_sql`` exactly: the FROM-clause table and
+    every JOIN-clause table contribute an ``(alias or name) -> name`` entry, and
+    the FROM-clause table name is the ``_current_table`` fallback. Only direct
+    ``exp.Table`` operands participate (a LATERAL/derived join contributes
+    nothing), matching the generator. CTE and derived-table aliasing is out of
+    scope here because NEAREST column references resolve against physical
+    relations, exactly as the generator's hand-rolled map did.
+    """
+    select = node.parent_select
+    alias_to_table: dict[str, str] = {}
+    current_table: str | None = None
+    if isinstance(select, exp.Select):
+        from_ = select.args.get("from_")
+        if from_ is not None and isinstance(from_.this, exp.Table):
+            current_table = from_.this.name
+            if from_.this.alias:
+                alias_to_table[from_.this.alias] = current_table
+            else:
+                alias_to_table[current_table] = current_table
+        for join in select.args.get("joins") or []:
+            if isinstance(join.this, exp.Table):
+                name = join.this.name
+                if join.this.alias:
+                    alias_to_table[join.this.alias] = name
+                else:
+                    alias_to_table[name] = name
+    return alias_to_table, current_table
+
+
+def _find_outer_table(node: exp.Expression) -> str | None:
+    """Find the outer relation label of *node*'s enclosing LATERAL join.
+
+    Walks up from the NEAREST node through the enclosing ``exp.Lateral`` to the
+    ``exp.Join``, then reads the join-owning SELECT's FROM-clause relation,
+    returning its alias or name. A byte-for-byte port of the generator's
+    ``_find_outer_table_in_lateral_join``; returns ``None`` when no such outer
+    relation exists (e.g. a standalone NEAREST).
+    """
+    current: exp.Expression | None = node
+    while current is not None:
+        parent = current.parent
+        if parent is None:
+            break
+        if isinstance(parent, exp.Lateral):
+            current = parent
+            continue
+        if isinstance(parent, exp.Join):
+            select = parent.parent
+            if isinstance(select, exp.Select):
+                from_ = select.args.get("from_")
+                if from_ is not None:
+                    table_expr = from_.this
+                    if isinstance(table_expr, exp.Table):
+                        return table_expr.alias or table_expr.name
+                    elif isinstance(table_expr, exp.Alias):
+                        return table_expr.alias
+            break
+        current = parent
+    return None
+
+
 def validate_operator_refs(expression: exp.Expression) -> None:
     """Assert every GIQL operator carries well-formed resolution metadata.
 
@@ -407,14 +768,41 @@ def validate_operator_refs(expression: exp.Expression) -> None:
 
         specs: tuple[SlotSpec, ...] = getattr(node, "GIQL_SLOTS", ())
         for spec in specs:
-            if not spec.is_ref_slot:
+            resolved = resolution.slots.get(spec.arg)
+            if resolved is None:
+                # Deferred: an unresolved slot is handled by the generator on
+                # its existing path (and may carry a SlotDeferral).
                 continue
-            ref = resolution.slots.get(spec.arg)
-            if ref is None:
-                # Deferred: unresolved reference slots are handled by the
-                # generator on its existing path in step 1.
-                continue
-            _validate_ref(ref, spec, type(node).__name__)
+            if spec.is_ref_slot:
+                _validate_ref(resolved, spec, type(node).__name__)
+            else:
+                _validate_interval(resolved, spec, type(node).__name__)
+
+
+def _validate_interval(interval: object, spec: SlotSpec, operator: str) -> None:
+    """Assert a single resolved interval is well-formed against its slot spec."""
+    if not isinstance(interval, ResolvedInterval):
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} carries {type(interval).__name__}, "
+            "expected ResolvedInterval."
+        )
+    if interval.kind not in spec.accepts:
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} resolved to kind {interval.kind!r}, "
+            f"which is not accepted by the slot (accepts {sorted(spec.accepts)})."
+        )
+    if not all(
+        isinstance(part, str) for part in (interval.chrom, interval.start, interval.end)
+    ):
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} has malformed interval endpoints; "
+            "expected SQL fragment strings for chrom/start/end."
+        )
+    if interval.kind == "literal_range" and interval.table is not None:
+        raise ResolutionError(
+            f"{operator} slot {spec.arg!r} resolved to a literal_range but "
+            "carries a Table config; literal ranges are already canonical."
+        )
 
 
 def _validate_ref(ref: object, spec: SlotSpec, operator: str) -> None:

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -566,6 +566,31 @@ class TestBaseGIQLGenerator:
         )
         assert output == expected
 
+    def test_giqlnearest_sql_implicit_outer_without_strand_column(self):
+        """
+        GIVEN a stranded NEAREST whose implicit-outer table declares no strand
+            column
+        WHEN the query is generated
+        THEN no strand filtering is emitted, preserving the divergence between
+            the explicit-column and implicit-outer reference paths.
+        """
+        # Arrange
+        tables = Tables()
+        tables.register("nostr", Table("nostr", strand_col=None))
+        tables.register("genes", Table("genes"))
+        sql = (
+            "SELECT * FROM nostr "
+            "CROSS JOIN LATERAL NEAREST(genes, k := 1, stranded := true)"
+        )
+        ast = parse_one(sql, dialect=GIQLDialect)
+
+        # Act
+        output = BaseGIQLGenerator(tables=tables).generate(ast)
+
+        # Assert
+        assert "strand" not in output
+        assert 'nostr."chrom" = genes."chrom"' in output
+
     def test_giqlnearest_sql_signed(self, tables_with_peaks_and_genes):
         """
         GIVEN a GIQLNearest with signed := true
@@ -914,8 +939,7 @@ class TestBaseGIQLGenerator:
         tables = Tables()
         tables.register("genes_closed", Table("genes_closed", interval_type="closed"))
         sql = (
-            "SELECT * FROM NEAREST("
-            "genes_closed, reference := 'chr1:1000-2000', k := 3)"
+            "SELECT * FROM NEAREST(genes_closed, reference := 'chr1:1000-2000', k := 3)"
         )
         ast = parse_one(sql, dialect=GIQLDialect)
         generator = BaseGIQLGenerator(tables=tables)
@@ -981,24 +1005,22 @@ class TestBaseGIQLGenerator:
 
     def test_giqlnearest_sql_outer_table_not_in_tables(self):
         """
-        GIVEN a GIQLNearest in correlated mode where outer table is not registered
-        WHEN giqlnearest_sql is called
+        GIVEN a NEAREST whose implicit-outer relation is found but not registered
+        WHEN the query is generated
         THEN ValueError is raised listing the issue.
         """
         tables = Tables()
         tables.register("genes", Table("genes"))
 
-        nearest = GIQLNearest(
-            this=exp.Table(this=exp.Identifier(this="genes")),
-            k=exp.Literal.number(3),
-        )
+        # The outer relation (unknown_table) is present in the LATERAL context
+        # but is not a registered table, so the implicit-outer reference defers.
+        sql = "SELECT * FROM unknown_table CROSS JOIN LATERAL NEAREST(genes, k := 3)"
+        ast = parse_one(sql, dialect=GIQLDialect)
 
         generator = BaseGIQLGenerator(tables=tables)
-        generator._alias_to_table = {"unknown_table": "unknown_table"}
-        generator._find_outer_table_in_lateral_join = lambda x: "unknown_table"
 
         with pytest.raises(ValueError, match="not found in tables"):
-            generator.giqlnearest_sql(nearest)
+            generator.generate(ast)
 
     def test_giqlnearest_sql_invalid_reference_range(self, tables_with_peaks_and_genes):
         """
@@ -1261,8 +1283,7 @@ class TestBaseGIQLGenerator:
 
         # Assert
         expected = (
-            "SELECT * FROM variants WHERE "
-            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+            f"SELECT * FROM variants WHERE (\"chrom\" = 'chr1' AND {expected_predicate})"
         )
         assert output == expected
 
@@ -1318,8 +1339,7 @@ class TestBaseGIQLGenerator:
 
         # Assert
         expected = (
-            "SELECT * FROM variants WHERE "
-            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+            f"SELECT * FROM variants WHERE (\"chrom\" = 'chr1' AND {expected_predicate})"
         )
         assert output == expected
 
@@ -1375,8 +1395,7 @@ class TestBaseGIQLGenerator:
 
         # Assert
         expected = (
-            "SELECT * FROM variants WHERE "
-            f"(\"chrom\" = 'chr1' AND {expected_predicate})"
+            f"SELECT * FROM variants WHERE (\"chrom\" = 'chr1' AND {expected_predicate})"
         )
         assert output == expected
 
@@ -1545,24 +1564,39 @@ class TestBaseGIQLGenerator:
         "coordinate_system, interval_type, start_a, end_a, start_b, end_b",
         [
             pytest.param(
-                "0based", "half_open",
-                'a."start"', 'a."end"', 'b."start"', 'b."end"',
+                "0based",
+                "half_open",
+                'a."start"',
+                'a."end"',
+                'b."start"',
+                'b."end"',
                 id="0based-half_open",
             ),
             pytest.param(
-                "0based", "closed",
-                'a."start"', '(a."end" + 1)', 'b."start"', '(b."end" + 1)',
+                "0based",
+                "closed",
+                'a."start"',
+                '(a."end" + 1)',
+                'b."start"',
+                '(b."end" + 1)',
                 id="0based-closed",
             ),
             pytest.param(
-                "1based", "half_open",
-                '(a."start" - 1)', '(a."end" - 1)',
-                '(b."start" - 1)', '(b."end" - 1)',
+                "1based",
+                "half_open",
+                '(a."start" - 1)',
+                '(a."end" - 1)',
+                '(b."start" - 1)',
+                '(b."end" - 1)',
                 id="1based-half_open",
             ),
             pytest.param(
-                "1based", "closed",
-                '(a."start" - 1)', 'a."end"', '(b."start" - 1)', 'b."end"',
+                "1based",
+                "closed",
+                '(a."start" - 1)',
+                'a."end"',
+                '(b."start" - 1)',
+                'b."end"',
                 id="1based-closed",
             ),
         ],
@@ -1660,23 +1694,31 @@ class TestBaseGIQLGenerator:
         "coordinate_system, interval_type, target_start, target_end",
         [
             pytest.param(
-                "0based", "half_open",
-                'genes."start"', 'genes."end"',
+                "0based",
+                "half_open",
+                'genes."start"',
+                'genes."end"',
                 id="0based-half_open",
             ),
             pytest.param(
-                "0based", "closed",
-                'genes."start"', '(genes."end" + 1)',
+                "0based",
+                "closed",
+                'genes."start"',
+                '(genes."end" + 1)',
                 id="0based-closed",
             ),
             pytest.param(
-                "1based", "half_open",
-                '(genes."start" - 1)', '(genes."end" - 1)',
+                "1based",
+                "half_open",
+                '(genes."start" - 1)',
+                '(genes."end" - 1)',
                 id="1based-half_open",
             ),
             pytest.param(
-                "1based", "closed",
-                '(genes."start" - 1)', 'genes."end"',
+                "1based",
+                "closed",
+                '(genes."start" - 1)',
+                'genes."end"',
                 id="1based-closed",
             ),
         ],
@@ -1715,9 +1757,7 @@ class TestBaseGIQLGenerator:
 
         # Assert — distance CASE expression uses canonicalized target endpoints
         # against the (already-canonical) literal reference [1000, 2000).
-        assert (
-            f"WHEN 1000 < {target_end} AND 2000 > {target_start} THEN 0" in output
-        )
+        assert f"WHEN 1000 < {target_end} AND 2000 > {target_start} THEN 0" in output
         assert f"WHEN 2000 <= {target_start} THEN ({target_start} - 2000)" in output
         assert f"ELSE (1000 - {target_end})" in output
 
@@ -1769,9 +1809,7 @@ class TestBaseGIQLGenerator:
             leaving end raw — while leaving bed_a's target columns raw.
         """
         # Arrange
-        sql = (
-            "SELECT * FROM vcf_b CROSS JOIN LATERAL NEAREST(bed_a, k := 1)"
-        )
+        sql = "SELECT * FROM vcf_b CROSS JOIN LATERAL NEAREST(bed_a, k := 1)"
         ast = parse_one(sql, dialect=GIQLDialect)
         generator = BaseGIQLGenerator(tables=tables_mixed_conventions)
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -18,6 +18,7 @@ from giql.expressions import SpatialSetPredicate
 from giql.resolver import META_KEY
 from giql.resolver import OperatorResolution
 from giql.resolver import ResolutionError
+from giql.resolver import ResolvedInterval
 from giql.resolver import ResolvedRef
 from giql.resolver import resolve_operator_refs
 from giql.resolver import validate_operator_refs
@@ -45,6 +46,11 @@ def _tables(*names: str) -> Tables:
 def _disjoin_node(ast: exp.Expression) -> GIQLDisjoin:
     """Return the single GIQLDisjoin node reachable from an annotated AST."""
     return next(n for n in ast.walk() if isinstance(n, GIQLDisjoin))
+
+
+def _nearest_node(ast: exp.Expression) -> GIQLNearest:
+    """Return the single GIQLNearest node reachable from an annotated AST."""
+    return next(n for n in ast.walk() if isinstance(n, GIQLNearest))
 
 
 class TestResolveOperatorRefs:
@@ -278,6 +284,226 @@ class TestResolveOperatorRefs:
         assert ref.kind == "registered_table"
         assert ref.name == "genes"
 
+    def test_resolve_operator_refs_resolves_nearest_literal_reference(self):
+        """Test that a NEAREST literal-range reference resolves to canonical literals.
+
+        Given:
+            A standalone NEAREST with a literal genomic-range reference.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach a literal_range ResolvedInterval carrying quoted
+            chrom and canonical 0-based half-open endpoint literals and no Table.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(genes, reference := 'chr1:1000-2000', k := 3)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("genes"))
+
+        # Assert
+        ref = _nearest_node(ast).meta[META_KEY].slot("reference")
+        assert ref == ResolvedInterval(
+            kind="literal_range",
+            chrom="'chr1'",
+            start="1000",
+            end="2000",
+            strand=None,
+            table=None,
+        )
+
+    def test_resolve_operator_refs_resolves_nearest_stranded_literal(self):
+        """Test that a stranded literal-range reference carries its strand literal.
+
+        Given:
+            A standalone NEAREST whose literal reference encodes a strand.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach a literal_range ResolvedInterval carrying the strand
+            as a quoted literal.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(genes, reference := 'chr1:1000-2000:+', k := 3)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("genes"))
+
+        # Assert
+        ref = _nearest_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "literal_range"
+        assert ref.strand == "'+'"
+
+    def test_resolve_operator_refs_defers_unparseable_literal_reference(self):
+        """Test that an unparseable literal reference is deferred without a record.
+
+        Given:
+            A standalone NEAREST whose literal reference cannot be parsed.
+        When:
+            Running the resolve pass.
+        Then:
+            It should leave the reference slot unresolved with no deferral
+            record, so the generator re-parses and raises its historical error.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(genes, reference := 'invalid_range', k := 3)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("genes"))
+
+        # Assert
+        resolution = _nearest_node(ast).meta[META_KEY]
+        assert resolution.slot("reference") is None
+        assert resolution.deferral("reference") is None
+
+    def test_resolve_operator_refs_resolves_nearest_column_reference(self):
+        """Test that an explicit column reference resolves to qualified columns.
+
+        Given:
+            A correlated NEAREST whose reference is an aliased outer column
+            (``p.interval`` where ``p`` aliases a registered table).
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach a column ResolvedInterval whose endpoints keep the
+            alias verbatim and whose Table config comes from the aliased table.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM peaks AS p "
+            "CROSS JOIN LATERAL NEAREST(genes, reference := p.interval, k := 3)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("peaks", "genes"))
+
+        # Assert
+        ref = _nearest_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "column"
+        assert ref.chrom == 'p."chrom"'
+        assert ref.start == 'p."start"'
+        assert ref.end == 'p."end"'
+        assert ref.strand == 'p."strand"'
+        assert ref.table is not None and ref.table.name == "peaks"
+
+    def test_resolve_operator_refs_resolves_implicit_outer_reference(self):
+        """Test that an omitted reference resolves to the LATERAL outer relation.
+
+        Given:
+            A correlated NEAREST with no reference inside a CROSS JOIN LATERAL
+            over a registered outer table.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach an implicit_outer ResolvedInterval qualified by the
+            outer relation and backed by the outer table's config.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM peaks CROSS JOIN LATERAL NEAREST(genes, k := 3)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("peaks", "genes"))
+
+        # Assert
+        ref = _nearest_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "implicit_outer"
+        assert ref.chrom == 'peaks."chrom"'
+        assert ref.strand == 'peaks."strand"'
+        assert ref.table is not None and ref.table.name == "peaks"
+
+    def test_resolve_operator_refs_implicit_outer_omits_strand_without_column(self):
+        """Test that an implicit-outer reference omits strand when the table has none.
+
+        Given:
+            A correlated NEAREST over an outer table configured without a strand
+            column.
+        When:
+            Running the resolve pass.
+        Then:
+            It should attach an implicit_outer ResolvedInterval whose strand is
+            None, preserving the generator's divergent strand handling.
+        """
+        # Arrange
+        tables = Tables()
+        tables.register("nostr", Table("nostr", strand_col=None))
+        tables.register("genes", Table("genes"))
+        ast = parse_one(
+            "SELECT * FROM nostr CROSS JOIN LATERAL NEAREST(genes, k := 1)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, tables)
+
+        # Assert
+        ref = _nearest_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "implicit_outer"
+        assert ref.strand is None
+
+    def test_resolve_operator_refs_defers_implicit_outer_missing(self):
+        """Test that a missing LATERAL outer relation records a deferral.
+
+        Given:
+            A NEAREST with no reference and no enclosing LATERAL outer relation.
+        When:
+            Running the resolve pass.
+        Then:
+            It should leave the reference unresolved and record an
+            implicit_outer_missing deferral for the generator's error.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(genes, k := 3)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("genes"))
+
+        # Assert
+        resolution = _nearest_node(ast).meta[META_KEY]
+        assert resolution.slot("reference") is None
+        assert resolution.deferral("reference").reason == "implicit_outer_missing"
+
+    def test_resolve_operator_refs_defers_implicit_outer_unregistered(self):
+        """Test that an unregistered LATERAL outer relation records its label.
+
+        Given:
+            A NEAREST with no reference whose enclosing LATERAL outer relation is
+            found but not registered.
+        When:
+            Running the resolve pass.
+        Then:
+            It should record an implicit_outer_unregistered deferral carrying the
+            offending outer-relation label.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM unknown_table CROSS JOIN LATERAL NEAREST(genes, k := 3)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("genes"))
+
+        # Assert
+        deferral = _nearest_node(ast).meta[META_KEY].deferral("reference")
+        assert deferral.reason == "implicit_outer_unregistered"
+        assert deferral.detail == "unknown_table"
+
     def test_resolve_operator_refs_returns_same_expression(self):
         """Test that the pass annotates and returns the same AST in place.
 
@@ -372,15 +598,17 @@ class TestResolveOperatorRefs:
         assert predicate.meta[META_KEY].slots == {}
 
     def test_resolve_operator_refs_unregistered_nearest_target_left_unresolved(self):
-        """Test that an unregistered NEAREST target leaves the slot unresolved.
+        """Test that an unregistered NEAREST target leaves the target slot unresolved.
 
         Given:
-            A NEAREST whose target table is not registered.
+            A NEAREST whose target table is not registered (its literal-range
+            reference resolves independently of the target).
         When:
             Running the resolve pass.
         Then:
-            It should attach an OperatorResolution with no resolved slots,
-            deferring the error to the generator.
+            It should attach an OperatorResolution whose target slot is
+            unresolved, deferring the target error to the generator, while the
+            literal reference still resolves.
         """
         # Arrange
         ast = parse_one(
@@ -393,7 +621,8 @@ class TestResolveOperatorRefs:
 
         # Assert
         nearest = next(n for n in ast.walk() if isinstance(n, GIQLNearest))
-        assert nearest.meta[META_KEY].slots == {}
+        assert nearest.meta[META_KEY].slot("this") is None
+        assert nearest.meta[META_KEY].slot("reference").kind == "literal_range"
 
     @settings(max_examples=50)
     @given(names=st.lists(_identifiers, min_size=4, max_size=4, unique=True))
@@ -614,4 +843,94 @@ class TestValidateOperatorRefs:
 
         # Act & assert
         with pytest.raises(ResolutionError, match="expected ResolvedRef"):
+            validate_operator_refs(ast)
+
+    def test_validate_operator_refs_accepts_resolved_interval(self):
+        """Test that validation accepts a well-formed interval slot.
+
+        Given:
+            A NEAREST annotated by the resolve pass with a resolved interval
+            reference.
+        When:
+            Running validation over it.
+        Then:
+            It should not raise.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(genes, reference := 'chr1:1000-2000', k := 3)",
+            dialect=GIQLDialect,
+        )
+        resolve_operator_refs(ast, _tables("genes"))
+
+        # Act & assert
+        validate_operator_refs(ast)
+
+    def test_validate_operator_refs_rejects_disallowed_interval_kind(self):
+        """Test that validation rejects an interval slot of a disallowed kind.
+
+        Given:
+            A NEAREST reference slot annotated with a ResolvedInterval whose kind
+            (a table-shaped ``registered_table``) the slot does not accept.
+        When:
+            Running validation over the tree.
+        Then:
+            It should raise a ResolutionError naming the rejected kind.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(genes, reference := 'chr1:1000-2000', k := 3)",
+            dialect=GIQLDialect,
+        )
+        node = _nearest_node(ast)
+        node.meta[META_KEY] = OperatorResolution(
+            "GIQLNearest",
+            {
+                "reference": ResolvedInterval(
+                    kind="registered_table",
+                    chrom="'chr1'",
+                    start="1000",
+                    end="2000",
+                    strand=None,
+                    table=None,
+                )
+            },
+        )
+
+        # Act & assert
+        with pytest.raises(ResolutionError, match="not accepted"):
+            validate_operator_refs(ast)
+
+    def test_validate_operator_refs_rejects_non_resolvedinterval_slot_value(self):
+        """Test that validation rejects an interval slot holding the wrong type.
+
+        Given:
+            A NEAREST reference slot whose resolution metadata holds a
+            ResolvedRef instead of a ResolvedInterval.
+        When:
+            Running validation over the tree.
+        Then:
+            It should raise a ResolutionError naming the expected type.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM NEAREST(genes, reference := 'chr1:1000-2000', k := 3)",
+            dialect=GIQLDialect,
+        )
+        node = _nearest_node(ast)
+        node.meta[META_KEY] = OperatorResolution(
+            "GIQLNearest",
+            {
+                "reference": ResolvedRef(
+                    kind="registered_table",
+                    name="genes",
+                    cols=("chrom", "start", "end"),
+                    table=Table("genes"),
+                    coverage_skippable=False,
+                )
+            },
+        )
+
+        # Act & assert
+        with pytest.raises(ResolutionError, match="expected ResolvedInterval"):
             validate_operator_refs(ast)


### PR DESCRIPTION
## Summary

Implement step 3 of epic #114's staged migration plan — port NEAREST to `ResolveOperatorRefs` resolution with declarative slot shapes. The resolver pass now resolves NEAREST's reference slot across its three declared forms: a literal genomic range (pre-canonicalized endpoints), a column reference (raw alias-qualified column SQL), and the implicit LATERAL outer form detected from scope ancestry. A new frozen `ResolvedInterval` dataclass models these non-table shapes, and a companion `SlotDeferral` channel records unresolvable slots so the emitter raises the historical diagnostics verbatim. `giqlnearest_sql` reads target and reference exclusively from the attached metadata; the generator's `_resolve_target_table`, `_resolve_nearest_reference`, and `_find_outer_table_in_lateral_join` helpers are deleted. Generated SQL is byte-identical, verified across 17 golden shapes spanning reference form × stranded/signed/max_distance × table encodings, and all five historical error messages are reproduced verbatim.

Closes #118

## Proposed changes

**Resolver (`src/giql/resolver.py`):** Add `ResolvedInterval` (kind = `literal_range` / `column` / `implicit_outer`) and `SlotDeferral`; broaden `OperatorResolution.slots` to hold either ref or interval metadata and add a `deferrals` map. NEAREST reference resolution replicates the deleted generator helpers exactly, including the alias-to-table mapping previously built by `select_sql` state (now derived from scope ancestry via `_enclosing_alias_map`) and the strand divergence between explicit column references (always carry a strand column) and implicit outer references (only when the table declares one). The validation boundary gains interval-slot arms.

**NEAREST emitter (`src/giql/generators/base.py`):** `giqlnearest_sql` consumes `ResolvedRef` + `ResolvedInterval`; coordinate canonicalization stays in the emitter (its removal is #123, after #121's `CanonicalizeCoordinates`). `_nearest_resolution` lazily runs the pass for direct `generate()` callers that bypass the `transpile()` pipeline, and `_raise_nearest_reference_error` maps deferrals to the legacy errors. Net emitter change −197/+101 lines.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestResolveOperatorRefs` | A standalone NEAREST with a literal reference | Running the pass | A `literal_range` interval with canonical endpoints | Literal resolution |
| 2 | `TestResolveOperatorRefs` | A stranded literal reference | Running the pass | The interval carries the parsed strand literal | Stranded literals |
| 3 | `TestResolveOperatorRefs` | An explicit column reference through a join alias | Running the pass | A `column` interval with alias-qualified physical columns | Column resolution |
| 4 | `TestResolveOperatorRefs` | NEAREST in a CROSS JOIN LATERAL with no reference | Running the pass | An `implicit_outer` interval resolved from the outer table | Implicit-outer detection |
| 5 | `TestResolveOperatorRefs` | Unresolvable references (missing outer, unregistered outer, unparseable literal) | Running the pass | A `SlotDeferral` recording the reason | Deferral channel |
| 6 | `TestValidateOperatorRefs` | Malformed interval metadata | Running validation | `ResolutionError` | Interval validation arms |
| 7 | `TestBaseGIQLGenerator` | A LATERAL NEAREST over an unregistered outer table | Generating SQL | The historical "not found in tables" error | Real-path regression (was a monkeypatch) |
| 8 | `TestBaseGIQLGenerator` | Explicit column vs implicit outer reference on a strandless table | Generating stranded SQL | Strand column emitted only for the explicit form | Strand divergence pin |