### PR TITLE
Validate CTE and subquery projection contracts in ResolveOperatorRefs — Closes #124

### DIFF
--- a/docs/recipes/disjoin.rst
+++ b/docs/recipes/disjoin.rst
@@ -80,6 +80,36 @@ single bin.
    engines need their own generator. The grid must also span every chromosome
    present in ``features``, or features on an uncovered chromosome are dropped.
 
+The CTE / Subquery Reference Contract
+-------------------------------------
+
+When the ``reference`` operand is an in-query CTE or a ``(SELECT ...)``
+subquery (rather than a registered table), it **must** project the canonical
+``chrom`` / ``start`` / ``end`` columns -- the 0-based, half-open genomic
+coordinates the operator references. A registered table may declare a custom
+column mapping or coordinate system, but a CTE or subquery carries no such
+declaration, so GIQL assumes it is already canonical.
+
+GIQL validates this contract at transpile time. If a CTE or subquery operand
+omits one of the canonical columns, ``transpile()`` raises a ``ValueError``
+naming the operator, the offending relation, and the missing column(s) -- a
+clear GIQL-level diagnostic rather than an opaque engine ``column not found``
+error at execution time. For example, ``reference := (SELECT chrom, start FROM
+mask)`` is rejected because it omits ``end``.
+
+.. code-block:: sql
+
+   -- Valid: the subquery projects all three canonical columns
+   SELECT * FROM DISJOIN(features, reference := (
+       SELECT chrom, start, "end" FROM mask WHERE score > 10
+   ))
+
+This check is best-effort. When the operand's output columns cannot be
+determined statically -- a ``SELECT *`` star projection, or a placeholder such
+as ``SELECT 1`` -- the operand is passed through without a diagnostic (the
+relation's schema is unknown at transpile time), and a genuinely missing column
+would still surface as an engine error at execution time.
+
 Coming from Bedtools?
 ---------------------
 

--- a/docs/transpilation/schema-mapping.rst
+++ b/docs/transpilation/schema-mapping.rst
@@ -186,9 +186,13 @@ If your data uses 1-based coordinates (like VCF or GFF), configure the
 
    To target a non-``REPLACE`` engine today, store your data in 0-based
    half-open form, or convert it explicitly in a CTE and reference that CTE
-   (which GIQL treats as already canonical). Making canonicalization emit
-   portable SQL on every engine is tracked in
-   `#132 <https://github.com/abdenlab/giql/issues/132>`_.
+   (which GIQL treats as already canonical). Such a CTE -- and any CTE or
+   subquery passed as an operator reference -- must project the canonical
+   ``chrom`` / ``start`` / ``end`` columns; GIQL validates this contract at
+   transpile time and raises a ``ValueError`` naming the missing column(s)
+   rather than emitting SQL that fails with an engine ``column not found``
+   error. Making canonicalization emit portable SQL on every engine is tracked
+   in `#132 <https://github.com/abdenlab/giql/issues/132>`_.
 
 Working with Point Features
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/giql/resolver.py
+++ b/src/giql/resolver.py
@@ -97,6 +97,7 @@ __all__ = [
     "ResolutionError",
     "resolve_operator_refs",
     "validate_operator_refs",
+    "validate_projection_contracts",
 ]
 
 #: The single namespaced key under which resolution metadata is stored on a
@@ -419,6 +420,7 @@ def resolve_operator_refs(expression: exp.Expression, tables: Tables) -> exp.Exp
             _resolve_operator(node, tables, frozenset())
 
     validate_operator_refs(expression)
+    validate_projection_contracts(expression)
     return expression
 
 
@@ -1157,3 +1159,195 @@ def _validate_ref(ref: object, spec: SlotSpec, operator: str) -> None:
             f"{operator} slot {spec.arg!r} resolved to a {ref.kind} but carries "
             "a Table config; CTE and subquery references are assumed canonical."
         )
+
+
+def validate_projection_contracts(expression: exp.Expression) -> None:
+    """Assert every CTE / subquery operator operand projects canonical columns.
+
+    A user-facing GIQL diagnostic boundary (epic #114, step 9). When an operator
+    reference slot resolves to an in-query CTE or a ``(SELECT ...)`` subquery
+    (:class:`ResolvedRef` kind ``"cte"`` / ``"subquery"``), the resolver and the
+    canonicalizer both *assume* it exposes the canonical ``chrom`` / ``start`` /
+    ``end`` columns the operator will reference — an assumption that, when wrong,
+    historically surfaced only as an opaque engine ``column not found`` error at
+    execution time. This pass inspects the operand's projection at transpile time
+    and raises a clear :class:`ValueError` naming the operator, the offending
+    relation, and the missing column(s) instead.
+
+    Unlike :func:`validate_operator_refs` (an internal invariant check that raises
+    :class:`ResolutionError`), this is a *user-facing* check that raises
+    :class:`ValueError` so it surfaces verbatim through ``transpile()``'s
+    "Resolution error" boundary.
+
+    False-positive guard
+    --------------------
+    A projection's output column names are only statically known when **every**
+    projection expression is an intentional named column — a bare ``exp.Column``
+    (whose output name is the column) or an aliased expression ``exp.Alias``
+    (whose output name is the explicit alias). If any projection is a ``*`` star
+    (whose columns expand from an unknown source schema) or an unnamed expression
+    (a bare literal like ``SELECT 1`` or a computed ``chrom + 1`` with no alias),
+    the relation's schema is not statically determinable and the operand is
+    **passed** without a diagnostic — a documented limitation that avoids
+    false-positives on star and placeholder projections. The check fires only
+    when the schema is fully known *and* a canonical column is provably absent.
+
+    Parameters
+    ----------
+    expression : exp.Expression
+        The pass-1-annotated AST to validate.
+
+    Raises
+    ------
+    ValueError
+        If a CTE or subquery operand's statically-known projection omits one or
+        more of the canonical ``chrom`` / ``start`` / ``end`` columns the
+        operator references.
+    """
+    cte_bodies = _cte_body_index(expression)
+    for node in expression.walk():
+        if not isinstance(node, _OPERATORS):
+            continue
+        resolution = node.meta.get(META_KEY)
+        if not isinstance(resolution, OperatorResolution):
+            continue
+        operator = resolution.operator
+        for arg, ref in resolution.slots.items():
+            if not isinstance(ref, ResolvedRef):
+                continue
+            if ref.kind not in ("cte", "subquery"):
+                continue
+            select = _projection_select(node, arg, ref, cte_bodies)
+            if select is None:
+                continue
+            _check_projection(node, arg, ref, select, operator)
+
+
+def _cte_body_index(expression: exp.Expression) -> dict[str, exp.Expression]:
+    """Map each in-query CTE alias to the query body it defines.
+
+    Built once per validation so a CTE-kind reference can locate its ``WITH``
+    definition and read its output projection. The body is the CTE's ``this`` —
+    an ``exp.Select`` or set operation (``exp.Union`` / ``exp.Intersect`` /
+    ``exp.Except``). When two CTEs share an alias (inner-WITH redeclaration), the
+    last one wins; the resolver's scope-based reference resolution already
+    selected which one the operator sees, and the projection contract is
+    identical across redeclarations for the columns we check.
+    """
+    index: dict[str, exp.Expression] = {}
+    for cte in expression.find_all(exp.CTE):
+        body = cte.this
+        if body is not None:
+            index[cte.alias] = body
+    return index
+
+
+def _projection_select(
+    node: exp.Expression,
+    arg: str,
+    ref: ResolvedRef,
+    cte_bodies: dict[str, exp.Expression],
+) -> exp.Expression | None:
+    """Return the query body whose projection backs reference slot *arg*.
+
+    For a CTE reference the body is looked up by name in *cte_bodies*; for a
+    subquery reference it is the operand AST node itself (an ``exp.Subquery``
+    unwrapped to its inner query, or a bare ``exp.Select`` / set operation).
+    Returns ``None`` when no projection-bearing body can be located — e.g. a CTE
+    whose definition is not in the index (out of scope) — so the caller skips it.
+    """
+    if ref.kind == "cte":
+        return cte_bodies.get(ref.name) if ref.name else None
+    operand = node.args.get(arg)
+    if isinstance(operand, exp.Subquery):
+        operand = operand.this
+    if isinstance(operand, (exp.Select, exp.SetOperation)):
+        return operand
+    return None
+
+
+def _static_output_columns(select: exp.Expression) -> frozenset[str] | None:
+    """Return a body's statically-known output column names, or ``None``.
+
+    ``None`` signals an *unresolvable* projection — one whose output schema
+    cannot be determined statically (a ``*`` star or any unnamed expression) —
+    which the contract check treats as a pass (the false-positive guard). A
+    non-``None`` result is the complete set of intentional output column names,
+    safe to test for the canonical columns.
+
+    A set operation (``UNION`` / ``INTERSECT`` / ``EXCEPT``) defers to its left
+    branch, whose projection determines the result's column names in SQL.
+    """
+    if isinstance(select, exp.SetOperation):
+        return _static_output_columns(select.this)
+    if not isinstance(select, exp.Select):
+        return None
+
+    names: set[str] = set()
+    for projection in select.selects:
+        if not isinstance(projection, (exp.Column, exp.Alias)):
+            # A star or an unnamed expression (bare literal, computed column):
+            # the output schema is not statically determinable, so the whole
+            # projection is unresolvable and the operand passes.
+            return None
+        if isinstance(projection, exp.Column) and isinstance(projection.this, exp.Star):
+            # A qualified star (``a.*``) also expands from an unknown schema.
+            return None
+        names.add(projection.output_name)
+    return frozenset(names)
+
+
+def _check_projection(
+    node: exp.Expression,
+    arg: str,
+    ref: ResolvedRef,
+    select: exp.Expression,
+    operator: str,
+) -> None:
+    """Raise a GIQL diagnostic if *select* omits a canonical column.
+
+    Compares the operand's statically-known output columns against the canonical
+    column names the operator references (``ref.cols``). A star or otherwise
+    unresolvable projection (``_static_output_columns`` returns ``None``) is a
+    pass. When the schema is known and any required column is absent, raises a
+    :class:`ValueError` naming the operator, the offending relation, the missing
+    column(s), and a source position when one is available.
+    """
+    columns = _static_output_columns(select)
+    if columns is None:
+        return
+    missing = [col for col in ref.cols if col not in columns]
+    if not missing:
+        return
+
+    relation = f"CTE {ref.name!r}" if ref.kind == "cte" else "subquery"
+    missing_str = ", ".join(repr(col) for col in missing)
+    have_str = ", ".join(repr(col) for col in sorted(columns)) or "no columns"
+    position = _source_position(node.args.get(arg))
+    raise ValueError(
+        f"{operator} {arg} {relation} does not project the canonical "
+        f"genomic column(s) {missing_str} that the operator references; "
+        f"it projects {have_str}. A CTE or subquery operand must project "
+        f"canonical 0-based half-open 'chrom'/'start'/'end' columns."
+        f"{position}"
+    )
+
+
+def _source_position(operand: exp.Expression | None) -> str:
+    """Return a `` (line L, col C)`` suffix for *operand*, or ``""``.
+
+    Mirrors ``sqlglot``'s ``validate_qualify_columns`` precedent of attaching the
+    parser-populated source position to a validation diagnostic. The position is
+    best-effort: when the parser did not record one (``meta`` carries no
+    ``line``), an empty string is returned and the textual diagnostic stands on
+    its own.
+    """
+    if operand is None:
+        return ""
+    line = operand.meta.get("line")
+    col = operand.meta.get("col")
+    if line is None:
+        return ""
+    if col is None:
+        return f" (line {line})"
+    return f" (line {line}, col {col})"

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -26,8 +26,10 @@ from giql.resolver import ResolvedInterval
 from giql.resolver import ResolvedRef
 from giql.resolver import resolve_operator_refs
 from giql.resolver import validate_operator_refs
+from giql.resolver import validate_projection_contracts
 from giql.table import Table
 from giql.table import Tables
+from giql.transpile import transpile
 
 hypothesis = pytest.importorskip("hypothesis")
 from hypothesis import given  # noqa: E402
@@ -1396,3 +1398,244 @@ class TestValidateOperatorRefs:
         # Act & assert
         with pytest.raises(ResolutionError, match="expected ResolvedInterval"):
             validate_operator_refs(ast)
+
+
+class TestValidateProjectionContracts:
+    """Tests for the validate_projection_contracts pass."""
+
+    def test_validate_projection_contracts_cte_missing_column_raises(self):
+        """Test that a CTE operand missing a canonical column is rejected.
+
+        Given:
+            A DISJOIN reference naming a CTE whose projection lists only
+            ``chrom`` and ``start``, omitting the canonical ``end`` column.
+        When:
+            Running the resolve pass over the annotated AST.
+        Then:
+            It should raise a ValueError naming the operator, the CTE, and the
+            missing ``end`` column.
+        """
+        # Arrange
+        ast = parse_one(
+            "WITH refs AS (SELECT chrom, start FROM other) "
+            "SELECT * FROM DISJOIN(features, reference := refs)",
+            dialect=GIQLDialect,
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match=r"GIQLDisjoin reference CTE 'refs'.*'end'"):
+            resolve_operator_refs(ast, _tables("features", "other"))
+
+    def test_validate_projection_contracts_subquery_missing_column_raises(self):
+        """Test that a subquery operand missing a canonical column is rejected.
+
+        Given:
+            A DISJOIN reference subquery whose projection lists only ``start``
+            and ``end``, omitting the canonical ``chrom`` column.
+        When:
+            Running the resolve pass over the annotated AST.
+        Then:
+            It should raise a ValueError naming the operator, the subquery, and
+            the missing ``chrom`` column.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM DISJOIN(features, "
+            'reference := (SELECT start, "end" FROM other))',
+            dialect=GIQLDialect,
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match=r"GIQLDisjoin reference subquery.*'chrom'"):
+            resolve_operator_refs(ast, _tables("features", "other"))
+
+    def test_validate_projection_contracts_well_formed_cte_passes(self):
+        """Test that a CTE projecting all canonical columns is accepted.
+
+        Given:
+            A DISJOIN reference naming a CTE whose projection lists all three
+            canonical ``chrom`` / ``start`` / ``end`` columns.
+        When:
+            Running the resolve pass over the annotated AST.
+        Then:
+            It should resolve the reference to a CTE without raising.
+        """
+        # Arrange
+        ast = parse_one(
+            'WITH refs AS (SELECT chrom, start, "end" FROM other) '
+            "SELECT * FROM DISJOIN(features, reference := refs)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features", "other"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "cte"
+
+    def test_validate_projection_contracts_well_formed_subquery_passes(self):
+        """Test that a subquery projecting all canonical columns is accepted.
+
+        Given:
+            A DISJOIN reference subquery whose projection lists all three
+            canonical ``chrom`` / ``start`` / ``end`` columns.
+        When:
+            Running the resolve pass over the annotated AST.
+        Then:
+            It should resolve the reference to a subquery without raising.
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM DISJOIN(features, "
+            'reference := (SELECT chrom, start, "end" FROM other))',
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features", "other"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "subquery"
+
+    def test_validate_projection_contracts_star_cte_passes(self):
+        """Test that a ``SELECT *`` CTE is passed without a false positive.
+
+        Given:
+            A DISJOIN reference naming a CTE whose projection is a ``*`` star,
+            so its output columns are not statically known.
+        When:
+            Running the resolve pass over the annotated AST.
+        Then:
+            It should resolve the reference without raising (documented star
+            limitation).
+        """
+        # Arrange
+        ast = parse_one(
+            "WITH refs AS (SELECT * FROM other) "
+            "SELECT * FROM DISJOIN(features, reference := refs)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features", "other"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "cte"
+
+    def test_validate_projection_contracts_star_subquery_passes(self):
+        """Test that a ``SELECT *`` subquery is passed without a false positive.
+
+        Given:
+            A DISJOIN reference subquery whose projection is a ``*`` star, so its
+            output columns are not statically known.
+        When:
+            Running the resolve pass over the annotated AST.
+        Then:
+            It should resolve the reference without raising (documented star
+            limitation).
+        """
+        # Arrange
+        ast = parse_one(
+            "SELECT * FROM DISJOIN(features, reference := (SELECT * FROM other))",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features", "other"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "subquery"
+
+    def test_validate_projection_contracts_placeholder_cte_passes(self):
+        """Test that a bare-literal placeholder CTE is passed.
+
+        Given:
+            A DISJOIN reference naming a CTE whose projection is the placeholder
+            ``SELECT 1`` -- an unnamed literal with no statically intentional
+            column schema.
+        When:
+            Running the resolve pass over the annotated AST.
+        Then:
+            It should resolve the reference without raising (unresolvable
+            projection limitation).
+        """
+        # Arrange
+        ast = parse_one(
+            "WITH refs AS (SELECT 1) SELECT * FROM DISJOIN(features, reference := refs)",
+            dialect=GIQLDialect,
+        )
+
+        # Act
+        resolve_operator_refs(ast, _tables("features", "other"))
+
+        # Assert
+        ref = _disjoin_node(ast).meta[META_KEY].slot("reference")
+        assert ref.kind == "cte"
+
+    def test_validate_projection_contracts_can_run_standalone(self):
+        """Test that the contract check runs as a standalone boundary.
+
+        Given:
+            An AST already annotated by the resolve pass whose DISJOIN reference
+            CTE omits the canonical ``end`` column.
+        When:
+            Calling ``validate_projection_contracts`` directly on the annotated
+            AST.
+        Then:
+            It should raise the GIQL diagnostic independently of the surrounding
+            resolve pass.
+        """
+        # Arrange
+        ast = parse_one(
+            "WITH refs AS (SELECT chrom, start FROM other) "
+            "SELECT * FROM DISJOIN(features, reference := refs)",
+            dialect=GIQLDialect,
+        )
+        node = _disjoin_node(ast)
+        node.meta[META_KEY] = OperatorResolution(
+            "GIQLDisjoin",
+            {
+                "this": ResolvedRef(
+                    kind="registered_table",
+                    name="features",
+                    cols=("chrom", "start", "end"),
+                    table=Table("features"),
+                    coverage_skippable=False,
+                ),
+                "reference": ResolvedRef(
+                    kind="cte",
+                    name="refs",
+                    cols=("chrom", "start", "end"),
+                    table=None,
+                    coverage_skippable=False,
+                ),
+            },
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match="does not project the canonical"):
+            validate_projection_contracts(ast)
+
+    def test_validate_projection_contracts_fires_through_transpile(self):
+        """Test that the diagnostic surfaces through ``transpile``.
+
+        Given:
+            A GIQL query whose DISJOIN reference CTE omits the canonical ``end``
+            column.
+        When:
+            Transpiling the query.
+        Then:
+            It should raise a ValueError carrying the GIQL-level diagnostic
+            rather than emitting SQL that fails at execution time.
+        """
+        # Arrange, act, & assert
+        with pytest.raises(ValueError, match=r"GIQLDisjoin reference CTE 'refs'.*'end'"):
+            transpile(
+                "WITH refs AS (SELECT chrom, start FROM other) "
+                "SELECT * FROM DISJOIN(features, reference := refs)",
+                tables=["features", "other"],
+            )


### PR DESCRIPTION
## Summary

Implement step 9 of epic #114's staged migration plan — validate CTE and subquery projection contracts in pass 1, closing the epic's headline footgun (payoff #1). When a DISJOIN reference or NEAREST target resolves to an in-query CTE or a `(SELECT ...)` subquery, the resolver assumes it exposes canonical `chrom`/`start`/`end` columns; if it doesn't, the user previously got an opaque engine `column not found` at execution time. A new `validate_projection_contracts` boundary in `resolve_operator_refs` now inspects those operands' projections and raises a clear GIQL `ValueError` at transpile time — naming the operator, the relation, the missing column(s), and a source position.

The check fires only when the operand's output schema is **statically known** (a projection of intentional named columns). Star projections and unnamed/computed projections (`SELECT *`, `SELECT 1`, `SELECT chrom + 1`) are unresolvable and pass through, so the contract is never falsely reported when GIQL cannot see the columns — this is what keeps every existing CTE/subquery operand green. Set operations defer to their left branch, matching SQL column-name semantics.

Closes #124

## Proposed changes

**Resolver (`src/giql/resolver.py`):** Add `validate_projection_contracts` (exported, called at the end of `resolve_operator_refs` after the internal invariant check) plus helpers: `_cte_body_index` (alias → CTE body), `_projection_select` (unwrap subquery to its inner select), `_static_output_columns` (the false-positive guard — returns the column set only when every projection is a named column, else `None`), `_check_projection` (diagnostic builder), `_source_position`. The boundary is additive and side-effect-free; it raises through `transpile()`'s existing resolution-error path.

**Docs (`docs/recipes/disjoin.rst`, `docs/transpilation/schema-mapping.rst`):** A new "CTE / Subquery Reference Contract" section in the DISJOIN recipe (valid example + the star/placeholder limitation), and an update to the schema-mapping note that previously described the contract as assumed-canonical and unvalidated.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestValidateProjectionContracts` | A CTE projecting only `chrom, start` | Resolving | Raises naming the missing `end` | CTE missing-column diagnostic |
| 2 | `TestValidateProjectionContracts` | A subquery projecting `start, end` | Resolving | Raises naming the missing `chrom` | Subquery missing-column diagnostic |
| 3 | `TestValidateProjectionContracts` | A CTE projecting all three | Resolving | Resolves to kind `cte`, no error | Well-formed CTE |
| 4 | `TestValidateProjectionContracts` | A subquery projecting all three | Resolving | Resolves to kind `subquery`, no error | Well-formed subquery |
| 5 | `TestValidateProjectionContracts` | A `SELECT *` CTE | Resolving | Passes (no false positive) | Star guard |
| 6 | `TestValidateProjectionContracts` | A `SELECT *` subquery | Resolving | Passes | Star guard |
| 7 | `TestValidateProjectionContracts` | A `SELECT 1` placeholder CTE | Resolving | Passes (unresolvable limitation) | Placeholder guard |
| 8 | `TestValidateProjectionContracts` | An annotated AST | Calling the boundary directly | Raises standalone | Boundary independence |
| 9 | `TestValidateProjectionContracts` | A malformed operand | Transpiling | The diagnostic surfaces through `transpile()` | End-to-end surfacing |