### PR TITLE
Reduce the generator to a pure emitter (final audit) — Closes #125

### DIFF
--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -3,10 +3,6 @@ from sqlglot.generator import Generator
 
 from giql.canonical import decanonical_end
 from giql.canonical import decanonical_start
-from giql.constants import DEFAULT_CHROM_COL
-from giql.constants import DEFAULT_END_COL
-from giql.constants import DEFAULT_START_COL
-from giql.constants import DEFAULT_STRAND_COL
 from giql.expressions import Contains
 from giql.expressions import GIQLDisjoin
 from giql.expressions import GIQLDistance
@@ -21,7 +17,6 @@ from giql.resolver import OperatorResolution
 from giql.resolver import ResolvedColumn
 from giql.resolver import ResolvedInterval
 from giql.resolver import ResolvedRef
-from giql.resolver import resolve_operator_refs
 from giql.table import Table
 from giql.table import Tables
 
@@ -46,40 +41,6 @@ class BaseGIQLGenerator(Generator):
     def __init__(self, tables: Tables | None = None, **kwargs):
         super().__init__(**kwargs)
         self.tables = tables or Tables()
-        self._current_table = None  # Track current table for column resolution
-        self._alias_to_table = {}  # Map aliases to table names
-
-    def select_sql(self, expression: exp.Select) -> str:
-        """Override SELECT generation to track table context and aliases."""
-        # Build alias-to-table mapping
-        self._alias_to_table = {}
-
-        # Extract from FROM clause
-        if expression.args.get("from_"):
-            from_clause = expression.args["from_"]
-            if isinstance(from_clause.this, exp.Table):
-                table_name = from_clause.this.name
-                self._current_table = table_name
-                # Check if table has an alias
-                if from_clause.this.alias:
-                    self._alias_to_table[from_clause.this.alias] = table_name
-                else:
-                    # No alias, table referenced by name
-                    self._alias_to_table[table_name] = table_name
-
-        # Extract from JOINs
-        if expression.args.get("joins"):
-            for join in expression.args["joins"]:
-                if isinstance(join.this, exp.Table):
-                    table_name = join.this.name
-                    # Check if table has an alias
-                    if join.this.alias:
-                        self._alias_to_table[join.this.alias] = table_name
-                    else:
-                        self._alias_to_table[table_name] = table_name
-
-        # Call parent implementation
-        return super().select_sql(expression)
 
     def intersects_sql(self, expression: Intersects) -> str:
         """Generate standard SQL for INTERSECTS.
@@ -537,13 +498,12 @@ class BaseGIQLGenerator(Generator):
 
         Reads the :class:`~giql.resolver.ResolvedColumn` metadata that
         ``ResolveOperatorRefs`` (pass 1) attaches to each interval operand. When
-        the pass deferred an operand (a literal range, an unqualified column, or
-        a tree the pass never reached) the emitter falls back to its historical
-        string-level resolution and raises the same diagnostics as before.
+        the pass deferred an operand (a literal range, or an unqualified column)
+        the emitter raises the historical literal-range diagnostic.
 
-        Coordinate canonicalization stays here (epic #114 step 8 / issue #123):
-        the resolved metadata carries each operand's :class:`~giql.table.Table`
-        so the endpoints are wrapped identically.
+        Coordinate canonicalization is owned by ``CanonicalizeCoordinates``
+        (pass 2, issue #123): the resolved metadata's endpoints are already
+        canonicalized in place, so the emitter consumes them verbatim.
 
         :param expression:
             GIQLDistance expression node
@@ -585,14 +545,12 @@ class BaseGIQLGenerator(Generator):
     def _distance_operand(
         self, expression: GIQLDistance, arg: str, position: str
     ) -> ResolvedColumn:
-        """Resolve one DISTANCE interval operand to a :class:`ResolvedColumn`.
+        """Return the :class:`ResolvedColumn` for one DISTANCE interval operand.
 
-        Prefers the metadata attached by ``ResolveOperatorRefs`` (pass 1). When
-        the pass deferred the operand — it could not resolve a literal range or
-        an unqualified column, or never ran (the generator was invoked directly
-        without the pass) — this falls back to the legacy ``_get_column_refs`` /
-        ``_resolve_table`` path, raising the historical literal-range error for
-        a non-column operand.
+        Reads the metadata attached by ``ResolveOperatorRefs`` (pass 1). When the
+        pass deferred the operand — a literal range or an unqualified column it
+        could not resolve — no column is attached and this raises the historical
+        literal-range diagnostic.
 
         :param expression:
             GIQLDistance expression node
@@ -612,19 +570,6 @@ class BaseGIQLGenerator(Generator):
             if resolved is not None:
                 return resolved
 
-        # Deferred: fall back to string-level resolution.
-        operand_sql = self.sql(expression.args.get(arg))
-        if "." in operand_sql and not operand_sql.startswith("'"):
-            chrom, start, end, strand = self._get_column_refs(
-                operand_sql, None, include_strand=True
-            )
-            return ResolvedColumn(
-                chrom=chrom,
-                start=start,
-                end=end,
-                strand=strand,
-                table=self._resolve_table(operand_sql),
-            )
         raise ValueError(f"Literal range as {position} argument not yet supported")
 
     def _generate_distance_case(
@@ -718,28 +663,17 @@ class BaseGIQLGenerator(Generator):
             f"ELSE ({start_a} - {end_b}) END END"
         )
 
-    def _predicate_operand(
-        self, expression: exp.Expression, arg: str, ctx_table: str | None
-    ) -> ResolvedColumn:
+    def _predicate_operand(self, expression: exp.Expression, arg: str) -> ResolvedColumn:
         """Return the :class:`ResolvedColumn` for a spatial predicate operand.
 
         Reads the column resolution attached to *expression* by the
-        ``ResolveOperatorRefs`` pass (the metadata-driven path used by the full
-        transpile pipeline). When the pass did not annotate the node — e.g. a
-        generator invoked on a bare AST without running pass 1 — it falls back to
-        the generator's historical ``_current_table`` / alias-map resolution so
-        direct ``generate()`` callers keep their existing behavior. Both paths
-        format physical column references identically, so the emitted SQL is the
-        same regardless of which produced the :class:`ResolvedColumn`.
+        ``ResolveOperatorRefs`` pass (pass 1). The emitter consumes only the
+        resolved metadata; all name/column resolution lives in the pass.
 
         :param expression:
             The spatial predicate node carrying the resolution metadata.
         :param arg:
             The operand slot key (``"this"`` or ``"expression"``).
-        :param ctx_table:
-            The current-table resolution context for the fallback path —
-            ``self._current_table`` for a literal-range operand, ``None`` for a
-            column-to-column operand.
         :return:
             The resolved column metadata.
         """
@@ -749,10 +683,10 @@ class BaseGIQLGenerator(Generator):
             if resolved is not None:
                 return resolved
 
-        column_ref = self.sql(expression, arg)
-        chrom, start, end = self._get_column_refs(column_ref, ctx_table)
-        table = self._resolve_table(column_ref, ctx_table)
-        return ResolvedColumn(chrom=chrom, start=start, end=end, strand="", table=table)
+        raise ValueError(
+            f"Spatial predicate operand {arg!r} was not resolved; run the "
+            "ResolveOperatorRefs pass (transpile pipeline) before generation."
+        )
 
     def _generate_spatial_op(self, expression: exp.Binary, op_type: str) -> str:
         """Generate SQL for a spatial operation.
@@ -769,15 +703,15 @@ class BaseGIQLGenerator(Generator):
         # Check if right side is a column reference or a literal range string
         if "." in right_raw and not right_raw.startswith("'"):
             # Column-to-column join (e.g., a.interval INTERSECTS b.interval)
-            left = self._predicate_operand(expression, "this", None)
-            right = self._predicate_operand(expression, "expression", None)
+            left = self._predicate_operand(expression, "this")
+            right = self._predicate_operand(expression, "expression")
             return self._generate_column_join(left, right, op_type)
         else:
             # Literal range string (e.g., interval INTERSECTS 'chr1:1000-2000')
             try:
                 range_str = right_raw.strip("'\"")
                 parsed_range = RangeParser.parse(range_str).to_zero_based_half_open()
-                left = self._predicate_operand(expression, "this", self._current_table)
+                left = self._predicate_operand(expression, "this")
                 return self._generate_range_predicate(left, parsed_range, op_type)
             except Exception as e:
                 raise ValueError(
@@ -919,7 +853,7 @@ class BaseGIQLGenerator(Generator):
         # Resolve the (single) left column operand once; every range condition
         # compares against the same column. The set predicate's ranges are
         # always literals, so only this operand needs resolution.
-        column = self._predicate_operand(expression, "this", self._current_table)
+        column = self._predicate_operand(expression, "this")
 
         # Parse all ranges
         parsed_ranges = []
@@ -970,10 +904,8 @@ class BaseGIQLGenerator(Generator):
 
         The transpile pipeline attaches an
         :class:`~giql.resolver.OperatorResolution` before generation, and it
-        survives the generator's defensive tree copy. Direct callers that invoke
-        ``generate`` / ``giqlnearest_sql`` without running the pass (notably unit
-        tests) get the metadata resolved lazily here against this generator's
-        registered tables, so the emit path always reads resolved metadata.
+        survives the generator's defensive tree copy. The emitter reads only the
+        attached metadata; resolution lives entirely in the pass.
 
         :param expression:
             GIQLNearest expression node
@@ -982,9 +914,6 @@ class BaseGIQLGenerator(Generator):
             if resolution did not produce one.
         """
         resolution = expression.meta.get(META_KEY)
-        if not isinstance(resolution, OperatorResolution):
-            resolve_operator_refs(expression.root(), self.tables)
-            resolution = expression.meta.get(META_KEY)
         return resolution if isinstance(resolution, OperatorResolution) else None
 
     def _raise_nearest_reference_error(
@@ -1145,106 +1074,3 @@ class BaseGIQLGenerator(Generator):
             return param_expr.this
         else:
             return str(param_expr).upper() in ("TRUE", "1", "YES")
-
-    def _get_column_refs(
-        self,
-        column_ref: str,
-        table_name: str | None = None,
-        include_strand: bool = False,
-    ) -> tuple[str, str, str] | tuple[str, str, str, str]:
-        """Get physical column names for genomic data.
-
-        :param column_ref:
-            Logical column reference (e.g., 'v.interval' or 'interval')
-        :param table_name:
-            Table name to look up schema (optional, overrides extraction from column_ref)
-        :param include_strand:
-            If True, return 4-tuple with strand column; otherwise return 3-tuple
-        :return:
-            Tuple of (chromosome_col, start_col, end_col) or
-            (chromosome_col, start_col, end_col, strand_col) if include_strand=True
-        """
-        # Default column names
-        chrom_col = DEFAULT_CHROM_COL
-        start_col = DEFAULT_START_COL
-        end_col = DEFAULT_END_COL
-        strand_col = DEFAULT_STRAND_COL
-
-        # Alias is kept verbatim for output formatting; table name is resolved
-        # separately to look up the Table config (alias != name in joins).
-        table_alias = column_ref.rsplit(".", 1)[0] if "." in column_ref else None
-        table_name = self._resolve_table_name(column_ref, table_name)
-
-        # Try to get custom column names from table config
-        if table_name and self.tables:
-            table = self.tables.get(table_name)
-            if table:
-                chrom_col = table.chrom_col
-                start_col = table.start_col
-                end_col = table.end_col
-                if table.strand_col:
-                    strand_col = table.strand_col
-
-        # Format with table alias if present
-        if table_alias:
-            base_cols = (
-                f'{table_alias}."{chrom_col}"',
-                f'{table_alias}."{start_col}"',
-                f'{table_alias}."{end_col}"',
-            )
-            if include_strand:
-                return base_cols + (f'{table_alias}."{strand_col}"',)
-            return base_cols
-        else:
-            base_cols = (
-                f'"{chrom_col}"',
-                f'"{start_col}"',
-                f'"{end_col}"',
-            )
-            if include_strand:
-                return base_cols + (f'"{strand_col}"',)
-            return base_cols
-
-    def _resolve_table_name(self, column_ref: str, table_name: str | None) -> str | None:
-        """Resolve the underlying table name for a column reference.
-
-        Precedence: explicit ``table_name`` (caller-provided context) > alias
-        map (JOIN-side resolution via ``self._alias_to_table``) >
-        ``self._current_table`` (FROM-clause fallback for unmapped dotted
-        aliases). Undotted refs return ``None`` because their caller is
-        expected to pass ``_current_table`` as the explicit ``table_name``
-        when relevant.
-
-        :param column_ref:
-            Column reference, possibly aliased (e.g. ``a.interval``)
-        :param table_name:
-            Explicit table name; takes precedence if non-empty
-        :return:
-            ``table_name`` if non-empty; otherwise the alias mapping from
-            ``self._alias_to_table`` (with ``self._current_table`` as fallback)
-            if ``column_ref`` is dotted; otherwise None
-        """
-        if table_name:
-            return table_name
-        if "." in column_ref:
-            alias = column_ref.rsplit(".", 1)[0]
-            return self._alias_to_table.get(alias, self._current_table)
-        return None
-
-    def _resolve_table(
-        self, column_ref: str, table_name: str | None = None
-    ) -> Table | None:
-        """Resolve the Table config that backs a column reference.
-
-        :param column_ref:
-            Column reference, possibly aliased (e.g. ``a.interval``)
-        :param table_name:
-            Explicit table name; if omitted, derived from ``column_ref`` alias
-            or falls back to ``self._current_table``
-        :return:
-            The Table config if registered, otherwise None
-        """
-        table_name = self._resolve_table_name(column_ref, table_name)
-        if table_name and self.tables:
-            return self.tables.get(table_name)
-        return None

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -156,10 +156,8 @@ class TestBaseGIQLGenerator:
         THEN Alias-to-table mapping includes the alias.
         """
         sql = "SELECT * FROM variants AS v WHERE v.interval INTERSECTS 'chr1:1000-2000'"
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_info)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_info)
 
         expected = (
             "SELECT * FROM variants AS v WHERE "
@@ -190,10 +188,8 @@ class TestBaseGIQLGenerator:
         THEN SQL with chrom = 'chr1' AND start < 2000 AND end > 1000 is generated.
         """
         sql = "SELECT * FROM variants WHERE interval INTERSECTS 'chr1:1000-2000'"
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         expected = (
             "SELECT * FROM variants WHERE "
@@ -212,10 +208,11 @@ class TestBaseGIQLGenerator:
             "SELECT * FROM features_a AS a CROSS JOIN features_b AS b "
             "WHERE a.interval INTERSECTS b.interval"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        # The full transpile pipeline rewrites a column-to-column INTERSECTS into a
+        # binned equi-join before the predicate emitter runs, so run passes 1 and 2
+        # directly to exercise the predicate emitter's column-join branch.
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         expected = (
             "SELECT * FROM features_a AS a CROSS JOIN features_b AS b WHERE "
@@ -239,9 +236,7 @@ class TestBaseGIQLGenerator:
         end = start + length
         sql = f"SELECT * FROM variants WHERE interval INTERSECTS '{chrom}:{start}-{end}'"
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         # Verify we can parse the output SQL (proves it's syntactically valid)
         parsed = parse_one(output)
@@ -254,10 +249,8 @@ class TestBaseGIQLGenerator:
         THEN SQL with start <= 1000 AND end > 1000 is generated.
         """
         sql = "SELECT * FROM variants WHERE interval CONTAINS 'chr1:1500'"
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         expected = (
             "SELECT * FROM variants WHERE "
@@ -272,10 +265,8 @@ class TestBaseGIQLGenerator:
         THEN SQL with start <= 1000 AND end >= 2000 is generated.
         """
         sql = "SELECT * FROM variants WHERE interval CONTAINS 'chr1:1500-2000'"
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         expected = (
             "SELECT * FROM variants WHERE "
@@ -294,10 +285,8 @@ class TestBaseGIQLGenerator:
             "SELECT * FROM features_a AS a CROSS JOIN features_b AS b "
             "WHERE a.interval CONTAINS b.interval"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         expected = (
             "SELECT * FROM features_a AS a CROSS JOIN features_b AS b WHERE "
@@ -321,9 +310,7 @@ class TestBaseGIQLGenerator:
         end = start + length
         sql = f"SELECT * FROM variants WHERE interval CONTAINS '{chrom}:{start}-{end}'"
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         # Verify we can parse the output SQL (proves it's syntactically valid)
         parsed = parse_one(output)
@@ -339,10 +326,8 @@ class TestBaseGIQLGenerator:
         THEN SQL with start >= 1000 AND end <= 2000 is generated.
         """
         sql = "SELECT * FROM variants WHERE interval WITHIN 'chr1:1000-5000'"
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         expected = (
             "SELECT * FROM variants WHERE "
@@ -360,10 +345,8 @@ class TestBaseGIQLGenerator:
             "SELECT * FROM features_a AS a CROSS JOIN features_b AS b "
             "WHERE a.interval WITHIN b.interval"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         expected = (
             "SELECT * FROM features_a AS a CROSS JOIN features_b AS b WHERE "
@@ -382,10 +365,8 @@ class TestBaseGIQLGenerator:
             "SELECT * FROM variants "
             "WHERE interval INTERSECTS ANY('chr1:1000-2000', 'chr1:5000-6000')"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         expected = (
             "SELECT * FROM variants WHERE "
@@ -404,10 +385,8 @@ class TestBaseGIQLGenerator:
             "SELECT * FROM variants "
             "WHERE interval INTERSECTS ALL('chr1:1000-2000', 'chr1:1500-1800')"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         expected = (
             "SELECT * FROM variants WHERE "
@@ -423,10 +402,8 @@ class TestBaseGIQLGenerator:
         THEN Subquery with ORDER BY distance LIMIT k is generated.
         """
         sql = "SELECT * FROM NEAREST(genes, reference := 'chr1:1000-2000', k := 3)"
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_peaks_and_genes)
 
         expected = (
             "SELECT * FROM (\n"
@@ -459,10 +436,8 @@ class TestBaseGIQLGenerator:
             "SELECT * FROM peaks "
             "CROSS JOIN LATERAL NEAREST(genes, reference := peaks.interval, k := 3)"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_peaks_and_genes)
 
         expected = (
             "SELECT * FROM peaks CROSS JOIN LATERAL (\n"
@@ -498,10 +473,8 @@ class TestBaseGIQLGenerator:
             "CROSS JOIN LATERAL NEAREST("
             "genes, reference := peaks.interval, k := 5, max_distance := 100000)"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_peaks_and_genes)
 
         expected = (
             "SELECT * FROM peaks CROSS JOIN LATERAL (\n"
@@ -544,10 +517,8 @@ class TestBaseGIQLGenerator:
             "CROSS JOIN LATERAL NEAREST("
             "genes, reference := peaks.interval, k := 3, stranded := true)"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_peaks_and_genes)
 
         expected = (
             "SELECT * FROM peaks CROSS JOIN LATERAL (\n"
@@ -603,10 +574,9 @@ class TestBaseGIQLGenerator:
             "SELECT * FROM nostr "
             "CROSS JOIN LATERAL NEAREST(genes, k := 1, stranded := true)"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
         # Act
-        output = BaseGIQLGenerator(tables=tables).generate(ast)
+        output = _generate_through_passes(sql, tables)
 
         # Assert
         assert "strand" not in output
@@ -623,10 +593,8 @@ class TestBaseGIQLGenerator:
             "CROSS JOIN LATERAL NEAREST("
             "genes, reference := peaks.interval, k := 3, signed := true)"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_peaks_and_genes)
 
         expected = (
             "SELECT * FROM peaks CROSS JOIN LATERAL (\n"
@@ -665,6 +633,8 @@ class TestBaseGIQLGenerator:
         # Use query without explicit reference to trigger correlated mode
         sql = "SELECT * FROM peaks CROSS JOIN LATERAL NEAREST(genes, k := 3)"
         ast = parse_one(sql, dialect=GIQLDialect)
+        ast = resolve_operator_refs(ast, tables_with_peaks_and_genes)
+        ast = canonicalize_coordinates(ast)
 
         generator = NoLateralGenerator(tables=tables_with_peaks_and_genes)
 
@@ -688,10 +658,8 @@ class TestBaseGIQLGenerator:
             f"SELECT * FROM NEAREST("
             f"genes, reference := 'chr1:1000-2000', k := {k}, max_distance := {max_distance})"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_peaks_and_genes)
 
         # k should appear in LIMIT
         assert f"LIMIT {k}" in output
@@ -708,10 +676,8 @@ class TestBaseGIQLGenerator:
             "SELECT DISTANCE(a.interval, b.interval) as dist "
             "FROM features_a a CROSS JOIN features_b b"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         expected = (
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
@@ -733,10 +699,8 @@ class TestBaseGIQLGenerator:
             "SELECT DISTANCE(a.interval, b.interval, stranded := true) as dist "
             "FROM features_a a CROSS JOIN features_b b"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         expected = (
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
@@ -766,10 +730,8 @@ class TestBaseGIQLGenerator:
             "SELECT DISTANCE(a.interval, b.interval, signed := true) as dist "
             "FROM features_a a CROSS JOIN features_b b"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         expected = (
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
@@ -792,10 +754,8 @@ class TestBaseGIQLGenerator:
             "DISTANCE(a.interval, b.interval, stranded := true, signed := true) as dist "
             "FROM features_a a CROSS JOIN features_b b"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         expected = (
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
@@ -915,10 +875,8 @@ class TestBaseGIQLGenerator:
             "SELECT * FROM NEAREST("
             "genes, reference := 'chr1:1000-2000:+', k := 3, stranded := true)"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_peaks_and_genes)
 
         # Should contain strand literal '+' and strand filtering
         assert "'+'" in output
@@ -933,10 +891,8 @@ class TestBaseGIQLGenerator:
         THEN Strand column is resolved from outer table and used.
         """
         sql = "SELECT * FROM peaks CROSS JOIN LATERAL NEAREST(genes, k := 3, stranded := true)"
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_peaks_and_genes)
 
         # Should have strand columns from both tables
         assert 'peaks."strand"' in output
@@ -982,6 +938,8 @@ class TestBaseGIQLGenerator:
         """
         sql = "SELECT DISTANCE('chr1:1000-2000', b.interval) as dist FROM features_b b"
         ast = parse_one(sql, dialect=GIQLDialect)
+        ast = resolve_operator_refs(ast, tables_with_two_tables)
+        ast = canonicalize_coordinates(ast)
 
         generator = BaseGIQLGenerator(tables=tables_with_two_tables)
 
@@ -996,6 +954,8 @@ class TestBaseGIQLGenerator:
         """
         sql = "SELECT DISTANCE(a.interval, 'chr1:1000-2000') as dist FROM features_a a"
         ast = parse_one(sql, dialect=GIQLDialect)
+        ast = resolve_operator_refs(ast, tables_with_two_tables)
+        ast = canonicalize_coordinates(ast)
 
         generator = BaseGIQLGenerator(tables=tables_with_two_tables)
 
@@ -1016,6 +976,8 @@ class TestBaseGIQLGenerator:
             this=exp.Table(this=exp.Identifier(this="genes")),
             k=exp.Literal.number(3),
         )
+        resolve_operator_refs(nearest, tables_with_peaks_and_genes)
+        canonicalize_coordinates(nearest)
 
         generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
 
@@ -1034,12 +996,9 @@ class TestBaseGIQLGenerator:
         # The outer relation (unknown_table) is present in the LATERAL context
         # but is not a registered table, so the implicit-outer reference defers.
         sql = "SELECT * FROM unknown_table CROSS JOIN LATERAL NEAREST(genes, k := 3)"
-        ast = parse_one(sql, dialect=GIQLDialect)
-
-        generator = BaseGIQLGenerator(tables=tables)
 
         with pytest.raises(ValueError, match="not found in tables"):
-            generator.generate(ast)
+            _generate_through_passes(sql, tables)
 
     def test_giqlnearest_sql_invalid_reference_range(self, tables_with_peaks_and_genes):
         """
@@ -1048,12 +1007,9 @@ class TestBaseGIQLGenerator:
         THEN ValueError is raised with parse error details.
         """
         sql = "SELECT * FROM NEAREST(genes, reference := 'invalid_range', k := 3)"
-        ast = parse_one(sql, dialect=GIQLDialect)
-
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
 
         with pytest.raises(ValueError, match="Could not parse reference genomic range"):
-            generator.generate(ast)
+            _generate_through_passes(sql, tables_with_peaks_and_genes)
 
     def test_giqlnearest_sql_no_tables_error(self):
         """
@@ -1093,10 +1049,8 @@ class TestBaseGIQLGenerator:
         THEN Default column names are used without table qualifier.
         """
         sql = "SELECT * FROM variants WHERE interval INTERSECTS 'chr1:1000-2000'"
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, Tables())
 
         expected = (
             "SELECT * FROM variants WHERE "
@@ -1121,6 +1075,8 @@ class TestBaseGIQLGenerator:
             k=exp.Literal.number(3),
             stranded=exp.Boolean(this=True),
         )
+        resolve_operator_refs(nearest, tables_with_peaks_and_genes)
+        canonicalize_coordinates(nearest)
 
         generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
         output = generator.giqlnearest_sql(nearest)
@@ -1144,6 +1100,8 @@ class TestBaseGIQLGenerator:
             reference=exp.Literal.string("chr1:1000-2000"),
             k=exp.Literal.number(3),
         )
+        resolve_operator_refs(nearest, tables_with_peaks_and_genes)
+        canonicalize_coordinates(nearest)
 
         generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
         output = generator.giqlnearest_sql(nearest)
@@ -1168,10 +1126,8 @@ class TestBaseGIQLGenerator:
             f"SELECT DISTANCE(a.interval, b.interval, stranded := {bool_repr}) as dist "
             "FROM features_a a, features_b b"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         # Should include strand handling (NULL checks for strand columns)
         assert "strand" in output.lower()
@@ -1193,10 +1149,8 @@ class TestBaseGIQLGenerator:
             f"SELECT DISTANCE(a.interval, b.interval, stranded := {bool_repr}) as dist "
             "FROM features_a a, features_b b"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         # Should NOT include strand NULL checks (basic distance)
         assert "strand" not in output.lower()
@@ -1217,10 +1171,8 @@ class TestBaseGIQLGenerator:
             f"SELECT DISTANCE(a.interval, b.interval, signed := {bool_repr}) as dist "
             "FROM features_a a, features_b b"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         # Signed distance has negative sign for upstream intervals
         assert "-(" in output
@@ -1241,10 +1193,8 @@ class TestBaseGIQLGenerator:
             f"SELECT DISTANCE(a.interval, b.interval, signed := {bool_repr}) as dist "
             "FROM features_a a, features_b b"
         )
-        ast = parse_one(sql, dialect=GIQLDialect)
 
-        generator = BaseGIQLGenerator(tables=tables_with_two_tables)
-        output = generator.generate(ast)
+        output = _generate_through_passes(sql, tables_with_two_tables)
 
         # Unsigned distance has no negative sign (both ELSE branches are positive)
         # Count occurrences of "-(" - signed has 1, unsigned has 0

--- a/tests/test_distance_transpilation.py
+++ b/tests/test_distance_transpilation.py
@@ -6,8 +6,27 @@ Tests verify that DISTANCE() is correctly transpiled to SQL CASE expressions.
 from sqlglot import parse_one
 
 from giql import transpile
+from giql.canonicalizer import canonicalize_coordinates
 from giql.dialect import GIQLDialect
 from giql.generators import BaseGIQLGenerator
+from giql.resolver import resolve_operator_refs
+from giql.table import Tables
+
+
+def _generate(sql: str, tables: Tables | None = None) -> str:
+    """Parse, run normalization passes 1 and 2, then generate SQL.
+
+    DISTANCE operand resolution and coordinate canonicalization moved out of the
+    emitter and into the ResolveOperatorRefs / CanonicalizeCoordinates passes
+    (epic #114, issues #119 / #123). Emitter-level tests must run both passes
+    before generating, exactly as :func:`giql.transpile.transpile` does, rather
+    than calling ``generate`` on a bare parsed AST.
+    """
+    tables = tables or Tables()
+    ast = parse_one(sql, dialect=GIQLDialect)
+    ast = resolve_operator_refs(ast, tables)
+    ast = canonicalize_coordinates(ast)
+    return BaseGIQLGenerator(tables=tables).generate(ast)
 
 
 class TestDistanceTranspilation:
@@ -24,9 +43,7 @@ class TestDistanceTranspilation:
         FROM features_a a CROSS JOIN features_b b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate(sql)
 
         expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end") ELSE (a."start" - b."end") END AS dist FROM features_a AS a CROSS JOIN features_b AS b"""
 
@@ -43,9 +60,7 @@ class TestDistanceTranspilation:
         FROM features_a a, features_b b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate(sql)
 
         expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end") ELSE (a."start" - b."end") END AS dist FROM features_a AS a, features_b AS b"""
 
@@ -62,9 +77,7 @@ class TestDistanceTranspilation:
         FROM features_a a CROSS JOIN features_b b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate(sql)
 
         expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end") ELSE (a."start" - b."end") END AS dist FROM features_a AS a CROSS JOIN features_b AS b"""
 
@@ -72,11 +85,12 @@ class TestDistanceTranspilation:
 
     def test_distance_resolver_path_matches_direct_generation(self):
         """
-        GIVEN a DISTANCE query over registered default-convention tables
-        WHEN transpiling through the full pipeline (the resolver pass) versus
-            generating directly from the parsed AST
-        THEN both paths should emit byte-identical SQL, proving the
-            ResolvedColumn metadata path reproduces the legacy string path
+        GIVEN a DISTANCE query over default-convention tables
+        WHEN transpiling through the full pipeline (with the tables registered)
+            versus running the two normalization passes with no tables registered
+        THEN both paths should emit byte-identical SQL, proving the qualified
+            ResolvedColumn metadata resolves identically whether or not the
+            operand's relation is registered
         """
         query = (
             "SELECT DISTANCE(a.interval, b.interval) AS dist "
@@ -84,8 +98,7 @@ class TestDistanceTranspilation:
         )
 
         via_transpile = transpile(query, tables=["features_a", "features_b"])
-        ast = parse_one(query, dialect=GIQLDialect)
-        via_generate = BaseGIQLGenerator().generate(ast)
+        via_generate = _generate(query)
 
         assert via_transpile == via_generate
 
@@ -101,9 +114,7 @@ class TestDistanceTranspilation:
         FROM features_a a CROSS JOIN features_b b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output = generator.generate(ast)
+        output = _generate(sql)
 
         # Signed distance: upstream (B before A) returns negative,
         # downstream (B after A) returns positive

--- a/tests/test_distance_udf.py
+++ b/tests/test_distance_udf.py
@@ -8,8 +8,26 @@ import duckdb
 import pytest
 from sqlglot import parse_one
 
+from giql.canonicalizer import canonicalize_coordinates
 from giql.dialect import GIQLDialect
 from giql.generators import BaseGIQLGenerator
+from giql.resolver import resolve_operator_refs
+from giql.table import Tables
+
+
+def _generate(sql: str) -> str:
+    """Parse, run normalization passes 1 and 2, then generate SQL.
+
+    DISTANCE operand resolution and coordinate canonicalization moved out of the
+    emitter and into the ResolveOperatorRefs / CanonicalizeCoordinates passes
+    (epic #114, issues #119 / #123). These behavioral tests must run both passes
+    before generating, exactly as :func:`giql.transpile.transpile` does, rather
+    than calling ``generate`` on a bare parsed AST.
+    """
+    ast = parse_one(sql, dialect=GIQLDialect)
+    ast = resolve_operator_refs(ast, Tables())
+    ast = canonicalize_coordinates(ast)
+    return BaseGIQLGenerator().generate(ast)
 
 
 class TestDistanceCalculation:
@@ -32,9 +50,7 @@ class TestDistanceCalculation:
         """
 
         # Parse and generate SQL
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         # Verify SQL contains CASE expression logic for overlaps
         assert "CASE" in output_sql
@@ -69,9 +85,7 @@ class TestDistanceCalculation:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -96,9 +110,7 @@ class TestDistanceCalculation:
             (SELECT 'chr2' as chrom, 150 as start, 250 as end) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -127,9 +139,7 @@ class TestDistanceCalculation:
             (SELECT 'chr1' as chrom, 200 as start, 300 as end) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -159,9 +169,7 @@ class TestDistanceCalculation:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -190,9 +198,7 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -217,9 +223,7 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '-' as strand) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -244,9 +248,7 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '-' as strand) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -271,9 +273,7 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -298,9 +298,7 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '.' as strand) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -325,9 +323,7 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -352,9 +348,7 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()
@@ -379,9 +373,7 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 150 as start, 250 as end, '-' as strand) b
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator()
-        output_sql = generator.generate(ast)
+        output_sql = _generate(sql)
 
         conn = duckdb.connect(":memory:")
         result = conn.execute(output_sql).fetchone()

--- a/tests/test_nearest_transpilation.py
+++ b/tests/test_nearest_transpilation.py
@@ -8,9 +8,26 @@ import pytest
 from sqlglot import parse_one
 
 from giql import Table
+from giql.canonicalizer import canonicalize_coordinates
 from giql.dialect import GIQLDialect
 from giql.generators import BaseGIQLGenerator
+from giql.resolver import resolve_operator_refs
 from giql.table import Tables
+
+
+def _generate(sql: str, tables: Tables) -> str:
+    """Parse, run normalization passes 1 and 2, then generate SQL.
+
+    Operator resolution and coordinate canonicalization moved out of the emitter
+    and into the ResolveOperatorRefs / CanonicalizeCoordinates passes (epic #114,
+    issues #118-#123). Emitter-level tests must run both passes before generating,
+    exactly as :func:`giql.transpile.transpile` does, rather than calling
+    ``generate`` on a bare parsed AST.
+    """
+    ast = parse_one(sql, dialect=GIQLDialect)
+    ast = resolve_operator_refs(ast, tables)
+    ast = canonicalize_coordinates(ast)
+    return BaseGIQLGenerator(tables=tables).generate(ast)
 
 
 @pytest.fixture
@@ -37,9 +54,7 @@ class TestNearestTranspilation:
         CROSS JOIN LATERAL NEAREST(genes, reference := peaks.interval, k := 3)
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate(sql, tables_with_peaks_and_genes)
 
         # Expectations:
         # - LATERAL subquery
@@ -65,9 +80,7 @@ class TestNearestTranspilation:
         CROSS JOIN LATERAL NEAREST(genes, reference := peaks.interval, k := 5, max_distance := 100000)
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate(sql, tables_with_peaks_and_genes)
 
         # Expectations:
         # - LATERAL subquery
@@ -88,9 +101,7 @@ class TestNearestTranspilation:
         FROM NEAREST(genes, reference := 'chr1:1000-2000', k := 3)
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate(sql, tables_with_peaks_and_genes)
 
         # Expectations:
         # - No LATERAL (standalone mode)
@@ -113,9 +124,7 @@ class TestNearestTranspilation:
         CROSS JOIN LATERAL NEAREST(genes, reference := peaks.interval, k := 3, stranded := true)
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate(sql, tables_with_peaks_and_genes)
 
         # Expectations:
         # - LATERAL subquery
@@ -138,9 +147,7 @@ class TestNearestTranspilation:
         CROSS JOIN LATERAL NEAREST(genes, reference := peaks.interval, k := 3, signed := true)
         """
 
-        ast = parse_one(sql, dialect=GIQLDialect)
-        generator = BaseGIQLGenerator(tables=tables_with_peaks_and_genes)
-        output = generator.generate(ast)
+        output = _generate(sql, tables_with_peaks_and_genes)
 
         # Expectations:
         # - LATERAL subquery


### PR DESCRIPTION
## Summary

Implement step 10 of epic #114's staged migration plan — the final audit that closes the epic. Remove the now-dead resolution code from `BaseGIQLGenerator`: the legacy `_get_column_refs` / `_resolve_table` / `_resolve_table_name` path, the `select_sql` override, and its `_alias_to_table` / `_current_table` tracking, plus the unused imports. These were reachable only through the direct-`generate()` fallback the operator emitters carried during the migration; the emitters now read exclusively the metadata attached by the resolver pass, raising the historical diagnostics for genuinely unresolvable operands. The generator performs no name resolution, no scope walks, and no input coordinate canonicalization — `base.py` shrinks from 1251 to 1076 lines.

This is the **in-design** end state (see #125's scope boundary): output coordinate de-canonicalization (`decanonical_*` on the synthesized `disjoin_start`/`disjoin_end` and NEAREST passthrough columns) and the per-node `*_sql` string-expansion methods remain in the emitter, both deferred to the operator-expansion-to-AST epic #137.

Closes #125

## Proposed changes

**Generator (`src/giql/generators/base.py`)** — Delete the legacy resolution helpers, the `select_sql` alias-map override and its `__init__` state, and the now-unused imports. Remove the metadata-vs-legacy fallback branches from `_distance_operand`, `_predicate_operand` (dropping its `ctx_table` parameter), and `_nearest_resolution` (dropping the lazy `resolve_operator_refs` call) so each emitter reads only pass-1 metadata. Confirmed: no `canonical_start`/`canonical_end`, no scope walks, no name/column resolution remain.

**Tests (`tests/generators/test_base.py`, `tests/test_{distance,nearest}_transpilation.py`, `tests/test_distance_udf.py`)** — Repoint the tests that invoked the generator on a bare parsed AST through the full resolve-then-canonicalize pipeline (via a two-pass helper matching `transpile()`), preserving the coverage the deleted fallback provided. Expected SQL is unchanged in every repointed test; only the production call switches. Tests that raise before any metadata read stay on direct generation.

## Epic #114 status

With this merged, epic #114 is complete: the transpile pipeline runs two normalization passes (`ResolveOperatorRefs`, `CanonicalizeCoordinates`) before generation; operator slot resolution and coordinate canonicalization are declarative and centralized; CTE/subquery projection contracts are validated at transpile time; and the generator consumes resolved metadata rather than re-deriving it. The remaining emitter responsibilities (operator string-expansion and output de-canonicalization) are tracked as the successor epic #137, which promotes them to an AST expansion pass and a stock per-dialect serializer.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `tests/generators/test_base.py` (repointed) | An operator query parsed to AST | Generating through the resolve+canonicalize pipeline | Byte-identical SQL to the prior direct-generate path | Coverage preserved without the legacy fallback |
| 2 | `tests/test_distance_transpilation.py` (repointed) | Registered vs unregistered DISTANCE operands | Transpiling through the pipeline | Equivalent two-pass output | Fallback removal parity |
| 3 | `tests/test_distance_udf.py` (repointed) | The DISTANCE UDF execution cases | Generating through the pipeline | Identical executed results | End-to-end behavior unchanged |
| 4 | `tests/test_nearest_transpilation.py` (repointed) | NEAREST shapes | Transpiling through the pipeline | Identical SQL | NEAREST emitter reads only metadata |
| 5 | Full suite + bedtools oracle | The complete corpus | Running with bedtools on PATH | 1428 passed, no snapshot edits | Zero behavior change |