### PR TITLE
Fix off-by-one error in DISTANCE operator — Closes #134

### DIFF
--- a/docs/dialect/distance-operators.rst
+++ b/docs/dialect/distance-operators.rst
@@ -16,10 +16,11 @@ Description
 ~~~~~~~~~~~
 
 The ``DISTANCE`` operator returns the number of base pairs separating two genomic
-intervals. It follows standard genomic distance conventions:
+intervals, matching ``bedtools closest -d`` semantics:
 
 - **Overlapping intervals**: Returns ``0``
-- **Non-overlapping intervals**: Returns the gap in base pairs (positive integer)
+- **Book-ended (adjacent) intervals** (``A.end == B.start`` in half-open coordinates): Returns ``1``
+- **Non-overlapping intervals**: Returns the half-open gap plus one (a raw gap of ``N`` bases reports ``N + 1``)
 - **Different chromosomes**: Returns ``NULL``
 
 Syntax
@@ -42,7 +43,8 @@ Return Value
 ~~~~~~~~~~~~
 
 - ``0`` for overlapping intervals
-- Positive integer (gap in base pairs) for non-overlapping same-chromosome intervals
+- ``1`` for book-ended (adjacent) intervals, matching ``bedtools closest -d``
+- Positive integer (half-open gap ``+ 1``) for non-overlapping same-chromosome intervals
 - ``NULL`` for intervals on different chromosomes
 
 Examples

--- a/src/giql/generators/base.py
+++ b/src/giql/generators/base.py
@@ -587,6 +587,13 @@ class BaseGIQLGenerator(Generator):
     ) -> str:
         """Generate SQL CASE expression for distance calculation.
 
+        Distances follow bedtools ``closest -d`` semantics: overlapping
+        intervals report ``0``, book-ended (adjacent) intervals where
+        ``A.end == B.start`` in half-open coordinates report ``1``, and a raw
+        half-open gap of N bases reports ``N + 1``. The ``+ 1`` is applied to
+        the absolute gap magnitude before any directional sign, so a downstream
+        book-ended pair reports ``+1`` and an upstream one ``-1`` in signed mode.
+
         :param chrom_a:
             Chromosome column for interval A
         :param start_a:
@@ -619,15 +626,15 @@ class BaseGIQLGenerator(Generator):
                 return (
                     f"CASE WHEN {chrom_a} != {chrom_b} THEN NULL "
                     f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
-                    f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a}) "
-                    f"ELSE -({start_a} - {end_b}) END"
+                    f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a} + 1) "
+                    f"ELSE -({start_a} - {end_b} + 1) END"
                 )
             # Unsigned (absolute) distance
             return (
                 f"CASE WHEN {chrom_a} != {chrom_b} THEN NULL "
                 f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
-                f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a}) "
-                f"ELSE ({start_a} - {end_b}) END"
+                f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a} + 1) "
+                f"ELSE ({start_a} - {end_b} + 1) END"
             )
 
         # Stranded distance calculation
@@ -642,11 +649,11 @@ class BaseGIQLGenerator(Generator):
                 f"WHEN {strand_b} = '.' OR {strand_b} = '?' THEN NULL "
                 f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
                 f"WHEN {end_a} <= {start_b} THEN "
-                f"CASE WHEN {strand_a} = '-' THEN -({start_b} - {end_a}) "
-                f"ELSE ({start_b} - {end_a}) END "
+                f"CASE WHEN {strand_a} = '-' THEN -({start_b} - {end_a} + 1) "
+                f"ELSE ({start_b} - {end_a} + 1) END "
                 f"ELSE "
-                f"CASE WHEN {strand_a} = '-' THEN ({start_a} - {end_b}) "
-                f"ELSE -({start_a} - {end_b}) END END"
+                f"CASE WHEN {strand_a} = '-' THEN ({start_a} - {end_b} + 1) "
+                f"ELSE -({start_a} - {end_b} + 1) END END"
             )
         # Stranded but not signed: apply strand flip only
         return (
@@ -656,11 +663,11 @@ class BaseGIQLGenerator(Generator):
             f"WHEN {strand_b} = '.' OR {strand_b} = '?' THEN NULL "
             f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
             f"WHEN {end_a} <= {start_b} THEN "
-            f"CASE WHEN {strand_a} = '-' THEN -({start_b} - {end_a}) "
-            f"ELSE ({start_b} - {end_a}) END "
+            f"CASE WHEN {strand_a} = '-' THEN -({start_b} - {end_a} + 1) "
+            f"ELSE ({start_b} - {end_a} + 1) END "
             f"ELSE "
-            f"CASE WHEN {strand_a} = '-' THEN -({start_a} - {end_b}) "
-            f"ELSE ({start_a} - {end_b}) END END"
+            f"CASE WHEN {strand_a} = '-' THEN -({start_a} - {end_b} + 1) "
+            f"ELSE ({start_a} - {end_b} + 1) END END"
         )
 
     def _predicate_operand(self, expression: exp.Expression, arg: str) -> ResolvedColumn:

--- a/src/giql/mcp/server.py
+++ b/src/giql/mcp/server.py
@@ -65,7 +65,7 @@ OPERATORS: dict[str, dict[str, Any]] = {
             {"name": "interval_a", "description": "First genomic interval"},
             {"name": "interval_b", "description": "Second genomic interval"},
         ],
-        "returns": "0 for overlapping, positive integer for gap, NULL for different chromosomes",
+        "returns": "0 for overlapping, 1 for book-ended, half-open gap + 1 for a gap, NULL for different chromosomes",
         "example": "SELECT DISTANCE(a.interval, b.interval) AS dist FROM a CROSS JOIN b",
         "doc_file": "dialect/distance-operators.rst",
     },

--- a/tests/generators/test_base.py
+++ b/tests/generators/test_base.py
@@ -411,16 +411,16 @@ class TestBaseGIQLGenerator:
             "CASE WHEN 'chr1' != genes.\"chrom\" THEN NULL "
             'WHEN 1000 < genes."end" AND 2000 > genes."start" THEN 0 '
             'WHEN 2000 <= genes."start" '
-            'THEN (genes."start" - 2000) '
-            'ELSE (1000 - genes."end") END AS distance\n'
+            'THEN (genes."start" - 2000 + 1) '
+            'ELSE (1000 - genes."end" + 1) END AS distance\n'
             "                FROM genes\n"
             "                WHERE 'chr1' = genes.\"chrom\"\n"
             "                ORDER BY ABS("
             "CASE WHEN 'chr1' != genes.\"chrom\" THEN NULL "
             'WHEN 1000 < genes."end" AND 2000 > genes."start" THEN 0 '
             'WHEN 2000 <= genes."start" '
-            'THEN (genes."start" - 2000) '
-            'ELSE (1000 - genes."end") END)\n'
+            'THEN (genes."start" - 2000 + 1) '
+            'ELSE (1000 - genes."end" + 1) END)\n'
             "                LIMIT 3\n"
             "            )"
         )
@@ -446,8 +446,8 @@ class TestBaseGIQLGenerator:
             'WHEN peaks."start" < genes."end" '
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END AS distance\n'
+            'THEN (genes."start" - peaks."end" + 1) '
+            'ELSE (peaks."start" - genes."end" + 1) END AS distance\n'
             "                FROM genes\n"
             '                WHERE peaks."chrom" = genes."chrom"\n'
             "                ORDER BY ABS("
@@ -455,8 +455,8 @@ class TestBaseGIQLGenerator:
             'WHEN peaks."start" < genes."end" '
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END)\n'
+            'THEN (genes."start" - peaks."end" + 1) '
+            'ELSE (peaks."start" - genes."end" + 1) END)\n'
             "                LIMIT 3\n"
             "            )"
         )
@@ -483,8 +483,8 @@ class TestBaseGIQLGenerator:
             'WHEN peaks."start" < genes."end" '
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END AS distance\n'
+            'THEN (genes."start" - peaks."end" + 1) '
+            'ELSE (peaks."start" - genes."end" + 1) END AS distance\n'
             "                FROM genes\n"
             '                WHERE peaks."chrom" = genes."chrom" '
             "AND (ABS("
@@ -492,15 +492,15 @@ class TestBaseGIQLGenerator:
             'WHEN peaks."start" < genes."end" '
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END)) <= 100000\n'
+            'THEN (genes."start" - peaks."end" + 1) '
+            'ELSE (peaks."start" - genes."end" + 1) END)) <= 100000\n'
             "                ORDER BY ABS("
             'CASE WHEN peaks."chrom" != genes."chrom" THEN NULL '
             'WHEN peaks."start" < genes."end" '
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE (peaks."start" - genes."end") END)\n'
+            'THEN (genes."start" - peaks."end" + 1) '
+            'ELSE (peaks."start" - genes."end" + 1) END)\n'
             "                LIMIT 5\n"
             "            )"
         )
@@ -531,11 +531,11 @@ class TestBaseGIQLGenerator:
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
             "THEN CASE WHEN peaks.\"strand\" = '-' "
-            'THEN -(genes."start" - peaks."end") '
-            'ELSE (genes."start" - peaks."end") END '
+            'THEN -(genes."start" - peaks."end" + 1) '
+            'ELSE (genes."start" - peaks."end" + 1) END '
             "ELSE CASE WHEN peaks.\"strand\" = '-' "
-            'THEN -(peaks."start" - genes."end") '
-            'ELSE (peaks."start" - genes."end") END END AS distance\n'
+            'THEN -(peaks."start" - genes."end" + 1) '
+            'ELSE (peaks."start" - genes."end" + 1) END END AS distance\n'
             "                FROM genes\n"
             '                WHERE peaks."chrom" = genes."chrom" '
             'AND peaks."strand" = genes."strand"\n'
@@ -548,11 +548,11 @@ class TestBaseGIQLGenerator:
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
             "THEN CASE WHEN peaks.\"strand\" = '-' "
-            'THEN -(genes."start" - peaks."end") '
-            'ELSE (genes."start" - peaks."end") END '
+            'THEN -(genes."start" - peaks."end" + 1) '
+            'ELSE (genes."start" - peaks."end" + 1) END '
             "ELSE CASE WHEN peaks.\"strand\" = '-' "
-            'THEN -(peaks."start" - genes."end") '
-            'ELSE (peaks."start" - genes."end") END END)\n'
+            'THEN -(peaks."start" - genes."end" + 1) '
+            'ELSE (peaks."start" - genes."end" + 1) END END)\n'
             "                LIMIT 3\n"
             "            )"
         )
@@ -603,8 +603,8 @@ class TestBaseGIQLGenerator:
             'WHEN peaks."start" < genes."end" '
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE -(peaks."start" - genes."end") END AS distance\n'
+            'THEN (genes."start" - peaks."end" + 1) '
+            'ELSE -(peaks."start" - genes."end" + 1) END AS distance\n'
             "                FROM genes\n"
             '                WHERE peaks."chrom" = genes."chrom"\n'
             "                ORDER BY ABS("
@@ -612,8 +612,8 @@ class TestBaseGIQLGenerator:
             'WHEN peaks."start" < genes."end" '
             'AND peaks."end" > genes."start" THEN 0 '
             'WHEN peaks."end" <= genes."start" '
-            'THEN (genes."start" - peaks."end") '
-            'ELSE -(peaks."start" - genes."end") END)\n'
+            'THEN (genes."start" - peaks."end" + 1) '
+            'ELSE -(peaks."start" - genes."end" + 1) END)\n'
             "                LIMIT 3\n"
             "            )"
         )
@@ -683,8 +683,8 @@ class TestBaseGIQLGenerator:
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
             'WHEN a."start" < b."end" AND a."end" > b."start" '
             'THEN 0 WHEN a."end" <= b."start" '
-            'THEN (b."start" - a."end") '
-            'ELSE (a."start" - b."end") END AS dist '
+            'THEN (b."start" - a."end" + 1) '
+            'ELSE (a."start" - b."end" + 1) END AS dist '
             "FROM features_a AS a CROSS JOIN features_b AS b"
         )
         assert output == expected
@@ -711,11 +711,11 @@ class TestBaseGIQLGenerator:
             'AND a."end" > b."start" THEN 0 '
             'WHEN a."end" <= b."start" '
             "THEN CASE WHEN a.\"strand\" = '-' "
-            'THEN -(b."start" - a."end") '
-            'ELSE (b."start" - a."end") END '
+            'THEN -(b."start" - a."end" + 1) '
+            'ELSE (b."start" - a."end" + 1) END '
             "ELSE CASE WHEN a.\"strand\" = '-' "
-            'THEN -(a."start" - b."end") '
-            'ELSE (a."start" - b."end") END END AS dist '
+            'THEN -(a."start" - b."end" + 1) '
+            'ELSE (a."start" - b."end" + 1) END END AS dist '
             "FROM features_a AS a CROSS JOIN features_b AS b"
         )
         assert output == expected
@@ -737,8 +737,8 @@ class TestBaseGIQLGenerator:
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
             'WHEN a."start" < b."end" AND a."end" > b."start" '
             'THEN 0 WHEN a."end" <= b."start" '
-            'THEN (b."start" - a."end") '
-            'ELSE -(a."start" - b."end") END AS dist '
+            'THEN (b."start" - a."end" + 1) '
+            'ELSE -(a."start" - b."end" + 1) END AS dist '
             "FROM features_a AS a CROSS JOIN features_b AS b"
         )
         assert output == expected
@@ -766,27 +766,28 @@ class TestBaseGIQLGenerator:
             'AND a."end" > b."start" THEN 0 '
             'WHEN a."end" <= b."start" '
             "THEN CASE WHEN a.\"strand\" = '-' "
-            'THEN -(b."start" - a."end") '
-            'ELSE (b."start" - a."end") END '
+            'THEN -(b."start" - a."end" + 1) '
+            'ELSE (b."start" - a."end" + 1) END '
             "ELSE CASE WHEN a.\"strand\" = '-' "
-            'THEN (a."start" - b."end") '
-            'ELSE -(a."start" - b."end") END END AS dist '
+            'THEN (a."start" - b."end" + 1) '
+            'ELSE -(a."start" - b."end" + 1) END END AS dist '
             "FROM features_a AS a CROSS JOIN features_b AS b"
         )
         assert output == expected
 
-    def test_giqldistance_should_not_apply_gap_plus_one_for_closed_intervals(
+    def test_giqldistance_canonicalizes_closed_ends_apart_from_gap_parity(
         self, tables_with_closed_intervals
     ):
-        """Test DISTANCE on closed-interval tables omits "+1" gap counting.
+        """Test DISTANCE on closed-interval tables keeps encoding and gap "+1" separate.
 
         Given:
             Two 0-based closed-interval tables and DISTANCE.
         When:
             giqldistance_sql is called.
         Then:
-            It should canonicalize each table-side end as (end + 1) but omit
-            any "+1" from the gap branches.
+            It should canonicalize each table-side end as (end + 1) for the
+            closed->half-open conversion, distinct from the bedtools-parity
+            + 1 the gap branches add to the canonical gap.
         """
         # Arrange
         tables_with_closed_intervals.register(
@@ -807,8 +808,8 @@ class TestBaseGIQLGenerator:
             'WHEN a."start" < (b."end" + 1) '
             'AND (a."end" + 1) > b."start" THEN 0 '
             'WHEN (a."end" + 1) <= b."start" '
-            'THEN (b."start" - (a."end" + 1)) '
-            'ELSE (a."start" - (b."end" + 1)) END AS dist '
+            'THEN (b."start" - (a."end" + 1) + 1) '
+            'ELSE (a."start" - (b."end" + 1) + 1) END AS dist '
             "FROM bed_features AS a CROSS JOIN bed_features_b AS b"
         )
         assert output == expected
@@ -898,10 +899,10 @@ class TestBaseGIQLGenerator:
         assert 'peaks."strand"' in output
         assert 'genes."strand"' in output
 
-    def test_giqlnearest_should_not_apply_gap_plus_one_for_closed_intervals(
+    def test_giqlnearest_canonicalizes_closed_end_in_wrapper_apart_from_gap_parity(
         self,
     ):
-        """Test NEAREST on a closed-interval target omits "+1" gap counting.
+        """Test NEAREST on a closed-interval target keeps encoding and gap "+1" separate.
 
         Given:
             A 0-based closed-interval target table and NEAREST.
@@ -909,8 +910,8 @@ class TestBaseGIQLGenerator:
             The query is transpiled.
         Then:
             It should canonicalize the target end as (end + 1) inside the
-            wrapper CTE while the distance gap branches read the bare canonical
-            end with no trailing "+ 1".
+            wrapper CTE, distinct from the bedtools-parity + 1 the distance gap
+            branches add to the canonical gap.
         """
         # Arrange
         sql = (
@@ -923,12 +924,36 @@ class TestBaseGIQLGenerator:
         # the distance CASE reads the bare canonical columns.
         output = transpile(sql, tables=[Table("genes_closed", interval_type="closed")])
 
-        # Assert — the wrapper carries (end + 1); the gap branches carry no "+ 1".
+        # Assert — the wrapper carries the closed->half-open (end + 1); the gap
+        # branches read the canonical columns and add the bedtools-parity + 1.
         assert '("end" + 1) AS "end"' in output
-        assert 'THEN (__giql_canon_0."start" - 2000)' in output
-        assert 'ELSE (1000 - __giql_canon_0."end")' in output
-        assert '__giql_canon_0."start" - 2000 + 1' not in output
-        assert '1000 - __giql_canon_0."end" + 1' not in output
+        assert 'THEN (__giql_canon_0."start" - 2000 + 1)' in output
+        assert 'ELSE (1000 - __giql_canon_0."end" + 1)' in output
+
+    def test_giqlnearest_closed_interval_does_not_double_count_plus_one(self):
+        """Test NEAREST on a closed target never fuses the two +1 terms.
+
+        Given:
+            A 0-based closed-interval target table and NEAREST.
+        When:
+            The query is transpiled.
+        Then:
+            It should keep the encoding (end + 1) and the gap-parity + 1 as
+            separate terms — never collapsing them into a `+ 1 + 1` /
+            `(end + 1 + 1)` that would double-count the off-by-one.
+        """
+        # Arrange
+        sql = (
+            "SELECT * FROM NEAREST(genes_closed, reference := 'chr1:1000-2000', k := 3)"
+        )
+
+        # Act
+        output = transpile(sql, tables=[Table("genes_closed", interval_type="closed")])
+
+        # Assert
+        assert "+ 1 + 1" not in output
+        assert '("end" + 1 + 1)' not in output
+        assert '("start" + 1 + 1)' not in output
 
     def test_giqldistance_sql_literal_first_arg_error(self, tables_with_two_tables):
         """
@@ -1607,8 +1632,8 @@ class TestBaseGIQLGenerator:
         expected = (
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
             f"WHEN {start_a} < {end_b} AND {end_a} > {start_b} THEN 0 "
-            f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a}) "
-            f"ELSE ({start_a} - {end_b}) END AS dist "
+            f"WHEN {end_a} <= {start_b} THEN ({start_b} - {end_a} + 1) "
+            f"ELSE ({start_a} - {end_b} + 1) END AS dist "
             "FROM dist_a AS a CROSS JOIN dist_b AS b"
         )
         assert output == expected
@@ -1642,8 +1667,8 @@ class TestBaseGIQLGenerator:
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
             'WHEN a."start" < b."end" AND a."end" > (b."start" - 1) THEN 0 '
             'WHEN a."end" <= (b."start" - 1) '
-            'THEN ((b."start" - 1) - a."end") '
-            'ELSE (a."start" - b."end") END AS dist '
+            'THEN ((b."start" - 1) - a."end" + 1) '
+            'ELSE (a."start" - b."end" + 1) END AS dist '
             "FROM bed_a AS a CROSS JOIN vcf_b AS b"
         )
         assert output == expected
@@ -1715,9 +1740,9 @@ class TestBaseGIQLGenerator:
             'WHEN 1000 < __giql_canon_0."end" AND 2000 > __giql_canon_0."start" THEN 0'
         ) in output
         assert (
-            'WHEN 2000 <= __giql_canon_0."start" THEN (__giql_canon_0."start" - 2000)'
+            'WHEN 2000 <= __giql_canon_0."start" THEN (__giql_canon_0."start" - 2000 + 1)'
         ) in output
-        assert 'ELSE (1000 - __giql_canon_0."end")' in output
+        assert 'ELSE (1000 - __giql_canon_0."end" + 1)' in output
 
     def test_giqlnearest_should_pass_target_columns_through_when_target_is_canonical(
         self,
@@ -1836,5 +1861,5 @@ class TestBaseGIQLGenerator:
             'AND vcf_b."end" > bed_a."start" THEN 0'
         ) in output
         assert 'WHEN vcf_b."end" <= bed_a."start"' in output
-        assert 'THEN (bed_a."start" - vcf_b."end")' in output
-        assert 'ELSE ((vcf_b."start" - 1) - bed_a."end")' in output
+        assert 'THEN (bed_a."start" - vcf_b."end" + 1)' in output
+        assert 'ELSE ((vcf_b."start" - 1) - bed_a."end" + 1)' in output

--- a/tests/integration/bedtools/test_distance.py
+++ b/tests/integration/bedtools/test_distance.py
@@ -5,69 +5,171 @@ genomic distance between intervals, cross-validated against bedtools
 closest -d output.
 """
 
+import pytest
+
+from .utils.bedtools_wrapper import closest
 from .utils.data_models import GenomicInterval
+
+
+def _oracle_distance(a: GenomicInterval, b: GenomicInterval) -> int:
+    """Return the bedtools ``closest -d`` distance between a single A and B."""
+    return closest([a.to_tuple()], [b.to_tuple()])[0][12]
 
 
 def test_distance_non_overlapping(giql_query):
     """
     GIVEN two non-overlapping intervals with a known gap
     WHEN DISTANCE is computed via GIQL
-    THEN the distance equals b.start - a.end (half-open arithmetic)
+    THEN the distance matches live bedtools closest -d
     """
+    a = GenomicInterval("chr1", 100, 200, "a1", 100, "+")
+    b = GenomicInterval("chr1", 300, 400, "b1", 100, "+")
     result = giql_query(
         """
         SELECT DISTANCE(a.interval, b.interval) AS dist
         FROM intervals_a a, intervals_b b
         """,
         tables=["intervals_a", "intervals_b"],
-        intervals_a=[GenomicInterval("chr1", 100, 200, "a1", 100, "+")],
-        intervals_b=[GenomicInterval("chr1", 300, 400, "b1", 100, "+")],
+        intervals_a=[a],
+        intervals_b=[b],
     )
 
     assert len(result) == 1
-    # Half-open distance: b.start - a.end = 300 - 200 = 100
-    assert result[0][0] == 100
+    assert result[0][0] == _oracle_distance(a, b)
 
 
 def test_distance_overlapping(giql_query):
     """
     GIVEN two overlapping intervals
     WHEN DISTANCE is computed via GIQL
-    THEN the distance is 0
+    THEN the distance is 0, matching live bedtools closest -d
     """
+    a = GenomicInterval("chr1", 100, 300, "a1", 100, "+")
+    b = GenomicInterval("chr1", 200, 400, "b1", 100, "+")
     result = giql_query(
         """
         SELECT DISTANCE(a.interval, b.interval) AS dist
         FROM intervals_a a, intervals_b b
         """,
         tables=["intervals_a", "intervals_b"],
-        intervals_a=[GenomicInterval("chr1", 100, 300, "a1", 100, "+")],
-        intervals_b=[GenomicInterval("chr1", 200, 400, "b1", 100, "+")],
+        intervals_a=[a],
+        intervals_b=[b],
     )
 
     assert len(result) == 1
-    assert result[0][0] == 0
+    assert result[0][0] == _oracle_distance(a, b)
 
 
 def test_distance_adjacent(giql_query):
     """
     GIVEN two adjacent intervals (touching, half-open coordinates)
     WHEN DISTANCE is computed via GIQL
-    THEN the distance is 0 (half-open: end of A == start of B means no gap)
+    THEN the distance is 1, matching live bedtools closest -d for book-ended features
     """
+    a = GenomicInterval("chr1", 100, 200, "a1", 100, "+")
+    b = GenomicInterval("chr1", 200, 300, "b1", 100, "+")
     result = giql_query(
         """
         SELECT DISTANCE(a.interval, b.interval) AS dist
         FROM intervals_a a, intervals_b b
         """,
         tables=["intervals_a", "intervals_b"],
-        intervals_a=[GenomicInterval("chr1", 100, 200, "a1", 100, "+")],
-        intervals_b=[GenomicInterval("chr1", 200, 300, "b1", 100, "+")],
+        intervals_a=[a],
+        intervals_b=[b],
     )
 
     assert len(result) == 1
-    # Half-open adjacent: b.start - a.end = 200 - 200 = 0
-    assert result[0][0] == 0
+    assert result[0][0] == _oracle_distance(a, b)
+
+
+@pytest.mark.parametrize(
+    ("b_start", "b_end"),
+    [
+        (150, 250),  # overlapping
+        (200, 300),  # book-ended downstream
+        (201, 300),  # 1 bp gap
+        (202, 300),  # 2 bp gap
+        (300, 400),  # 100 bp gap
+        (10200, 10300),  # large gap
+    ],
+    ids=["overlap", "book_ended", "gap_1bp", "gap_2bp", "gap_100bp", "gap_large"],
+)
+def test_distance_matches_bedtools_across_gap_sizes(giql_query, b_start, b_end):
+    """
+    GIVEN A chr1:100-200 and B at a range of gaps from overlap to a large gap
+    WHEN DISTANCE is computed via GIQL
+    THEN the result equals live bedtools closest -d for every gap, so a future
+        off-by-one in either direction fails automatically
+    """
+    a = GenomicInterval("chr1", 100, 200, "a1", 100, "+")
+    b = GenomicInterval("chr1", b_start, b_end, "b1", 100, "+")
+    result = giql_query(
+        """
+        SELECT DISTANCE(a.interval, b.interval) AS dist
+        FROM intervals_a a, intervals_b b
+        """,
+        tables=["intervals_a", "intervals_b"],
+        intervals_a=[a],
+        intervals_b=[b],
+    )
+
+    assert len(result) == 1
+    assert result[0][0] == _oracle_distance(a, b)
+
+
+def test_distance_book_ended_upstream_matches_bedtools(giql_query):
+    """
+    GIVEN a book-ended pair with B upstream of A (A chr1:200-300, B chr1:100-200)
+    WHEN DISTANCE is computed via GIQL
+    THEN the result is 1, matching bedtools, confirming direction symmetry of
+        the parity +1
+    """
+    a = GenomicInterval("chr1", 200, 300, "a1", 100, "+")
+    b = GenomicInterval("chr1", 100, 200, "b1", 100, "+")
+    result = giql_query(
+        """
+        SELECT DISTANCE(a.interval, b.interval) AS dist
+        FROM intervals_a a, intervals_b b
+        """,
+        tables=["intervals_a", "intervals_b"],
+        intervals_a=[a],
+        intervals_b=[b],
+    )
+
+    assert len(result) == 1
+    assert result[0][0] == _oracle_distance(a, b)
+
+
+def test_distance_multi_row_cross_join_matches_bedtools(giql_query):
+    """
+    GIVEN two A intervals and two B intervals at mixed gaps in one query
+    WHEN DISTANCE is computed for every (a, b) pair via a GIQL cross join
+    THEN each pair's distance equals live bedtools closest -d for that pair,
+        exercising the multi-row table-scan path
+    """
+    a_rows = [
+        GenomicInterval("chr1", 100, 200, "a1", 100, "+"),
+        GenomicInterval("chr1", 500, 600, "a2", 100, "+"),
+    ]
+    b_rows = [
+        GenomicInterval("chr1", 200, 300, "b1", 100, "+"),
+        GenomicInterval("chr1", 800, 900, "b2", 100, "+"),
+    ]
+    result = giql_query(
+        """
+        SELECT a.name, b.name, DISTANCE(a.interval, b.interval) AS dist
+        FROM intervals_a a, intervals_b b
+        """,
+        tables=["intervals_a", "intervals_b"],
+        intervals_a=a_rows,
+        intervals_b=b_rows,
+    )
+
+    by_pair = {(row[0], row[1]): row[2] for row in result}
+    assert len(by_pair) == 4
+    for a in a_rows:
+        for b in b_rows:
+            assert by_pair[(a.name, b.name)] == _oracle_distance(a, b)
 
 
 def test_distance_cross_chromosome(giql_query):
@@ -96,7 +198,7 @@ def test_distance_signed_downstream(giql_query):
     """
     GIVEN B is downstream of A (B starts after A ends) on + strand
     WHEN DISTANCE with signed := true is computed
-    THEN the distance is positive (downstream)
+    THEN the distance is +101, the gap (100) plus the bedtools parity 1
     """
     result = giql_query(
         """
@@ -109,14 +211,14 @@ def test_distance_signed_downstream(giql_query):
     )
 
     assert len(result) == 1
-    assert result[0][0] > 0, f"Expected positive (downstream), got {result[0][0]}"
+    assert result[0][0] == 101, f"Expected +101 (downstream), got {result[0][0]}"
 
 
 def test_distance_signed_upstream(giql_query):
     """
     GIVEN B is upstream of A (B ends before A starts) on + strand
     WHEN DISTANCE with signed := true is computed
-    THEN the distance is negative (upstream)
+    THEN the distance is -101, the gap (100) plus parity 1, negated for upstream
     """
     result = giql_query(
         """
@@ -129,7 +231,7 @@ def test_distance_signed_upstream(giql_query):
     )
 
     assert len(result) == 1
-    assert result[0][0] < 0, f"Expected negative (upstream), got {result[0][0]}"
+    assert result[0][0] == -101, f"Expected -101 (upstream), got {result[0][0]}"
 
 
 def test_distance_stranded_unstranded_input(giql_query):
@@ -158,21 +260,23 @@ def test_distance_stranded_same_strand(giql_query):
     """
     GIVEN two non-overlapping intervals both on + strand
     WHEN DISTANCE with stranded := true is computed
-    THEN the distance is computed normally (same strand is valid)
+    THEN the distance matches live bedtools closest -d (same + strand, no flip)
     """
+    a = GenomicInterval("chr1", 100, 200, "a1", 100, "+")
+    b = GenomicInterval("chr1", 300, 400, "b1", 100, "+")
     result = giql_query(
         """
         SELECT DISTANCE(a.interval, b.interval, stranded := true) AS dist
         FROM intervals_a a, intervals_b b
         """,
         tables=["intervals_a", "intervals_b"],
-        intervals_a=[GenomicInterval("chr1", 100, 200, "a1", 100, "+")],
-        intervals_b=[GenomicInterval("chr1", 300, 400, "b1", 100, "+")],
+        intervals_a=[a],
+        intervals_b=[b],
     )
 
     assert len(result) == 1
-    # Both on same + strand, distance should be computed normally
-    assert result[0][0] == 100, f"Expected 100, got {result[0][0]}"
+    # Same + strand applies no flip, so the value matches the unsigned oracle.
+    assert result[0][0] == _oracle_distance(a, b)
 
 
 def test_distance_signed_stranded_minus_strand(giql_query):
@@ -197,8 +301,6 @@ def test_distance_signed_stranded_minus_strand(giql_query):
     )
 
     assert len(result) == 1
-    # On - strand with signed+stranded, genomic downstream becomes
-    # transcript upstream, so sign should be negative
-    assert result[0][0] < 0, (
-        f"Expected negative distance on - strand, got {result[0][0]}"
-    )
+    # On - strand with signed+stranded, genomic downstream becomes transcript
+    # upstream, so the sign flips: -(gap 100 + parity 1) = -101.
+    assert result[0][0] == -101, f"Expected -101 on - strand, got {result[0][0]}"

--- a/tests/integration/bedtools/test_nearest.py
+++ b/tests/integration/bedtools/test_nearest.py
@@ -45,36 +45,36 @@ def test_nearest_non_overlapping(duckdb_connection):
 
     sql = transpile(
         """
-        SELECT a.*, b.*
+        SELECT a.name, b.name, b.distance
         FROM intervals_a a
         CROSS JOIN LATERAL NEAREST(
             intervals_b,
             reference := a.interval,
             k := 1
         ) b
-        ORDER BY a.chrom, a.start
         """,
         tables=["intervals_a", "intervals_b"],
     )
     giql_result = duckdb_connection.execute(sql).fetchall()
 
-    # Verify row counts match
-    assert len(giql_result) == len(bedtools_result), (
-        f"Row count mismatch: GIQL={len(giql_result)}, bedtools={len(bedtools_result)}"
+    # Align both sides by A name; the bedtools closest row is BED6+BED6+distance,
+    # so A name is field 3, B name field 9, and distance field 12.
+    giql_by_a = {a_name: (b_name, distance) for a_name, b_name, distance in giql_result}
+    bt_by_a = {row[3]: (row[9], row[12]) for row in bedtools_result}
+
+    assert giql_by_a.keys() == bt_by_a.keys(), (
+        f"A coverage mismatch: GIQL={set(giql_by_a)}, bedtools={set(bt_by_a)}"
     )
 
-    # Verify each A interval found the correct B neighbor
-    for giql_row, bt_row in zip(
-        sorted(giql_result, key=lambda r: (r[0], r[1])),
-        sorted(bedtools_result, key=lambda r: (r[0], r[1])),
-    ):
-        # Compare A interval name
-        assert giql_row[3] == bt_row[3], (
-            f"A name mismatch: GIQL={giql_row[3]}, bedtools={bt_row[3]}"
+    for a_name, (bt_b_name, bt_distance) in bt_by_a.items():
+        giql_b_name, giql_distance = giql_by_a[a_name]
+        # Matched B neighbor must agree.
+        assert giql_b_name == bt_b_name, (
+            f"{a_name} B mismatch: GIQL={giql_b_name}, bedtools={bt_b_name}"
         )
-        # Compare matched B interval name
-        assert giql_row[9] == bt_row[9], (
-            f"B name mismatch: GIQL={giql_row[9]}, bedtools={bt_row[9]}"
+        # GIQL distance is signed; its magnitude must equal bedtools closest -d.
+        assert abs(giql_distance) == bt_distance, (
+            f"{a_name} distance mismatch: GIQL={giql_distance}, bedtools={bt_distance}"
         )
 
 
@@ -173,11 +173,11 @@ def test_nearest_boundary_cases(giql_query):
     """
     GIVEN adjacent intervals (touching but not overlapping)
     WHEN NEAREST operator is applied
-    THEN adjacent interval is reported as nearest (distance = 0)
+    THEN adjacent interval is reported as nearest (distance = 1, bedtools parity)
     """
     result = giql_query(
         """
-        SELECT a.*, b.*
+        SELECT b.name, b.distance
         FROM intervals_a a
         CROSS JOIN LATERAL NEAREST(
             intervals_b,
@@ -194,8 +194,10 @@ def test_nearest_boundary_cases(giql_query):
     )
 
     assert len(result) == 1
-    # b1 is adjacent (distance 0), b2 is far (distance 300)
-    assert result[0][9] == "b1"
+    # b1 is adjacent (book-ended), reported as distance 1 under bedtools parity;
+    # b2 is far (301).
+    assert result[0][0] == "b1"
+    assert result[0][1] == 1
 
 
 def test_nearest_k_greater_than_one(giql_query):
@@ -228,6 +230,51 @@ def test_nearest_k_greater_than_one(giql_query):
     assert set(b_names) == {"b_far", "b_near", "b_farther"}
 
 
+def test_nearest_k3_reported_distance_matches_bedtools(duckdb_connection):
+    """
+    GIVEN one query interval and three candidates at distinct (untied) gaps
+    WHEN NEAREST with k := 3 is applied and the distance column is read
+    THEN each neighbor's reported distance magnitude equals live bedtools
+        closest -d -k 3 for the same neighbor
+    """
+    intervals_a = [GenomicInterval("chr1", 200, 300, "a1", 100, "+")]
+    intervals_b = [
+        GenomicInterval("chr1", 310, 350, "b_near", 100, "+"),  # gap 10 -> 11
+        GenomicInterval("chr1", 400, 450, "b_mid", 100, "+"),  # gap 100 -> 101
+        GenomicInterval("chr1", 600, 700, "b_far", 100, "+"),  # gap 300 -> 301
+    ]
+
+    load_intervals(duckdb_connection, "intervals_a", [i.to_tuple() for i in intervals_a])
+    load_intervals(duckdb_connection, "intervals_b", [i.to_tuple() for i in intervals_b])
+
+    bedtools_result = closest(
+        [i.to_tuple() for i in intervals_a],
+        [i.to_tuple() for i in intervals_b],
+        k=3,
+    )
+    oracle_by_name = {row[9]: row[12] for row in bedtools_result}
+
+    sql = transpile(
+        """
+        SELECT b.name, b.distance
+        FROM intervals_a a
+        CROSS JOIN LATERAL NEAREST(
+            intervals_b,
+            reference := a.interval,
+            k := 3
+        ) b
+        """,
+        tables=["intervals_a", "intervals_b"],
+    )
+    giql_result = duckdb_connection.execute(sql).fetchall()
+
+    assert len(giql_result) == 3
+    for name, distance in giql_result:
+        assert abs(distance) == oracle_by_name[name], (
+            f"{name}: GIQL={distance}, bedtools={oracle_by_name[name]}"
+        )
+
+
 def test_nearest_k_exceeds_available(giql_query):
     """
     GIVEN one query interval and only two database intervals
@@ -257,13 +304,15 @@ def test_nearest_k_exceeds_available(giql_query):
 
 def test_nearest_max_distance(giql_query):
     """
-    GIVEN one query interval, one near and one far database interval
+    GIVEN candidates whose reported distances straddle max_distance := 50: one
+        below, one exactly at 50, and one at 51
     WHEN NEAREST with max_distance := 50 is applied
-    THEN only the near interval (within 50bp) is returned
+    THEN the candidates at 11 and exactly 50 are kept and the one at 51 is
+        excluded, pinning the inclusive `<= max_distance` boundary on both sides
     """
     result = giql_query(
         """
-        SELECT a.name, b.name
+        SELECT b.name, b.distance
         FROM intervals_a a
         CROSS JOIN LATERAL NEAREST(
             intervals_b,
@@ -275,14 +324,21 @@ def test_nearest_max_distance(giql_query):
         tables=["intervals_a", "intervals_b"],
         intervals_a=[GenomicInterval("chr1", 200, 300, "a1", 100, "+")],
         intervals_b=[
+            # gap 10 -> reported 11 (well within)
             GenomicInterval("chr1", 310, 350, "b_near", 100, "+"),
-            GenomicInterval("chr1", 500, 600, "b_far", 100, "+"),
+            # gap 49 -> reported 50 == max_distance (inclusive, kept)
+            GenomicInterval("chr1", 349, 400, "b_edge", 100, "+"),
+            # gap 50 -> reported 51 == max_distance + 1 (excluded)
+            GenomicInterval("chr1", 350, 450, "b_over", 100, "+"),
         ],
     )
 
-    b_names = [row[1] for row in result]
-    # b_near is 10bp away (310 - 300), b_far is 200bp away (500 - 300)
-    assert b_names == ["b_near"], f"Expected only b_near within 50bp, got {b_names}"
+    by_name = {row[0]: row[1] for row in result}
+    assert sorted(by_name) == ["b_edge", "b_near"], (
+        f"Expected b_near and b_edge within 50bp, got {sorted(by_name)}"
+    )
+    assert by_name["b_near"] == 11
+    assert by_name["b_edge"] == 50  # exactly at the boundary, kept
 
 
 def test_nearest_standalone_literal_reference(giql_query):

--- a/tests/integration/bedtools/test_nearest_property.py
+++ b/tests/integration/bedtools/test_nearest_property.py
@@ -1,0 +1,153 @@
+"""Property-based correctness tests for the NEAREST distance shift (#134).
+
+These tests use Hypothesis to generate random reference intervals and
+candidate sets, then verify three invariants of the bedtools-parity +1
+applied to NEAREST: the reported distance equals the half-open gap plus
+one (zero for overlaps), the k-nearest *selection* is unchanged by the
+uniform monotonic shift, and ``max_distance`` filters on the shifted
+distance.
+"""
+
+import pytest
+from hypothesis import HealthCheck
+from hypothesis import given
+from hypothesis import settings
+from hypothesis import strategies as st
+
+from giql import transpile
+
+from .utils.data_models import GenomicInterval
+from .utils.duckdb_loader import load_intervals
+
+duckdb = pytest.importorskip("duckdb")
+
+
+def _expected_distance(ref: GenomicInterval, cand: GenomicInterval) -> int:
+    """Compute the bedtools-parity distance between two half-open intervals.
+
+    Overlapping intervals are 0; otherwise the raw half-open gap plus one.
+    """
+    if ref.start < cand.end and ref.end > cand.start:
+        return 0
+    if cand.start >= ref.end:
+        return cand.start - ref.end + 1
+    return ref.start - cand.end + 1
+
+
+@st.composite
+def _candidates(draw, min_size=1, max_size=20):
+    """Generate a list of same-chromosome candidate intervals with unique names."""
+    n = draw(st.integers(min_value=min_size, max_value=max_size))
+    candidates = []
+    for i in range(n):
+        start = draw(st.integers(min_value=0, max_value=120_000))
+        length = draw(st.integers(min_value=1, max_value=5_000))
+        candidates.append(
+            GenomicInterval("chr1", start, start + length, f"c{i}", 100, "+")
+        )
+    return candidates
+
+
+@st.composite
+def _reference(draw):
+    """Generate a single canonical (0-based half-open) reference interval."""
+    start = draw(st.integers(min_value=0, max_value=100_000))
+    length = draw(st.integers(min_value=1, max_value=5_000))
+    return GenomicInterval("chr1", start, start + length, "ref", 100, "+")
+
+
+def _run_nearest(reference, candidates, k, max_distance=None):
+    """Run standalone NEAREST in DuckDB and return [(name, distance), ...]."""
+    conn = duckdb.connect(":memory:")
+    try:
+        load_intervals(conn, "candidates", [c.to_tuple() for c in candidates])
+        max_clause = "" if max_distance is None else f", max_distance := {max_distance}"
+        sql = transpile(
+            f"""
+            SELECT name, distance
+            FROM NEAREST(
+                candidates,
+                reference := 'chr1:{reference.start}-{reference.end}',
+                k := {k}{max_clause}
+            )
+            """,
+            tables=["candidates"],
+        )
+        return conn.execute(sql).fetchall()
+    finally:
+        conn.close()
+
+
+@given(reference=_reference(), candidates=_candidates())
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_nearest_reported_distance_equals_gap_plus_one(reference, candidates):
+    """
+    GIVEN a random reference interval and a random candidate set
+    WHEN NEAREST returns every candidate with its distance
+    THEN each reported distance equals the half-open gap + 1 (0 for overlaps)
+    """
+    by_name = {c.name: c for c in candidates}
+
+    rows = _run_nearest(reference, candidates, k=len(candidates))
+
+    for name, distance in rows:
+        assert distance == _expected_distance(reference, by_name[name]), (
+            f"{name}: reported {distance}, expected "
+            f"{_expected_distance(reference, by_name[name])}"
+        )
+
+
+@given(data=st.data(), reference=_reference(), candidates=_candidates())
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_nearest_k_selection_is_unchanged_by_the_shift(data, reference, candidates):
+    """
+    GIVEN a random reference, candidate set, and k
+    WHEN NEAREST returns the k nearest candidates
+    THEN the multiset of reported distances equals the k smallest distances by
+        raw half-open gap, so the uniform +1 does not change which candidates
+        are selected
+    """
+    k = data.draw(st.integers(min_value=1, max_value=len(candidates)))
+    expected_sorted = sorted(_expected_distance(reference, c) for c in candidates)
+
+    rows = _run_nearest(reference, candidates, k=k)
+
+    reported_sorted = sorted(distance for _, distance in rows)
+    assert reported_sorted == expected_sorted[:k]
+
+
+@given(
+    data=st.data(),
+    reference=_reference(),
+    candidates=_candidates(),
+)
+@settings(
+    max_examples=50,
+    deadline=None,
+    suppress_health_check=[HealthCheck.too_slow],
+)
+def test_nearest_max_distance_filters_on_the_shifted_distance(
+    data, reference, candidates
+):
+    """
+    GIVEN a random reference, candidate set, and threshold
+    WHEN NEAREST is run with that max_distance over all candidates
+    THEN the returned candidates are exactly those whose gap + 1 is <= the
+        threshold, so no candidate at threshold + 1 ever survives
+    """
+    expected = {c.name: _expected_distance(reference, c) for c in candidates}
+    threshold = data.draw(st.integers(min_value=0, max_value=max(expected.values()) + 5))
+
+    rows = _run_nearest(reference, candidates, k=len(candidates), max_distance=threshold)
+
+    returned = {name for name, _ in rows}
+    survivors = {name for name, dist in expected.items() if dist <= threshold}
+    assert returned == survivors

--- a/tests/integration/coordinate_space/test_distance_coordinate_space.py
+++ b/tests/integration/coordinate_space/test_distance_coordinate_space.py
@@ -31,7 +31,7 @@ class TestDistanceCoordinateSpace:
     def test_distance_returns_canonical_gap_when_both_sides_share_convention(
         self, giql_query, coordinate_system, interval_type
     ):
-        """Test DISTANCE returns 100 for a 100 bp gap in any same-convention encoding.
+        """Test DISTANCE returns 101 for a 100 bp gap in any same-convention encoding.
 
         Given:
             Two non-overlapping intervals (canonical [100, 200) and
@@ -39,8 +39,9 @@ class TestDistanceCoordinateSpace:
         When:
             DISTANCE(a.interval, b.interval) is executed.
         Then:
-            It should return 100, matching the canonical 0-based half-open
-            gap, regardless of how the intervals are stored.
+            It should return 101 (the canonical 0-based half-open gap of 100
+            plus the bedtools closest -d parity + 1), regardless of how the
+            intervals are stored.
         """
         # Arrange
         s_a, e_a = encode(100, 200, coordinate_system, interval_type)
@@ -62,7 +63,7 @@ class TestDistanceCoordinateSpace:
         )
 
         # Assert
-        assert result == [(100,)]
+        assert result == [(101,)]
 
     @pytest.mark.parametrize(
         ("coordinate_system", "interval_type"),
@@ -109,10 +110,10 @@ class TestDistanceCoordinateSpace:
         CONVENTIONS,
         ids=lambda v: str(v),
     )
-    def test_distance_returns_zero_for_adjacent_half_open_boundary(
+    def test_distance_returns_one_for_adjacent_half_open_boundary(
         self, giql_query, coordinate_system, interval_type
     ):
-        """Test DISTANCE returns 0 when intervals touch at the half-open boundary.
+        """Test DISTANCE returns 1 when intervals touch at the half-open boundary.
 
         Given:
             Canonical adjacent intervals [100, 200) and [200, 300)
@@ -120,7 +121,8 @@ class TestDistanceCoordinateSpace:
         When:
             DISTANCE is executed.
         Then:
-            It should return 0 regardless of encoding.
+            It should return 1 (bedtools closest -d parity for book-ended
+            features) regardless of encoding.
         """
         # Arrange
         s_a, e_a = encode(100, 200, coordinate_system, interval_type)
@@ -142,7 +144,7 @@ class TestDistanceCoordinateSpace:
         )
 
         # Assert
-        assert result == [(0,)]
+        assert result == [(1,)]
 
     @pytest.mark.parametrize(
         ("conv_a", "conv_b"),
@@ -152,7 +154,7 @@ class TestDistanceCoordinateSpace:
     def test_distance_is_invariant_under_mixed_conventions(
         self, giql_query, conv_a, conv_b
     ):
-        """Test DISTANCE returns 100 for any pair of (convention_a, convention_b).
+        """Test DISTANCE returns 101 for any pair of (convention_a, convention_b).
 
         Given:
             Canonical intervals [100, 200) and [300, 400) encoded in
@@ -160,9 +162,9 @@ class TestDistanceCoordinateSpace:
         When:
             DISTANCE is executed.
         Then:
-            It should return 100 for every (convention_a, convention_b)
-            pair, demonstrating that each side is canonicalized
-            independently.
+            It should return 101 (the 100 bp half-open gap plus the bedtools
+            parity + 1) for every (convention_a, convention_b) pair,
+            demonstrating that each side is canonicalized independently.
         """
         # Arrange
         s_a, e_a = encode(100, 200, *conv_a)
@@ -184,7 +186,7 @@ class TestDistanceCoordinateSpace:
         )
 
         # Assert
-        assert result == [(100,)]
+        assert result == [(101,)]
 
     @pytest.mark.parametrize(
         ("coordinate_system", "interval_type"),
@@ -234,7 +236,7 @@ class TestDistanceCoordinateSpace:
     def test_signed_distance_returns_positive_when_b_is_downstream(
         self, giql_query, coordinate_system, interval_type
     ):
-        """Test signed DISTANCE returns +100 when B is downstream in any encoding.
+        """Test signed DISTANCE returns +101 when B is downstream in any encoding.
 
         Given:
             Canonical A=[100, 200) and B=[300, 400) re-encoded under the
@@ -242,7 +244,8 @@ class TestDistanceCoordinateSpace:
         When:
             DISTANCE runs.
         Then:
-            It should return +100 regardless of encoding.
+            It should return +101 (100 bp gap + bedtools parity 1) regardless
+            of encoding.
         """
         # Arrange
         s_a, e_a = encode(100, 200, coordinate_system, interval_type)
@@ -264,7 +267,7 @@ class TestDistanceCoordinateSpace:
         )
 
         # Assert
-        assert result == [(100,)]
+        assert result == [(101,)]
 
     @pytest.mark.parametrize(
         ("coordinate_system", "interval_type"),
@@ -274,7 +277,7 @@ class TestDistanceCoordinateSpace:
     def test_signed_distance_returns_negative_when_b_is_upstream(
         self, giql_query, coordinate_system, interval_type
     ):
-        """Test signed DISTANCE returns -100 when B is upstream in any encoding.
+        """Test signed DISTANCE returns -101 when B is upstream in any encoding.
 
         Given:
             Canonical A=[300, 400) and B=[100, 200) re-encoded under the
@@ -282,7 +285,8 @@ class TestDistanceCoordinateSpace:
         When:
             DISTANCE runs.
         Then:
-            It should return -100 regardless of encoding.
+            It should return -101 (100 bp gap + bedtools parity 1, negated)
+            regardless of encoding.
         """
         # Arrange
         s_a, e_a = encode(300, 400, coordinate_system, interval_type)
@@ -304,4 +308,169 @@ class TestDistanceCoordinateSpace:
         )
 
         # Assert
-        assert result == [(-100,)]
+        assert result == [(-101,)]
+
+    @pytest.mark.parametrize(
+        ("conv_a", "conv_b"),
+        [(a, b) for a in CONVENTIONS for b in CONVENTIONS],
+        ids=lambda v: str(v),
+    )
+    def test_distance_book_ended_is_one_under_mixed_conventions(
+        self, giql_query, conv_a, conv_b
+    ):
+        """Test DISTANCE returns 1 for a book-ended pair for any convention pair.
+
+        Given:
+            Canonical book-ended intervals [100, 200) and [200, 300) encoded in
+            convention_a on table A and convention_b on table B.
+        When:
+            DISTANCE is executed.
+        Then:
+            It should return 1 (bedtools parity for touching features) for every
+            (convention_a, convention_b) pair, proving the +1 lands on the
+            canonical gap regardless of how each side is stored.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, *conv_a)
+        s_b, e_b = encode(200, 300, *conv_b)
+        tables = [
+            make_table("intervals_a", *conv_a),
+            make_table("intervals_b", *conv_b),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(1,)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_distance_one_bp_gap_returns_two_in_any_encoding(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test DISTANCE returns 2 for a 1 bp gap in any same-convention encoding.
+
+        Given:
+            Canonical intervals [100, 200) and [201, 300) (a 1 bp half-open
+            gap) re-encoded under the same convention on both sides.
+        When:
+            DISTANCE is executed.
+        Then:
+            It should return 2 (half-open gap 1 + bedtools parity 1) regardless
+            of encoding.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, coordinate_system, interval_type)
+        s_b, e_b = encode(201, 300, coordinate_system, interval_type)
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(2,)]
+
+    @pytest.mark.parametrize(
+        ("conv_a", "conv_b"),
+        [(a, b) for a in CONVENTIONS for b in CONVENTIONS],
+        ids=lambda v: str(v),
+    )
+    def test_distance_one_bp_gap_is_two_under_mixed_conventions(
+        self, giql_query, conv_a, conv_b
+    ):
+        """Test DISTANCE returns 2 for a 1 bp gap for any convention pair.
+
+        Given:
+            Canonical intervals [100, 200) and [201, 300) (a 1 bp half-open
+            gap) encoded in convention_a on table A and convention_b on table B.
+        When:
+            DISTANCE is executed.
+        Then:
+            It should return 2 for every (convention_a, convention_b) pair, the
+            tightest parity check across independent per-side canonicalization.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, *conv_a)
+        s_b, e_b = encode(201, 300, *conv_b)
+        tables = [
+            make_table("intervals_a", *conv_a),
+            make_table("intervals_b", *conv_b),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(2,)]
+
+    @pytest.mark.parametrize(
+        ("coordinate_system", "interval_type"),
+        CONVENTIONS,
+        ids=lambda v: str(v),
+    )
+    def test_stranded_distance_book_ended_is_one_in_any_encoding(
+        self, giql_query, coordinate_system, interval_type
+    ):
+        """Test stranded DISTANCE returns 1 for a book-ended pair in any encoding.
+
+        Given:
+            Canonical book-ended intervals [100, 200) and [200, 300), both on
+            '+' strand, re-encoded under the same convention on both sides.
+        When:
+            DISTANCE with stranded := true is executed.
+        Then:
+            It should return 1 regardless of encoding, exercising the parity +1
+            in the stranded branch under coordinate canonicalization.
+        """
+        # Arrange
+        s_a, e_a = encode(100, 200, coordinate_system, interval_type)
+        s_b, e_b = encode(200, 300, coordinate_system, interval_type)
+        tables = [
+            make_table("intervals_a", coordinate_system, interval_type),
+            make_table("intervals_b", coordinate_system, interval_type),
+        ]
+
+        # Act
+        result = giql_query(
+            """
+            SELECT DISTANCE(a.interval, b.interval, stranded := true) AS dist
+            FROM intervals_a a, intervals_b b
+            """,
+            tables=tables,
+            intervals_a=[_row("chr1", s_a, e_a, "a1")],
+            intervals_b=[_row("chr1", s_b, e_b, "b1")],
+        )
+
+        # Assert
+        assert result == [(1,)]

--- a/tests/integration/coordinate_space/test_nearest_coordinate_space.py
+++ b/tests/integration/coordinate_space/test_nearest_coordinate_space.py
@@ -154,9 +154,10 @@ class TestNearestCoordinateSpace:
         When:
             NEAREST runs via LATERAL join.
         Then:
-            It should return only ``b_near`` (10 bp) and ``b_far`` (50 bp,
-            inclusive boundary) regardless of encoding; ``b_mid`` (200 bp)
-            should be excluded.
+            It should return only ``b_near`` (half-open gap 10 -> reported 11)
+            regardless of encoding; under bedtools parity ``b_far`` reports 51
+            (half-open gap 50 + 1), which exceeds ``max_distance := 50``, so it
+            joins ``b_mid`` (201) in being excluded.
         """
         # Arrange
         tables = [
@@ -184,7 +185,7 @@ class TestNearestCoordinateSpace:
         )
 
         # Assert
-        assert sorted(row[0] for row in result) == ["b_far", "b_near"]
+        assert sorted(row[0] for row in result) == ["b_near"]
 
     @pytest.mark.parametrize(
         ("coordinate_system", "interval_type"),
@@ -204,9 +205,9 @@ class TestNearestCoordinateSpace:
             ``SELECT * FROM NEAREST(intervals_b, reference := ..., k := 2)``
             runs in standalone mode.
         Then:
-            It should return ``b_near`` (10 bp) and ``b_far`` (200 bp)
-            regardless of target encoding; ``b_mid`` (140 bp) is the
-            second-nearest, so the expected pair is ``{b_near, b_mid}``.
+            It should return ``b_near`` (touching, reported 1) and ``b_mid``
+            (reported 141) regardless of target encoding; ``b_far`` (reported
+            201) is farther, so the expected pair is ``{b_near, b_mid}``.
         """
         # Arrange
         tables = [make_table("intervals_b", coordinate_system, interval_type)]
@@ -227,8 +228,8 @@ class TestNearestCoordinateSpace:
         )
 
         # Assert
-        # Distances from [350, 360): b_near [310,350) -> 0 (touching),
-        # b_mid [500,600) -> 140, b_far [100,150) -> 200.
+        # Distances from [350, 360) with bedtools parity: b_near [310,350) ->
+        # 1 (touching), b_mid [500,600) -> 141, b_far [100,150) -> 201.
         assert sorted(row[0] for row in result) == ["b_mid", "b_near"]
 
     @pytest.mark.parametrize(
@@ -285,13 +286,13 @@ class TestNearestCoordinateSpace:
     def test_correlated_nearest_picks_adjacent_neighbor_when_touching_half_open_boundary(
         self, giql_query, coordinate_system, interval_type
     ):
-        """Test correlated NEAREST picks the touching candidate (gap 0) in any encoding.
+        """Test correlated NEAREST picks the touching candidate (reported 1) in any encoding.
 
         Given:
             Canonical A=[100, 200) with two B candidates -- b_adjacent at
-            canonical [200, 300) (touching half-open boundary, gap 0) and
-            b_far at [500, 600) -- re-encoded under the same convention on
-            both sides.
+            canonical [200, 300) (touching half-open boundary, reported
+            distance 1 under bedtools parity) and b_far at [500, 600) --
+            re-encoded under the same convention on both sides.
         When:
             NEAREST k=1 runs via LATERAL join.
         Then:
@@ -302,9 +303,7 @@ class TestNearestCoordinateSpace:
             make_table("intervals_a", coordinate_system, interval_type),
             make_table("intervals_b", coordinate_system, interval_type),
         ]
-        intervals_a = _encode_rows(
-            [(100, 200, "a1")], coordinate_system, interval_type
-        )
+        intervals_a = _encode_rows([(100, 200, "a1")], coordinate_system, interval_type)
         intervals_b = _encode_rows(
             [(200, 300, "b_adjacent"), (500, 600, "b_far")],
             coordinate_system,

--- a/tests/test_distance_transpilation.py
+++ b/tests/test_distance_transpilation.py
@@ -45,7 +45,7 @@ class TestDistanceTranspilation:
 
         output = _generate(sql)
 
-        expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end") ELSE (a."start" - b."end") END AS dist FROM features_a AS a CROSS JOIN features_b AS b"""
+        expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end" + 1) ELSE (a."start" - b."end" + 1) END AS dist FROM features_a AS a CROSS JOIN features_b AS b"""
 
         assert output == expected, f"Expected:\n{expected}\n\nGot:\n{output}"
 
@@ -62,7 +62,7 @@ class TestDistanceTranspilation:
 
         output = _generate(sql)
 
-        expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end") ELSE (a."start" - b."end") END AS dist FROM features_a AS a, features_b AS b"""
+        expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end" + 1) ELSE (a."start" - b."end" + 1) END AS dist FROM features_a AS a, features_b AS b"""
 
         assert output == expected, f"Expected:\n{expected}\n\nGot:\n{output}"
 
@@ -79,7 +79,7 @@ class TestDistanceTranspilation:
 
         output = _generate(sql)
 
-        expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end") ELSE (a."start" - b."end") END AS dist FROM features_a AS a CROSS JOIN features_b AS b"""
+        expected = """SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 WHEN a."end" <= b."start" THEN (b."start" - a."end" + 1) ELSE (a."start" - b."end" + 1) END AS dist FROM features_a AS a CROSS JOIN features_b AS b"""
 
         assert output == expected, f"Expected:\n{expected}\n\nGot:\n{output}"
 
@@ -121,8 +121,8 @@ class TestDistanceTranspilation:
         expected = (
             'SELECT CASE WHEN a."chrom" != b."chrom" THEN NULL '
             'WHEN a."start" < b."end" AND a."end" > b."start" THEN 0 '
-            'WHEN a."end" <= b."start" THEN (b."start" - a."end") '
-            'ELSE -(a."start" - b."end") END AS dist '
+            'WHEN a."end" <= b."start" THEN (b."start" - a."end" + 1) '
+            'ELSE -(a."start" - b."end" + 1) END AS dist '
             "FROM features_a AS a CROSS JOIN features_b AS b"
         )
 

--- a/tests/test_distance_udf.py
+++ b/tests/test_distance_udf.py
@@ -30,6 +30,15 @@ def _generate(sql: str) -> str:
     return BaseGIQLGenerator().generate(ast)
 
 
+def _run(sql: str):
+    """Generate, execute against in-memory DuckDB, and return the first column."""
+    conn = duckdb.connect(":memory:")
+    try:
+        return conn.execute(_generate(sql)).fetchone()[0]
+    finally:
+        conn.close()
+
+
 class TestDistanceCalculation:
     """Unit tests for basic distance calculation logic."""
 
@@ -73,9 +82,9 @@ class TestDistanceCalculation:
         WHEN DISTANCE() is calculated between them
         THEN the distance should be a positive integer (gap size)
         """
-        # Interval A: chr1:100-200
-        # Interval B: chr1:300-400
-        # Gap: 300 - 200 = 100 base pairs
+        # Arrange
+        # Interval A: chr1:100-200, Interval B: chr1:300-400
+        # Half-open gap: 300 - 200 = 100; bedtools closest -d parity adds 1 -> 101
         sql = """
         SELECT
             DISTANCE(a.interval, b.interval) as distance
@@ -85,15 +94,11 @@ class TestDistanceCalculation:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end) b
         """
 
-        output_sql = _generate(sql)
+        # Act
+        result = _run(sql)
 
-        conn = duckdb.connect(":memory:")
-        result = conn.execute(output_sql).fetchone()
-
-        # Gap distance should be 100
-        assert result[0] == 100, f"Expected distance 100, got {result[0]}"
-
-        conn.close()
+        # Assert
+        assert result == 101, f"Expected distance 101, got {result}"
 
     def test_different_chromosomes_return_null(self):
         """
@@ -122,14 +127,15 @@ class TestDistanceCalculation:
 
         conn.close()
 
-    def test_adjacent_bookended_intervals_return_zero(self):
+    def test_adjacent_bookended_intervals_return_one(self):
         """
         GIVEN two adjacent intervals where end_a == start_b (bookended)
         WHEN DISTANCE() is calculated between them
-        THEN the distance should be 0 (following bedtools convention)
+        THEN the distance should be 1 (bedtools closest -d reports 1 for
+            book-ended features)
         """
-        # Interval A: chr1:100-200
-        # Interval B: chr1:200-300 (starts exactly where A ends)
+        # Arrange
+        # Interval A: chr1:100-200, Interval B: chr1:200-300 (starts where A ends)
         sql = """
         SELECT
             DISTANCE(a.interval, b.interval) as distance
@@ -139,17 +145,11 @@ class TestDistanceCalculation:
             (SELECT 'chr1' as chrom, 200 as start, 300 as end) b
         """
 
-        output_sql = _generate(sql)
+        # Act
+        result = _run(sql)
 
-        conn = duckdb.connect(":memory:")
-        result = conn.execute(output_sql).fetchone()
-
-        # Bookended intervals should return distance = 0
-        assert result[0] == 0, (
-            f"Expected distance 0 for bookended intervals, got {result[0]}"
-        )
-
-        conn.close()
+        # Assert
+        assert result == 1, f"Expected distance 1 for bookended intervals, got {result}"
 
     def test_zero_width_intervals_point_features(self):
         """
@@ -157,9 +157,9 @@ class TestDistanceCalculation:
         WHEN DISTANCE() is calculated
         THEN the distance should be calculated correctly
         """
-        # Point feature at chr1:150 (start=150, end=150)
-        # Interval at chr1:300-400
-        # Distance: 300 - 150 = 150
+        # Arrange
+        # Point feature at chr1:150 (start=150, end=150), interval at chr1:300-400
+        # Half-open gap: 300 - 150 = 150; bedtools parity adds 1 -> 151
         sql = """
         SELECT
             DISTANCE(a.interval, b.interval) as distance
@@ -169,15 +169,144 @@ class TestDistanceCalculation:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end) b
         """
 
-        output_sql = _generate(sql)
+        # Act
+        result = _run(sql)
 
-        conn = duckdb.connect(":memory:")
-        result = conn.execute(output_sql).fetchone()
+        # Assert
+        assert result == 151, f"Expected distance 151, got {result}"
 
-        # Distance should be 150
-        assert result[0] == 150, f"Expected distance 150, got {result[0]}"
+    def test_one_base_gap_returns_two(self):
+        """
+        GIVEN two intervals separated by a 1 bp half-open gap (A chr1:100-200,
+            B chr1:201-300)
+        WHEN DISTANCE() is calculated between them
+        THEN the distance should be 2 (half-open gap 1 + bedtools parity 1)
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval) as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 201 as start, 300 as end) b
+        """
 
-        conn.close()
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == 2, f"Expected distance 2, got {result}"
+
+    @pytest.mark.parametrize(
+        ("b_start", "expected"),
+        [(199, 0), (200, 1), (201, 2), (202, 3)],
+    )
+    def test_distance_increments_by_one_across_the_overlap_boundary(
+        self, b_start, expected
+    ):
+        """
+        GIVEN A chr1:100-200 and B starting at 199, 200, 201, or 202 (1 bp
+            overlap, book-ended, 1 bp gap, 2 bp gap)
+        WHEN DISTANCE() is calculated between them
+        THEN the distance steps 0, 1, 2, 3 as the gap opens, pinning the
+            overlap -> book-ended -> gap transition
+        """
+        # Arrange
+        sql = f"""
+        SELECT DISTANCE(a.interval, b.interval) as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end) a
+        CROSS JOIN (SELECT 'chr1' as chrom, {b_start} as start, 300 as end) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == expected, f"Expected distance {expected}, got {result}"
+
+    def test_single_base_overlap_returns_zero(self):
+        """
+        GIVEN two intervals sharing exactly 1 bp (A chr1:100-200, B chr1:199-300)
+        WHEN DISTANCE() is calculated between them
+        THEN the distance should be 0, distinguishing a minimal overlap from a
+            book-ended pair
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval) as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 199 as start, 300 as end) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == 0, f"Expected distance 0, got {result}"
+
+    def test_upstream_operand_order_returns_positive_distance(self):
+        """
+        GIVEN A downstream of B (A chr1:300-400, B chr1:100-200), unsigned
+        WHEN DISTANCE() is calculated between them
+        THEN the distance should be 101, proving the parity +1 is applied
+            symmetrically on the upstream (ELSE) branch as well
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval) as distance
+        FROM (SELECT 'chr1' as chrom, 300 as start, 400 as end) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 100 as start, 200 as end) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == 101, f"Expected distance 101, got {result}"
+
+
+class TestSignedDistance:
+    """Unit tests for signed (non-stranded) distance calculation."""
+
+    def test_signed_book_ended_downstream_returns_positive_one(self):
+        """
+        GIVEN a book-ended pair with B downstream of A (A chr1:100-200,
+            B chr1:200-300)
+        WHEN DISTANCE() is calculated with signed := true
+        THEN the distance should be +1, the issue's named book-ended sign case
+            (sign applied after the parity +1)
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, signed := true) as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 200 as start, 300 as end) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == 1, f"Expected distance 1, got {result}"
+
+    def test_signed_book_ended_upstream_returns_negative_one(self):
+        """
+        GIVEN a book-ended pair with B upstream of A (A chr1:200-300,
+            B chr1:100-200)
+        WHEN DISTANCE() is calculated with signed := true
+        THEN the distance should be -1, proving the sign wraps the post-parity
+            magnitude on the upstream branch
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, signed := true) as distance
+        FROM (SELECT 'chr1' as chrom, 200 as start, 300 as end) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 100 as start, 200 as end) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == -1, f"Expected distance -1, got {result}"
 
 
 class TestStrandedDistance:
@@ -189,6 +318,7 @@ class TestStrandedDistance:
         WHEN DISTANCE() is calculated with stranded := true
         THEN the distance should be calculated normally (positive value)
         """
+        # Arrange
         sql = """
         SELECT
             DISTANCE(a.interval, b.interval, stranded := true) as distance
@@ -198,15 +328,12 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) b
         """
 
-        output_sql = _generate(sql)
+        # Act
+        result = _run(sql)
 
-        conn = duckdb.connect(":memory:")
-        result = conn.execute(output_sql).fetchone()
-
-        # Gap distance should be 100 (positive, since strand is '+')
-        assert result[0] == 100, f"Expected distance 100, got {result[0]}"
-
-        conn.close()
+        # Assert
+        # Gap distance should be 101 (positive, since strand is '+')
+        assert result == 101, f"Expected distance 101, got {result}"
 
     def test_stranded_same_strand_minus(self):
         """
@@ -214,6 +341,7 @@ class TestStrandedDistance:
         WHEN DISTANCE() is calculated with stranded := true
         THEN the distance should be negative (multiplied by -1)
         """
+        # Arrange
         sql = """
         SELECT
             DISTANCE(a.interval, b.interval, stranded := true) as distance
@@ -223,15 +351,12 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '-' as strand) b
         """
 
-        output_sql = _generate(sql)
+        # Act
+        result = _run(sql)
 
-        conn = duckdb.connect(":memory:")
-        result = conn.execute(output_sql).fetchone()
-
-        # Gap distance should be -100 (negative, since first interval strand is '-')
-        assert result[0] == -100, f"Expected distance -100, got {result[0]}"
-
-        conn.close()
+        # Assert
+        # Gap distance should be -101 (negative, since first interval strand is '-')
+        assert result == -101, f"Expected distance -101, got {result}"
 
     def test_stranded_different_strands_calculates_distance(self):
         """
@@ -239,6 +364,7 @@ class TestStrandedDistance:
         WHEN DISTANCE() is calculated with stranded := true
         THEN the distance should be calculated normally (positive, since first interval is '+')
         """
+        # Arrange
         sql = """
         SELECT
             DISTANCE(a.interval, b.interval, stranded := true) as distance
@@ -248,15 +374,12 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '-' as strand) b
         """
 
-        output_sql = _generate(sql)
+        # Act
+        result = _run(sql)
 
-        conn = duckdb.connect(":memory:")
-        result = conn.execute(output_sql).fetchone()
-
-        # Different strands should still calculate distance, sign based on first interval
-        assert result[0] == 100, f"Expected distance 100, got {result[0]}"
-
-        conn.close()
+        # Assert
+        # Different strands still calculate distance, sign based on first interval
+        assert result == 101, f"Expected distance 101, got {result}"
 
     def test_stranded_different_strands_minus_first(self):
         """
@@ -264,6 +387,7 @@ class TestStrandedDistance:
         WHEN DISTANCE() is calculated with stranded := true
         THEN the distance should be negative (based on first interval's strand)
         """
+        # Arrange
         sql = """
         SELECT
             DISTANCE(a.interval, b.interval, stranded := true) as distance
@@ -273,15 +397,12 @@ class TestStrandedDistance:
             (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) b
         """
 
-        output_sql = _generate(sql)
+        # Act
+        result = _run(sql)
 
-        conn = duckdb.connect(":memory:")
-        result = conn.execute(output_sql).fetchone()
-
+        # Assert
         # Distance should be negative since first interval is '-'
-        assert result[0] == -100, f"Expected distance -100, got {result[0]}"
-
-        conn.close()
+        assert result == -101, f"Expected distance -101, got {result}"
 
     def test_stranded_dot_strand_returns_null(self):
         """
@@ -384,3 +505,194 @@ class TestStrandedDistance:
         )
 
         conn.close()
+
+    def test_stranded_book_ended_plus_strand_returns_one(self):
+        """
+        GIVEN a book-ended pair both on '+' strand (A chr1:100-200,
+            B chr1:200-300)
+        WHEN DISTANCE() is calculated with stranded := true
+        THEN the distance should be 1 (parity +1 reaches the stranded branch;
+            '+' applies no flip)
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true) as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end, '+' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 200 as start, 300 as end, '+' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == 1, f"Expected distance 1, got {result}"
+
+    def test_stranded_book_ended_minus_strand_returns_negative_one(self):
+        """
+        GIVEN a book-ended pair both on '-' strand (A chr1:100-200,
+            B chr1:200-300)
+        WHEN DISTANCE() is calculated with stranded := true
+        THEN the distance should be -1, the '-' strand flipping the sign of the
+            post-parity magnitude
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true) as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end, '-' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 200 as start, 300 as end, '-' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == -1, f"Expected distance -1, got {result}"
+
+    def test_stranded_upstream_plus_strand_returns_positive(self):
+        """
+        GIVEN B upstream of A both on '+' strand (A chr1:300-400, B chr1:100-200)
+        WHEN DISTANCE() is calculated with stranded := true
+        THEN the distance should be 101, exercising the stranded upstream (ELSE)
+            branch that the existing stranded tests never reach
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true) as distance
+        FROM (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 100 as start, 200 as end, '+' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == 101, f"Expected distance 101, got {result}"
+
+    def test_stranded_upstream_minus_strand_returns_negative(self):
+        """
+        GIVEN B upstream of A both on '-' strand (A chr1:300-400, B chr1:100-200)
+        WHEN DISTANCE() is calculated with stranded := true
+        THEN the distance should be -101, the '-' flip applied to the upstream
+            branch's post-parity magnitude
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true) as distance
+        FROM (SELECT 'chr1' as chrom, 300 as start, 400 as end, '-' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 100 as start, 200 as end, '-' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == -101, f"Expected distance -101, got {result}"
+
+    def test_stranded_question_strand_returns_null(self):
+        """
+        GIVEN one interval with '?' strand (A chr1:100-200 '?', B chr1:300-400 '+')
+        WHEN DISTANCE() is calculated with stranded := true
+        THEN the distance should be NULL, confirming the parity +1 did not
+            perturb the '?' NULL short-circuit
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true) as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end, '?' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result is None, f"Expected NULL for '?' strand, got {result}"
+
+
+class TestStrandedSignedDistance:
+    """Unit tests for the combined stranded + signed distance calculation."""
+
+    def test_stranded_signed_upstream_plus_strand_returns_negative(self):
+        """
+        GIVEN B upstream of A both on '+' strand (A chr1:300-400, B chr1:100-200)
+        WHEN DISTANCE() is calculated with stranded := true, signed := true
+        THEN the distance should be -101, the upstream-branch sign that DIVERGES
+            from the stranded-only variant ('+' -> -(magnitude+1))
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true, signed := true)
+            as distance
+        FROM (SELECT 'chr1' as chrom, 300 as start, 400 as end, '+' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 100 as start, 200 as end, '+' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == -101, f"Expected distance -101, got {result}"
+
+    def test_stranded_signed_upstream_minus_strand_returns_positive(self):
+        """
+        GIVEN B upstream of A both on '-' strand (A chr1:300-400, B chr1:100-200)
+        WHEN DISTANCE() is calculated with stranded := true, signed := true
+        THEN the distance should be +101, the only ELSE-branch case where the
+            sign is +(magnitude+1) ('-' strand double-flip)
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true, signed := true)
+            as distance
+        FROM (SELECT 'chr1' as chrom, 300 as start, 400 as end, '-' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 100 as start, 200 as end, '-' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == 101, f"Expected distance 101, got {result}"
+
+    def test_stranded_signed_book_ended_minus_strand_returns_negative_one(self):
+        """
+        GIVEN a book-ended pair both on '-' strand, B downstream (A chr1:100-200,
+            B chr1:200-300)
+        WHEN DISTANCE() is calculated with stranded := true, signed := true
+        THEN the distance should be -1, pinning the sign at the smallest
+            (book-ended) post-parity magnitude
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true, signed := true)
+            as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end, '-' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 200 as start, 300 as end, '-' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result == -1, f"Expected distance -1, got {result}"
+
+    def test_stranded_signed_null_strand_returns_null(self):
+        """
+        GIVEN one interval with '.' strand (A chr1:100-200 '.', B chr1:200-300 '+')
+        WHEN DISTANCE() is calculated with stranded := true, signed := true
+        THEN the distance should be NULL, confirming the parity +1 left the NULL
+            short-circuit intact in the combined variant
+        """
+        # Arrange
+        sql = """
+        SELECT DISTANCE(a.interval, b.interval, stranded := true, signed := true)
+            as distance
+        FROM (SELECT 'chr1' as chrom, 100 as start, 200 as end, '.' as strand) a
+        CROSS JOIN (SELECT 'chr1' as chrom, 200 as start, 300 as end, '+' as strand) b
+        """
+
+        # Act
+        result = _run(sql)
+
+        # Assert
+        assert result is None, f"Expected NULL for '.' strand, got {result}"


### PR DESCRIPTION
## Summary

`DISTANCE` returned the raw 0-based half-open gap between non-overlapping intervals, so book-ended (adjacent) intervals where `A.end == B.start` reported `0` — the same value as overlapping intervals — instead of the `1` that `bedtools closest -d` reports. bedtools is the project's correctness oracle, so this was an off-by-one against it for every non-overlapping pair.

Add `1` to the absolute gap magnitude in the two non-overlapping branches of the shared distance CASE, across all four variants it emits (unsigned, signed, stranded, stranded+signed). The overlap branch stays `0` and the NULL branches (cross-chromosome, `.`/`?`/NULL strand) are untouched. The offset is applied before any directional sign, so a downstream book-ended pair reports `+1` and an upstream one `-1` in signed mode. The transform was verified against live `bedtools closest -d` (v2.31.1) to be a uniform `+1` on every non-overlapping distance, not a book-ended special case.

`_generate_distance_case` is shared by `DISTANCE` and `NEAREST`, so both shift in lockstep — they stay consistent and both match bedtools. `NEAREST`'s ranking is unchanged because the offset is monotonic; only its reported `distance` column and `max_distance` boundary move by one.

Closes #134

## Proposed changes

- **Distance generator (`src/giql/generators/base.py`)** — Add `+ 1` to the absolute gap magnitude in both non-overlapping branches of all four variants of `_generate_distance_case`, before the directional sign is applied. Document the bedtools-parity convention on the method.
- **Documentation (`docs/dialect/distance-operators.rst`)** — State that book-ended intervals return `1` and a non-overlapping gap returns the half-open gap plus one, matching `bedtools closest -d`, while overlapping intervals still return `0`.
- **Tests** — Update existing distance/nearest assertions to the parity-corrected values and add coverage that pins the new behavior so a future regression fails automatically: the magnitude/sign formula at the UDF layer (1 bp gap, the overlap→book-ended→gap value sweep, signed and stranded book-ended signs, the previously untested stranded upstream branch, a stranded+signed class for the upstream sign divergence); mixed-convention invariance of the book-ended and 1 bp boundaries; live-`bedtools closest -d` cross-validation for `DISTANCE` (replacing hard-coded constants) and for the `NEAREST` reported distance; an inclusive `max_distance` boundary check on both sides; and Hypothesis properties for distance == gap+1, selection invariance under the shift, and `max_distance` filtering on the shifted distance.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestDistanceCalculation` | A `chr1:100-200` and B at `199/200/201/202` | DISTANCE is computed | Steps `0, 1, 2, 3` across the overlap boundary | Off-by-one transition |
| 2 | `TestSignedDistance` | A book-ended pair, B downstream then upstream | DISTANCE with `signed := true` | Returns `+1` then `-1` | Signed book-ended sign |
| 3 | `TestStrandedDistance` | B upstream of A on `+`/`-` strand | DISTANCE with `stranded := true` | Returns `101`/`-101` | Stranded upstream branch |
| 4 | `TestStrandedSignedDistance` | B upstream of A on `+`/`-` strand | DISTANCE with `stranded` and `signed` | Returns `-101`/`+101` | Upstream sign divergence |
| 5 | `test_distance_coordinate_space` | A book-ended/1 bp-gap pair across the convention matrix | DISTANCE is computed | Returns `1`/`2` for every encoding pair | Encoding invariance |
| 6 | `test_distance.py` | A `chr1:100-200` and B across gap sizes | DISTANCE is computed | Equals live `bedtools closest -d` | Oracle parity |
| 7 | `test_nearest.py` | Candidates straddling `max_distance := 50` | NEAREST is applied | The candidate at exactly 50 is kept and 51 excluded | Inclusive boundary |
| 8 | `test_nearest_property.py` | Random reference, candidates, k, threshold | NEAREST runs in DuckDB | Distance == gap+1, selection unchanged, `max_distance` filters on the shifted value | Shift invariants |