### PR TITLE
Build the operator-expander registry and ExpandOperators pass scaffolding — Closes #138

### DIFF
--- a/src/giql/expander.py
+++ b/src/giql/expander.py
@@ -1,0 +1,398 @@
+"""The operator-expander registry and the ``ExpandOperators`` pass (epic #137).
+
+This module is step 2 of epic #137. It lands the dispatch infrastructure that the
+remaining steps migrate each operator onto, one at a time:
+
+* an :class:`OperatorExpander` protocol — ``expand(node, ctx) -> exp.Expression``,
+  the unit that turns one GIQL operator node into standard sqlglot AST for the
+  active target;
+* an :class:`ExpansionContext` carrying everything an expander needs — the pass-1
+  :class:`~giql.resolver.OperatorResolution` metadata, the active
+  :class:`~giql.targets.Target` and its :class:`~giql.targets.Capabilities`,
+  collision-safe alias minting, and the registered :class:`~giql.table.Tables`;
+* a :class:`ExpanderRegistry` keyed by ``(target, operator_type)`` resolving an
+  expander through the fallback chain ``(target, op)`` → ``(generic, op)`` →
+  the legacy ``*_sql`` emitter;
+* a :func:`register` decorator — the **public extension hook** by which a user
+  adds a target or overrides an operator for one, e.g.
+  ``@register(DuckDBTarget, GIQLDisjoin)``;
+* the :class:`ExpandOperators` pass, which runs after
+  :func:`giql.canonicalizer.canonicalize_coordinates`, walks the AST, and
+  replaces every opted-in GIQL operator node with the registry's expansion.
+
+Gating (mirrors ``GIQL_CANONICALIZE``)
+--------------------------------------
+The pass is gated per operator by a ``GIQL_EXPAND`` class attribute on the
+operator's expression class, exactly as pass 2 is gated by ``GIQL_CANONICALIZE``.
+An operator takes the new AST-expansion path **only when both** hold:
+
+* its class sets ``GIQL_EXPAND = True``, and
+* the registry resolves an expander for ``(active target, operator type)`` —
+  i.e. a ``(target, op)`` or ``(generic, op)`` expander is registered.
+
+Otherwise it falls through to the legacy ``*_sql`` emitter on
+:class:`giql.generators.base.BaseGIQLGenerator`. As of this issue **no operator
+sets ``GIQL_EXPAND`` and the registry is empty, so the pass is a strict no-op**:
+no node is touched and the emitted SQL is byte-identical. Each later migration PR
+(epic #137 steps 4-9) registers a generic expander, flips one operator's
+``GIQL_EXPAND`` flag, and deletes that operator's ``*_sql`` method.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+from typing import Protocol
+from typing import runtime_checkable
+
+from sqlglot import exp
+from sqlglot.helper import name_sequence
+
+from giql.resolver import META_KEY
+from giql.resolver import OperatorResolution
+from giql.table import Tables
+from giql.targets import GenericTarget
+from giql.targets import Target
+
+__all__ = [
+    "EXPAND_ALIAS_PREFIX",
+    "ExpansionContext",
+    "OperatorExpander",
+    "ExpanderRegistry",
+    "REGISTRY",
+    "register",
+    "expand_operators",
+    "ExpandOperators",
+]
+
+#: The prefix every alias minted by :meth:`ExpansionContext.alias` carries. The
+#: leading double underscore keeps synthesized names clear of user identifiers,
+#: mirroring the ``__giql_canon_`` / ``__giql_dj_`` reserved prefixes.
+EXPAND_ALIAS_PREFIX = "__giql_x_"
+
+#: The GIQL operator expression classes the pass inspects. Membership alone does
+#: not opt an operator in: the per-class ``GIQL_EXPAND`` flag plus a registered
+#: expander do (see module docstring). Imported lazily inside the pass to avoid a
+#: module-level import cycle with :mod:`giql.expressions`.
+
+
+class ExpansionContext:
+    """Everything an :class:`OperatorExpander` needs to expand one operator.
+
+    A fresh context is built per operator node by :class:`ExpandOperators`. It
+    bundles the node's pass-1 resolution metadata together with the active
+    target, collision-safe alias minting, and the registered tables, so an
+    expander never has to reach back into the pass or re-resolve anything.
+
+    Attributes
+    ----------
+    node : exp.Expression
+        The GIQL operator node being expanded.
+    resolution : OperatorResolution | None
+        The metadata :func:`giql.resolver.resolve_operator_refs` attached to
+        *node* (its resolved reference slots, column operands, deferrals, and
+        de-canonicalization output tables). ``None`` only if the node was never
+        annotated — an internal invariant violation an expander may assert on.
+    target : Target
+        The active :class:`~giql.targets.Target`, exposing its
+        ``capabilities`` and ``sqlglot_dialect``.
+    tables : Tables
+        The registered :class:`~giql.table.Tables` container.
+    """
+
+    __slots__ = ("node", "resolution", "target", "tables", "_alias_seq")
+
+    def __init__(
+        self,
+        node: exp.Expression,
+        resolution: OperatorResolution | None,
+        target: Target,
+        tables: Tables,
+        alias_seq: Callable[[], str] | None = None,
+    ) -> None:
+        self.node = node
+        self.resolution = resolution
+        self.target = target
+        self.tables = tables
+        # A single sequence is threaded across every context built for one
+        # ``ExpandOperators`` run so aliases minted for sibling operators never
+        # collide; a standalone context falls back to its own sequence.
+        self._alias_seq = alias_seq or name_sequence(EXPAND_ALIAS_PREFIX)
+
+    @property
+    def capabilities(self):
+        """The active target's :class:`~giql.targets.Capabilities`."""
+        return self.target.capabilities
+
+    def alias(self) -> str:
+        """Mint a fresh, query-unique alias with the reserved expander prefix.
+
+        Draws sequential names from a per-run :func:`sqlglot.helper.name_sequence`
+        so two expanders (or two slots of one expander) never collide.
+        """
+        return self._alias_seq()
+
+
+@runtime_checkable
+class OperatorExpander(Protocol):
+    """Turns one GIQL operator node into standard sqlglot AST for a target.
+
+    An expander is any callable-bearing object whose :meth:`expand` takes the
+    operator node and its :class:`ExpansionContext` and returns the sqlglot AST
+    the node expands to for the active target. The returned expression replaces
+    the operator node in the tree; the stock per-target serializer renders it.
+
+    The protocol is :func:`~typing.runtime_checkable`, so the registry can assert
+    a registered object satisfies it. A plain function is *not* an
+    ``OperatorExpander`` (it has no ``expand`` method); register one by wrapping
+    it (see :func:`register`, which accepts either form).
+    """
+
+    def expand(self, node: exp.Expression, ctx: ExpansionContext) -> exp.Expression: ...
+
+
+#: A bare expander function — the form most expanders are written in. The
+#: registry stores either an :class:`OperatorExpander` object or one of these.
+ExpanderFn = Callable[[exp.Expression, ExpansionContext], exp.Expression]
+
+
+def _as_callable(expander: OperatorExpander | ExpanderFn) -> ExpanderFn:
+    """Normalize an expander to a plain ``(node, ctx) -> Expression`` callable."""
+    if isinstance(expander, OperatorExpander):
+        return expander.expand
+    if callable(expander):
+        return expander
+    raise TypeError(
+        "An operator expander must be an OperatorExpander (an object with an "
+        f"'expand' method) or a callable; got {type(expander).__name__}."
+    )
+
+
+class ExpanderRegistry:
+    """Maps ``(target, operator_type)`` to the expander that handles it.
+
+    Resolution follows the epic's fallback chain so a generic expander written
+    once covers every target, and a per-target entry overrides it only where the
+    engine genuinely differs:
+
+    1. ``(target, op)`` — an expander registered for the *exact* active target;
+    2. ``(generic, op)`` — the portable expander registered for
+       :class:`~giql.targets.GenericTarget`;
+    3. ``None`` — no expander, so the caller keeps the legacy ``*_sql`` emitter.
+
+    The registry keys on the frozen, value-equal :class:`~giql.targets.Target`
+    *instance* (two ``DuckDBTarget()`` compare and hash alike), so registering
+    against ``DuckDBTarget`` and resolving against a freshly built
+    ``DuckDBTarget()`` hit the same entry. Registering against the *class*
+    ``DuckDBTarget`` is a convenience the decorator instantiates.
+    """
+
+    def __init__(self) -> None:
+        self._expanders: dict[tuple[Target, type], ExpanderFn] = {}
+
+    def register(
+        self,
+        target: Target,
+        operator: type,
+        expander: OperatorExpander | ExpanderFn,
+    ) -> None:
+        """Register *expander* for ``(target, operator)``, overriding any prior.
+
+        Parameters
+        ----------
+        target : Target
+            The target instance the expander handles. Use
+            :class:`~giql.targets.GenericTarget` for the portable fallback.
+        operator : type
+            The GIQL operator expression class (e.g.
+            :class:`~giql.expressions.GIQLDisjoin`).
+        expander : OperatorExpander | ExpanderFn
+            The expander object or function. A later registration for the same
+            key replaces an earlier one (last-write-wins override).
+        """
+        self._expanders[(target, operator)] = _as_callable(expander)
+
+    def resolve(self, target: Target, operator: type) -> ExpanderFn | None:
+        """Return the expander for ``(target, operator)`` via the fallback chain.
+
+        Tries the exact ``(target, op)`` entry, then the
+        ``(GenericTarget(), op)`` fallback, then ``None`` (legacy emitter).
+        """
+        fn = self._expanders.get((target, operator))
+        if fn is not None:
+            return fn
+        if target != GenericTarget():
+            fn = self._expanders.get((GenericTarget(), operator))
+            if fn is not None:
+                return fn
+        return None
+
+    def unregister(self, target: Target, operator: type) -> None:
+        """Drop the ``(target, operator)`` entry if present (test affordance)."""
+        self._expanders.pop((target, operator), None)
+
+    def clear(self) -> None:
+        """Drop every registration (test affordance)."""
+        self._expanders.clear()
+
+    def __contains__(self, key: tuple[Target, type]) -> bool:
+        return key in self._expanders
+
+
+#: The process-wide registry the :func:`register` decorator writes to and the
+#: :class:`ExpandOperators` pass reads from. Empty as of this issue, so the pass
+#: is a strict no-op.
+REGISTRY = ExpanderRegistry()
+
+
+def register(
+    target: type[Target] | Target, operator: type
+) -> Callable[[OperatorExpander | ExpanderFn], OperatorExpander | ExpanderFn]:
+    """Register an operator expander for ``(target, operator)`` — the extension hook.
+
+    The public decorator by which a built-in or user-supplied expander is added
+    to the process-wide :data:`REGISTRY`::
+
+        @register(DuckDBTarget, GIQLDisjoin)
+        def expand_disjoin(node, ctx): ...
+
+    Parameters
+    ----------
+    target : type[Target] | Target
+        The target the expander handles, given as the target *class* (the usual
+        form — it is instantiated with its default capabilities) or an explicit
+        instance. Pass :class:`~giql.targets.GenericTarget` for the portable
+        expander every target falls back to.
+    operator : type
+        The GIQL operator expression class the expander handles.
+
+    Returns
+    -------
+    Callable
+        A decorator that registers its argument and returns it unchanged, so the
+        decorated object stays usable on its own.
+    """
+    target_instance = target() if isinstance(target, type) else target
+
+    def decorator(
+        expander: OperatorExpander | ExpanderFn,
+    ) -> OperatorExpander | ExpanderFn:
+        REGISTRY.register(target_instance, operator, expander)
+        return expander
+
+    return decorator
+
+
+def _giql_operators() -> tuple[type, ...]:
+    """Return the GIQL operator classes, imported lazily to avoid a cycle."""
+    from giql.expressions import Contains
+    from giql.expressions import GIQLCluster
+    from giql.expressions import GIQLDisjoin
+    from giql.expressions import GIQLDistance
+    from giql.expressions import GIQLMerge
+    from giql.expressions import GIQLNearest
+    from giql.expressions import Intersects
+    from giql.expressions import SpatialSetPredicate
+    from giql.expressions import Within
+
+    return (
+        GIQLDisjoin,
+        GIQLNearest,
+        GIQLDistance,
+        GIQLCluster,
+        GIQLMerge,
+        Intersects,
+        Contains,
+        Within,
+        SpatialSetPredicate,
+    )
+
+
+def expand_operators(
+    expression: exp.Expression,
+    target: Target,
+    tables: Tables,
+    registry: ExpanderRegistry | None = None,
+) -> exp.Expression:
+    """Replace each opted-in GIQL operator with its registry expansion.
+
+    Pass 3 of the normalization pipeline (epic #137). Runs after
+    :func:`giql.canonicalizer.canonicalize_coordinates`. For every GIQL operator
+    node it dispatches to the new AST-expansion path **only when** the operator's
+    class sets ``GIQL_EXPAND = True`` *and* the registry resolves an expander for
+    ``(target, operator type)`` through its fallback chain; otherwise the node is
+    left untouched and the legacy ``*_sql`` emitter handles it.
+
+    The pass mutates and returns *expression* in place. **With no operator
+    flagged and an empty registry it is a strict no-op** and the emitted SQL is
+    byte-identical, so the existing suite is the migration oracle.
+
+    Parameters
+    ----------
+    expression : exp.Expression
+        The pass-1/pass-2-annotated AST.
+    target : Target
+        The active target whose expanders to dispatch to.
+    tables : Tables
+        The registered table configurations, threaded into each context.
+    registry : ExpanderRegistry | None
+        The registry to resolve against; defaults to the process-wide
+        :data:`REGISTRY`.
+
+    Returns
+    -------
+    exp.Expression
+        The same *expression*, with opted-in operator nodes replaced by their
+        target-specific expansions (none, while every flag is off / the registry
+        is empty).
+    """
+    reg = registry if registry is not None else REGISTRY
+    operators = _giql_operators()
+    alias_seq = name_sequence(EXPAND_ALIAS_PREFIX)
+
+    # Collect first, then mutate: replacing nodes mid-walk is unsafe.
+    pending: list[tuple[exp.Expression, ExpanderFn]] = []
+    for node in expression.walk():
+        if not isinstance(node, operators):
+            continue
+        if not getattr(node, "GIQL_EXPAND", False):
+            continue
+        fn = reg.resolve(target, type(node))
+        if fn is None:
+            continue
+        pending.append((node, fn))
+
+    for node, fn in pending:
+        resolution = node.meta.get(META_KEY)
+        if not isinstance(resolution, OperatorResolution):
+            resolution = None
+        ctx = ExpansionContext(node, resolution, target, tables, alias_seq)
+        replacement = fn(node, ctx)
+        if replacement is not node:
+            node.replace(replacement)
+
+    return expression
+
+
+class ExpandOperators:
+    """Callable wrapper for :func:`expand_operators`, parallel to the transformers.
+
+    The transpile pipeline composes transformer *objects* bound to their
+    :class:`~giql.table.Tables`; this wrapper gives the expansion pass the same
+    shape — construct it with the active target and tables, then call it on the
+    AST — so it slots into the pipeline uniformly after
+    :class:`giql.canonicalizer.canonicalize_coordinates`.
+    """
+
+    def __init__(
+        self,
+        target: Target,
+        tables: Tables,
+        registry: ExpanderRegistry | None = None,
+    ) -> None:
+        self.target = target
+        self.tables = tables
+        self.registry = registry
+
+    def transform(self, expression: exp.Expression) -> exp.Expression:
+        """Run the expansion pass over *expression* and return it."""
+        return expand_operators(expression, self.target, self.tables, self.registry)

--- a/src/giql/expander.py
+++ b/src/giql/expander.py
@@ -16,6 +16,14 @@ remaining steps migrate each operator onto, one at a time:
 * a :func:`register` decorator — the **public extension hook** by which a user
   adds a target or overrides an operator for one, e.g.
   ``@register(DuckDBTarget, GIQLDisjoin)``;
+* the registry's teardown seam — :meth:`ExpanderRegistry.unregister`,
+  :meth:`ExpanderRegistry.clear`, and ``in`` membership (``__contains__``) — the
+  **supported public API** for undoing a custom registration. A user who
+  registers a custom expander (e.g. in a test fixture or a plugin's teardown)
+  resets the process-wide :data:`REGISTRY` through these rather than reaching
+  into private state: ``REGISTRY.unregister(DuckDBTarget(), GIQLDisjoin)`` drops
+  one entry, ``REGISTRY.clear()`` drops them all, and
+  ``(DuckDBTarget(), GIQLDisjoin) in REGISTRY`` tests for one;
 * the :class:`ExpandOperators` pass, which runs after
   :func:`giql.canonicalizer.canonicalize_coordinates`, walks the AST, and
   replaces every opted-in GIQL operator node with the registry's expansion.
@@ -227,14 +235,34 @@ class ExpanderRegistry:
         return None
 
     def unregister(self, target: Target, operator: type) -> None:
-        """Drop the ``(target, operator)`` entry if present (test affordance)."""
+        """Drop the ``(target, operator)`` entry if present.
+
+        Part of the registry's **public teardown seam**: a caller that
+        registered a custom expander (a plugin, or a test fixture) undoes one
+        registration with this rather than mutating private state. Resolving the
+        same key afterward falls back through the chain to ``None``. Dropping an
+        absent key is a no-op.
+        """
         self._expanders.pop((target, operator), None)
 
     def clear(self) -> None:
-        """Drop every registration (test affordance)."""
+        """Drop every registration.
+
+        The bulk form of :meth:`unregister`, and the **public reset** for the
+        process-wide :data:`REGISTRY` — e.g. a test fixture that saves and
+        restores the registry around a body that registers custom expanders.
+        """
         self._expanders.clear()
 
     def __contains__(self, key: tuple[Target, type]) -> bool:
+        """Whether an *exact* ``(target, operator)`` entry is registered.
+
+        Tests the exact key only — it does **not** walk the generic fallback
+        chain :meth:`resolve` follows (``(GenericTarget(), op) in registry`` is
+        the only way ``(target, op)`` reports present via the generic entry).
+        Part of the public teardown seam, for asserting a registration landed or
+        was torn down.
+        """
         return key in self._expanders
 
 

--- a/src/giql/expander.py
+++ b/src/giql/expander.py
@@ -57,6 +57,7 @@ from sqlglot.helper import name_sequence
 
 from giql.resolver import META_KEY
 from giql.resolver import OperatorResolution
+from giql.resolver import ResolutionError
 from giql.table import Tables
 from giql.targets import GenericTarget
 from giql.targets import Target
@@ -76,11 +77,6 @@ __all__ = [
 #: leading double underscore keeps synthesized names clear of user identifiers,
 #: mirroring the ``__giql_canon_`` / ``__giql_dj_`` reserved prefixes.
 EXPAND_ALIAS_PREFIX = "__giql_x_"
-
-#: The GIQL operator expression classes the pass inspects. Membership alone does
-#: not opt an operator in: the per-class ``GIQL_EXPAND`` flag plus a registered
-#: expander do (see module docstring). Imported lazily inside the pass to avoid a
-#: module-level import cycle with :mod:`giql.expressions`.
 
 
 class ExpansionContext:
@@ -165,7 +161,10 @@ ExpanderFn = Callable[[exp.Expression, ExpansionContext], exp.Expression]
 
 def _as_callable(expander: OperatorExpander | ExpanderFn) -> ExpanderFn:
     """Normalize an expander to a plain ``(node, ctx) -> Expression`` callable."""
-    if isinstance(expander, OperatorExpander):
+    # ``@runtime_checkable`` only checks an ``expand`` attribute *exists*, so an
+    # object with a non-callable ``expand`` would pass the isinstance check; guard
+    # that the attribute is actually callable before trusting the protocol branch.
+    if isinstance(expander, OperatorExpander) and callable(expander.expand):
         return expander.expand
     if callable(expander):
         return expander
@@ -265,6 +264,20 @@ class ExpanderRegistry:
         """
         return key in self._expanders
 
+    def __len__(self) -> int:
+        """The number of registered ``(target, operator)`` entries.
+
+        Part of the public introspection surface (alongside ``in``): emptiness is
+        observable without reaching into private state, so a teardown fixture or
+        leak guard can assert the registry is clear via ``len(registry)`` or
+        ``bool(registry)``.
+        """
+        return len(self._expanders)
+
+    def __bool__(self) -> bool:
+        """Whether any expander is registered (``False`` when empty)."""
+        return bool(self._expanders)
+
 
 #: The process-wide registry the :func:`register` decorator writes to and the
 #: :class:`ExpandOperators` pass reads from. Empty as of this issue, so the pass
@@ -299,7 +312,19 @@ def register(
         A decorator that registers its argument and returns it unchanged, so the
         decorated object stays usable on its own.
     """
-    target_instance = target() if isinstance(target, type) else target
+    if isinstance(target, type):
+        try:
+            target_instance: Target = target()
+        except TypeError as exc:
+            raise TypeError(
+                f"register() could not instantiate target class {target.__name__!r} "
+                "with no arguments: a custom Target subclass with required fields "
+                "cannot be defaulted. Pass an instance (e.g. "
+                f"@register({target.__name__}(...), ...)) or give its fields "
+                "defaults so the class form can construct it."
+            ) from exc
+    else:
+        target_instance = target
 
     def decorator(
         expander: OperatorExpander | ExpanderFn,
@@ -310,8 +335,13 @@ def register(
     return decorator
 
 
+# The GIQL operator expression classes the pass inspects. Membership alone does
+# not opt an operator in: the per-class ``GIQL_EXPAND`` flag plus a registered
+# expander do (see module docstring). Imported lazily as a precaution; there is no
+# real cycle (``canonicalizer.py`` imports the same classes eagerly at module
+# level), so a later step may hoist these to module scope to match that sibling.
 def _giql_operators() -> tuple[type, ...]:
-    """Return the GIQL operator classes, imported lazily to avoid a cycle."""
+    """Return the GIQL operator classes, imported lazily as a precaution."""
     from giql.expressions import Contains
     from giql.expressions import GIQLCluster
     from giql.expressions import GIQLDisjoin
@@ -389,16 +419,54 @@ def expand_operators(
             continue
         pending.append((node, fn))
 
+    # Replace deepest-first: replacing an ancestor node detaches any collected
+    # descendant, whose later ``node.replace`` would be a silent no-op (the
+    # detached node's parent is gone), so the inner operator would never expand.
+    # Mutating leaves first keeps every still-collected ancestor attached. A
+    # detached node is skipped defensively as a second line of defence (#154).
+    pending.sort(key=lambda item: _node_depth(item[0]), reverse=True)
+
     for node, fn in pending:
+        if node is not expression and node.parent is None:
+            # An ancestor expansion already detached this node from the tree;
+            # replacing it would be a no-op, so skip it.
+            continue
         resolution = node.meta.get(META_KEY)
         if not isinstance(resolution, OperatorResolution):
-            resolution = None
+            # Pass 1 guarantees every operator node carries its resolution; a
+            # missing or malformed one is an internal invariant violation, not a
+            # user error, so fail loudly rather than minting a None-resolution
+            # context the expander would then dereference blindly.
+            raise ResolutionError(
+                f"{type(node).__name__} reached the ExpandOperators pass without "
+                "valid resolution metadata; pass 1 (resolve_operator_refs) must "
+                "run first and annotate every operator node."
+            )
         ctx = ExpansionContext(node, resolution, target, tables, alias_seq)
         replacement = fn(node, ctx)
+        if not isinstance(replacement, exp.Expression):
+            raise TypeError(
+                f"expander {fn!r} for {type(node).__name__} returned "
+                f"{type(replacement).__name__}, not exp.Expression"
+            )
         if replacement is not node:
             node.replace(replacement)
 
     return expression
+
+
+def _node_depth(node: exp.Expression) -> int:
+    """The number of ancestors above *node* (root is depth 0).
+
+    Used to order the collect-then-replace loop deepest-first so replacing an
+    ancestor never detaches a still-pending descendant before its own replace.
+    """
+    depth = 0
+    parent = node.parent
+    while parent is not None:
+        depth += 1
+        parent = parent.parent
+    return depth
 
 
 class ExpandOperators:

--- a/src/giql/expressions.py
+++ b/src/giql/expressions.py
@@ -232,6 +232,10 @@ class GIQLCluster(exp.Func):
         "predicate": False,  # pairwise boolean gate (current row vs PREV(col))
     }
 
+    # Inert today: the CLUSTER/MERGE transformers rewrite these nodes before the
+    # ExpandOperators pass runs, so the pass never sees a GIQLCluster to dispatch
+    # and this flag is not a live opt-in. It is forward-looking for #144, which
+    # migrates these operators onto the expander registry.
     GIQL_EXPAND = _EXPAND
 
     @classmethod
@@ -275,6 +279,10 @@ class GIQLMerge(exp.Func):
         "predicate": False,  # pairwise boolean gate (current row vs PREV(col))
     }
 
+    # Inert today: the CLUSTER/MERGE transformers rewrite these nodes before the
+    # ExpandOperators pass runs, so the pass never sees a GIQLMerge to dispatch
+    # and this flag is not a live opt-in. It is forward-looking for #144, which
+    # migrates these operators onto the expander registry.
     GIQL_EXPAND = _EXPAND
 
     @classmethod

--- a/src/giql/expressions.py
+++ b/src/giql/expressions.py
@@ -110,6 +110,14 @@ class SpatialPredicate(exp.Binary):
 #: half-open) operands are left untouched and the emitted SQL stays byte-identical.
 _CANONICALIZE = True
 
+#: Default opt-out from the ``ExpandOperators`` pass (epic #137, step 2). The
+#: per-operator ``GIQL_EXPAND`` flag mirrors ``GIQL_CANONICALIZE``: an operator
+#: takes the new AST-expansion path only when it sets ``GIQL_EXPAND = True`` *and*
+#: an expander is registered for it; otherwise the legacy ``*_sql`` emitter runs.
+#: Every operator defaults to ``False`` here, so the pass is a strict no-op until a
+#: later migration step (#140+) flips one operator's flag alongside its expander.
+_EXPAND = False
+
 
 class Intersects(SpatialPredicate):
     """INTERSECTS spatial predicate.
@@ -118,6 +126,7 @@ class Intersects(SpatialPredicate):
     """
 
     GIQL_CANONICALIZE = _CANONICALIZE
+    GIQL_EXPAND = _EXPAND
 
     GIQL_SLOTS = (
         SlotSpec("this", frozenset({"column"}), required=True),
@@ -132,6 +141,7 @@ class Contains(SpatialPredicate):
     """
 
     GIQL_CANONICALIZE = _CANONICALIZE
+    GIQL_EXPAND = _EXPAND
 
     GIQL_SLOTS = (
         SlotSpec("this", frozenset({"column"}), required=True),
@@ -146,6 +156,7 @@ class Within(SpatialPredicate):
     """
 
     GIQL_CANONICALIZE = _CANONICALIZE
+    GIQL_EXPAND = _EXPAND
 
     GIQL_SLOTS = (
         SlotSpec("this", frozenset({"column"}), required=True),
@@ -169,6 +180,7 @@ class SpatialSetPredicate(exp.Expression):
     }
 
     GIQL_CANONICALIZE = _CANONICALIZE
+    GIQL_EXPAND = _EXPAND
 
     GIQL_SLOTS = (
         SlotSpec("this", frozenset({"column"}), required=True),
@@ -220,6 +232,8 @@ class GIQLCluster(exp.Func):
         "predicate": False,  # pairwise boolean gate (current row vs PREV(col))
     }
 
+    GIQL_EXPAND = _EXPAND
+
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
@@ -261,6 +275,8 @@ class GIQLMerge(exp.Func):
         "predicate": False,  # pairwise boolean gate (current row vs PREV(col))
     }
 
+    GIQL_EXPAND = _EXPAND
+
     @classmethod
     def from_arg_list(cls, args):
         kwargs, positional_args = _split_named_and_positional(args)
@@ -297,6 +313,7 @@ class GIQLDistance(exp.Func):
     }
 
     GIQL_CANONICALIZE = _CANONICALIZE
+    GIQL_EXPAND = _EXPAND
 
     GIQL_SLOTS = (
         SlotSpec("this", frozenset({"column"}), required=True),
@@ -344,6 +361,7 @@ class GIQLNearest(exp.Func):
     #: half-open) operands are left untouched and the emitted SQL stays
     #: byte-identical.
     GIQL_CANONICALIZE = _CANONICALIZE
+    GIQL_EXPAND = _EXPAND
 
     GIQL_SLOTS = (
         SlotSpec("this", frozenset({"registered_table"}), required=True),
@@ -393,6 +411,7 @@ class GIQLDisjoin(exp.Func):
     #: (0-based half-open) operands are left unwrapped and the emitted SQL stays
     #: byte-identical.
     GIQL_CANONICALIZE = True
+    GIQL_EXPAND = _EXPAND
 
     GIQL_SLOTS = (
         SlotSpec("this", frozenset({"registered_table"}), required=True),

--- a/src/giql/transpile.py
+++ b/src/giql/transpile.py
@@ -13,6 +13,7 @@ from sqlglot import parse_one
 
 from giql.canonicalizer import canonicalize_coordinates
 from giql.dialect import GIQLDialect
+from giql.expander import ExpandOperators
 from giql.generators import BaseGIQLGenerator
 from giql.resolver import resolve_operator_refs
 from giql.table import Table
@@ -190,6 +191,15 @@ def transpile(
     # is a strict no-op until the per-operator port issues (#122, #123) land.
     with _reraise_as_value_error("Canonicalization error"):
         ast = canonicalize_coordinates(ast)
+
+    # Pass 3 of the normalization pipeline (epic #137): replace each opted-in
+    # GIQL operator node with the AST its registered expander produces for the
+    # active target. No operator sets GIQL_EXPAND and the registry is empty, so
+    # this is a strict no-op until the per-operator migration issues land; the
+    # legacy *_sql emitters on the generator remain the fallback.
+    expand_operators = ExpandOperators(target, tables_container)
+    with _reraise_as_value_error("Expansion error"):
+        ast = expand_operators.transform(ast)
 
     with _reraise_as_value_error("Transpilation error"):
         sql = generator.generate(ast)

--- a/src/giql/transpile.py
+++ b/src/giql/transpile.py
@@ -163,6 +163,16 @@ def transpile(
         with _reraise_as_value_error("Transformation error"):
             duckdb_sql = duckdb_transformer.transform_to_sql(ast)
         if duckdb_sql is not None:
+            # WARNING: this early return emits the legacy IEJoin SQL directly and
+            # SKIPS the normalization pipeline below — pass 1 (resolution), pass 2
+            # (canonicalization), and pass 3 (ExpandOperators, constructed ~40
+            # lines down). The ExpandOperators registry is therefore NOT consulted
+            # on this path: a flagged operator on an IEJoin-eligible duckdb query
+            # is left un-expanded. This is benign today (the registry is empty and
+            # no operator opts in), but any DuckDB-pathed operator migration (#141)
+            # must either run expansion BEFORE this early return or have the IEJoin
+            # transformer defer to the registry. See the strict-xfail
+            # characterization test pinning this gap in tests/test_expander.py.
             return duckdb_sql
 
     intersects_transformer = IntersectsBinnedJoinTransformer(

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -55,12 +55,16 @@ def _record(label: str):
 
 @pytest.fixture
 def clean_registry():
-    """Isolate the process-wide REGISTRY, restoring its contents afterward."""
-    saved = dict(REGISTRY._expanders)
+    """Isolate the process-wide REGISTRY, leaving it empty afterward.
+
+    The registry is empty at import (the pass ships inert), so a test that opts
+    in clears on the way out; emptiness is asserted through the public
+    ``bool()``/``len()`` surface rather than private state.
+    """
+    assert not REGISTRY, "REGISTRY was non-empty entering clean_registry"
     REGISTRY.clear()
     yield REGISTRY
     REGISTRY.clear()
-    REGISTRY._expanders.update(saved)
 
 
 @pytest.fixture(autouse=True)
@@ -71,11 +75,33 @@ def _registry_leak_guard():
     every test, so a test that registers without cleaning up (a leak that would
     silently flip the no-op pass for a later test) fails loudly. Tests that
     register on the process-wide REGISTRY do so through ``clean_registry``, which
-    clears on the way out; this guard catches anything that bypasses it.
+    clears on the way out; this guard catches anything that bypasses it. Both
+    checks go through the public ``bool()`` surface (A5), not private state.
     """
-    assert not REGISTRY._expanders, "REGISTRY leaked into a test from a prior one"
+    assert not REGISTRY, "REGISTRY leaked into a test from a prior one"
     yield
-    assert not REGISTRY._expanders, "a test leaked a registration into REGISTRY"
+    assert not REGISTRY, "a test leaked a registration into REGISTRY"
+
+
+@pytest.fixture(autouse=True)
+def _expand_flag_leak_guard():
+    """Assert every operator's GIQL_EXPAND is restored at each test boundary.
+
+    The symmetric partner of the registry leak guard: each operator class ships
+    opted out (its own GIQL_EXPAND attribute is False), and a test that flips one
+    via ``_opted_in`` must restore it. A leaked opt-in would silently flip the
+    no-op pass for a later test, so this catches anything that bypasses the
+    exception-safe ``_opted_in`` manager.
+    """
+    for op in _OPERATOR_CLASSES:
+        assert op.__dict__.get("GIQL_EXPAND") is False, (
+            f"{op.__name__}.GIQL_EXPAND leaked into a test from a prior one"
+        )
+    yield
+    for op in _OPERATOR_CLASSES:
+        assert op.__dict__.get("GIQL_EXPAND") is False, (
+            f"a test leaked a GIQL_EXPAND opt-in on {op.__name__}"
+        )
 
 
 class _CountingExpander:
@@ -286,6 +312,29 @@ class TestExpanderRegistry:
         with pytest.raises(TypeError):
             registry.register(GenericTarget(), GIQLDisjoin, object())
 
+    def test_register_rejects_object_with_non_callable_expand(self):
+        """Test that an object whose expand attribute is not callable is rejected.
+
+        Given:
+            An object exposing an 'expand' attribute that is data, not a method,
+            so it passes the runtime-checkable protocol's attribute check.
+        When:
+            Registering it.
+        Then:
+            It should raise TypeError (the registry requires a callable expand,
+            not merely the attribute's presence).
+        """
+
+        # Arrange
+        class _BadExpander:
+            expand = "not callable"
+
+        registry = ExpanderRegistry()
+
+        # Act & assert
+        with pytest.raises(TypeError):
+            registry.register(GenericTarget(), GIQLDisjoin, _BadExpander())
+
 
 class TestExpanderRegistryFallbackGaps:
     """Edge cases of the registry fallback and op-scoped keying."""
@@ -390,7 +439,7 @@ class TestExpanderRegistryFallbackGaps:
         registry.unregister(DuckDBTarget(), GIQLDisjoin)
         assert (DuckDBTarget(), GIQLDisjoin) not in registry
 
-    def test_public_teardown_seam_resets_process_registry(self):
+    def test_public_teardown_seam_resets_process_registry(self, clean_registry):
         """Test that the public seam tears a custom registration off REGISTRY.
 
         Given:
@@ -1041,23 +1090,6 @@ class TestOperatorOptOut:
         # Assert
         assert flag is False
 
-    def test_expand_sentinel_is_false(self):
-        """Test that the shared _EXPAND opt-out sentinel is False.
-
-        Given:
-            The expressions module's _EXPAND sentinel that every operator's
-            GIQL_EXPAND defaults to.
-        When:
-            Reading it.
-        Then:
-            It should be False, the single source the per-class flags inherit.
-        """
-        # Arrange & act
-        from giql.expressions import _EXPAND
-
-        # Assert
-        assert _EXPAND is False
-
 
 class TestOptedInRestoresFlag:
     """The _opted_in helper restores GIQL_EXPAND even when its body raises."""
@@ -1366,6 +1398,10 @@ class TestTranspileExpanderDispatch:
         captured = {}
 
         def _capture(node, ctx):
+            # Snapshot the node's SQL *at dispatch* — canonicalization ran before
+            # this pass, so a non-canonical target is already wrapped in a
+            # __giql_canon_ CTE the expander sees in its operand.
+            captured["node_sql"] = ctx.node.sql(dialect=GIQLDialect)
             captured["resolution"] = ctx.resolution
             # Returning the node unchanged leaves the canonical CTE in the tree.
             return node
@@ -1375,11 +1411,11 @@ class TestTranspileExpanderDispatch:
 
         # Act
         with _opted_in(GIQLDisjoin):
-            sql = transpile("SELECT * FROM DISJOIN(variants)", tables=[one_based])
+            transpile("SELECT * FROM DISJOIN(variants)", tables=[one_based])
 
         # Assert
         assert captured["resolution"] is not None
-        assert "__giql_canon_" in sql
+        assert "__giql_canon_" in captured["node_sql"]
 
     def test_replacement_reaches_generator(self, clean_registry):
         """Test that the expander's replacement node is what the generator renders.
@@ -1483,10 +1519,11 @@ class TestExpandOperatorsWalk:
 
         # Act
         with _opted_in(GIQLDisjoin):
-            pass_.transform(ast)
+            result = pass_.transform(ast)
 
         # Assert
         assert len(counting.calls) == 1
+        assert not list(result.find_all(GIQLDisjoin))
 
     @pytest.mark.parametrize(
         "query",
@@ -1519,10 +1556,11 @@ class TestExpandOperatorsWalk:
 
         # Act
         with _opted_in(Intersects):
-            pass_.transform(ast)
+            result = pass_.transform(ast)
 
         # Assert
         assert len(counting.calls) == 1
+        assert not list(result.find_all(Intersects))
 
     def test_walk_replacement_serializes_through_generator(self, clean_registry):
         """Test that the pass's replacement serializes cleanly to SQL.
@@ -1679,16 +1717,107 @@ class TestExpandOperatorsWalk:
         assert seen[0] != seen[1]
         assert all(a.startswith(EXPAND_ALIAS_PREFIX) for a in seen)
 
+    def test_walk_expands_inner_before_outer_replaces_subtree(self, clean_registry):
+        """Test that a nested operator expands into the live tree before its ancestor.
+
+        Given:
+            An outer DISJOIN whose reference subquery contains an inner DISJOIN,
+            both flagged. The outer's expander returns a fresh node that does NOT
+            re-attach the inner subtree, and inspects its own subtree so the
+            recorded order reveals whether the inner had already expanded when the
+            outer ran.
+        When:
+            Running the pass.
+        Then:
+            BOTH operators expand and the outer sees the inner already gone — the
+            deepest-first order expands the inner into the live tree before the
+            outer replaces it. Under the former outer-first order
+            the outer replacement detached the still-pending inner, whose later
+            replace() landed in a discarded subtree, so the inner never reached
+            the live tree (#154). The recorded order pins the discriminator: the
+            inner must expand first.
+        """
+        # Arrange
+        order = []
+        tables = _tables(("variants", "genes"))
+        ast = _prepare(
+            "SELECT * FROM "
+            "DISJOIN(variants, reference := (SELECT * FROM DISJOIN(genes)))",
+            tables,
+        )
+        # Identify the outer node up front: it is the one carrying a descendant
+        # DISJOIN. Tag by identity so the label survives the inner's replacement.
+        outer = next(
+            n for n in ast.find_all(GIQLDisjoin) if list(n.find_all(GIQLDisjoin))[1:]
+        )
+
+        def _expander(node, ctx):
+            if node is outer:
+                # When the outer runs, the inner must already be gone from the
+                # outer's subtree (deepest-first expanded and replaced it). Under
+                # the old outer-first order an un-expanded inner DISJOIN would
+                # still be present here.
+                order.append(
+                    "outer_sees_no_inner"
+                    if not list(node.find_all(GIQLDisjoin))[1:]
+                    else "outer_sees_inner"
+                )
+                return exp.column("EXPANDED_outer")
+            order.append("inner")
+            return exp.column("EXPANDED_inner")
+
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _expander)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            result = pass_.transform(ast)
+
+        # Assert
+        # The inner expands first, into the live tree, so the outer sees it gone.
+        assert order == ["inner", "outer_sees_no_inner"]
+        assert not list(result.find_all(GIQLDisjoin))
+
+    def test_transform_raises_on_node_missing_resolution(self, clean_registry):
+        """Test that the pass raises when an operator lacks resolution metadata.
+
+        Given:
+            A flagged DISJOIN whose pass-1 resolution metadata has been stripped
+            (an internal invariant violation), with a registered expander.
+        When:
+            Running the pass.
+        Then:
+            It raises ResolutionError rather than dispatching with a None
+            resolution (pass 1 must annotate every operator node).
+        """
+        # Arrange
+        from giql.resolver import META_KEY
+        from giql.resolver import ResolutionError
+
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _record("x"))
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        for node in ast.find_all(GIQLDisjoin):
+            node.meta.pop(META_KEY, None)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act & assert
+        with _opted_in(GIQLDisjoin):
+            with pytest.raises(ResolutionError):
+                pass_.transform(ast)
+
     def test_lazy_import_has_no_cycle_in_fresh_process(self):
         """Test that importing the expander module standalone raises no cycle.
 
         Given:
             A fresh Python process with nothing pre-imported.
         When:
-            Importing giql.expander and calling its lazy operator accessor.
+            Importing giql.expander and running its public expand_operators pass
+            over a parsed operator AST.
         Then:
-            It imports and resolves the nine operator classes without an import
-            cycle (the lazy _giql_operators import breaks the module cycle).
+            It imports and runs the inert pass without an import cycle, leaving at
+            least one operator node intact (the empty registry is a no-op), so the
+            lazy operator import resolves through a public entry point.
         """
         # Arrange
         import os
@@ -1696,9 +1825,17 @@ class TestExpandOperatorsWalk:
         import sys
 
         code = (
-            "import giql.expander as e; "
-            "ops = e._giql_operators(); "
-            "assert len(ops) == 9, ops; "
+            "from giql.expander import expand_operators, ExpanderRegistry; "
+            "from giql.expressions import GIQLDisjoin; "
+            "from giql.dialect import GIQLDialect; "
+            "from giql.table import Table, Tables; "
+            "from giql.targets import GenericTarget; "
+            "from sqlglot import parse_one; "
+            "t = Tables(); t.register('variants', Table('variants')); "
+            "ast = parse_one('SELECT * FROM DISJOIN(variants)', dialect=GIQLDialect); "
+            "out = expand_operators(ast, GenericTarget(), t, ExpanderRegistry()); "
+            "ops = list(out.find_all(GIQLDisjoin)); "
+            "assert len(ops) >= 1, ops; "
             "print('ok')"
         )
         # Strip coverage's subprocess auto-start hooks so the child is a genuinely

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -30,6 +30,9 @@ from giql.expander import OperatorExpander
 from giql.expander import expand_operators
 from giql.expander import register
 from giql.expressions import GIQLDisjoin
+from giql.expressions import GIQLMerge
+from giql.expressions import Intersects
+from giql.generators import BaseGIQLGenerator
 from giql.resolver import resolve_operator_refs
 from giql.table import Table
 from giql.table import Tables
@@ -58,6 +61,33 @@ def clean_registry():
     yield REGISTRY
     REGISTRY.clear()
     REGISTRY._expanders.update(saved)
+
+
+@pytest.fixture(autouse=True)
+def _registry_leak_guard():
+    """Assert the process-wide REGISTRY is empty at each test boundary.
+
+    A leak guard: the registry is empty at import and must return to empty after
+    every test, so a test that registers without cleaning up (a leak that would
+    silently flip the no-op pass for a later test) fails loudly. Tests that
+    register on the process-wide REGISTRY do so through ``clean_registry``, which
+    clears on the way out; this guard catches anything that bypasses it.
+    """
+    assert not REGISTRY._expanders, "REGISTRY leaked into a test from a prior one"
+    yield
+    assert not REGISTRY._expanders, "a test leaked a registration into REGISTRY"
+
+
+class _CountingExpander:
+    """An expander recording each call so a walk's dispatch count can be pinned."""
+
+    def __init__(self, label="counted"):
+        self.calls = []
+        self._label = label
+
+    def __call__(self, node, ctx):
+        self.calls.append((node, ctx))
+        return exp.Literal.string(self._label)
 
 
 class TestExpanderRegistry:
@@ -257,6 +287,139 @@ class TestExpanderRegistry:
             registry.register(GenericTarget(), GIQLDisjoin, object())
 
 
+class TestExpanderRegistryFallbackGaps:
+    """Edge cases of the registry fallback and op-scoped keying."""
+
+    def test_non_generic_target_with_no_entries_resolves_none(self):
+        """Test that a target with neither a specific nor generic entry yields None.
+
+        Given:
+            A registry with no entry for the target and no generic entry.
+        When:
+            Resolving (DataFusionTarget(), op).
+        Then:
+            It resolves to None (legacy emitter fallback), having exhausted the
+            chain.
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        registry.register(DuckDBTarget(), GIQLDisjoin, _record("duckdb"))
+
+        # Act
+        resolved = registry.resolve(DataFusionTarget(), GIQLDisjoin)
+
+        # Assert
+        assert resolved is None
+
+    def test_generic_entry_is_operator_scoped(self):
+        """Test that a generic entry for one operator does not satisfy another.
+
+        Given:
+            A generic expander registered for operator X (GIQLDisjoin) only.
+        When:
+            Resolving operator Y (GIQLMerge) for a target.
+        Then:
+            It resolves to None — the generic fallback is keyed per operator, not
+            a catch-all for the target.
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        registry.register(GenericTarget(), GIQLDisjoin, _record("generic"))
+
+        # Act
+        resolved = registry.resolve(DuckDBTarget(), GIQLMerge)
+
+        # Assert
+        assert resolved is None
+
+    def test_contains_checks_exact_key_not_fallback(self):
+        """Test that __contains__ tests the exact key, ignoring the generic chain.
+
+        Given:
+            A registry with a generic entry for op only.
+        When:
+            Testing membership of an exact (DuckDBTarget, op) key.
+        Then:
+            The exact target key reports absent while the generic key reports
+            present (membership does not walk the fallback chain).
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        registry.register(GenericTarget(), GIQLDisjoin, _record("generic"))
+
+        # Act & assert
+        assert (GenericTarget(), GIQLDisjoin) in registry
+        assert (DuckDBTarget(), GIQLDisjoin) not in registry
+
+    def test_unregister_drops_entry_and_falls_through(self):
+        """Test that unregister drops an entry so the key resolves to None after.
+
+        Given:
+            A registry with one (DuckDBTarget, op) entry.
+        When:
+            Unregistering that key.
+        Then:
+            Resolving it returns None and the key reports absent (public teardown
+            seam).
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        registry.register(DuckDBTarget(), GIQLDisjoin, _record("duckdb"))
+
+        # Act
+        registry.unregister(DuckDBTarget(), GIQLDisjoin)
+
+        # Assert
+        assert registry.resolve(DuckDBTarget(), GIQLDisjoin) is None
+        assert (DuckDBTarget(), GIQLDisjoin) not in registry
+
+    def test_unregister_absent_key_is_noop(self):
+        """Test that unregistering an absent key does not raise.
+
+        Given:
+            An empty registry.
+        When:
+            Unregistering a key that was never registered.
+        Then:
+            It returns without raising (idempotent teardown).
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+
+        # Act & assert (no raise)
+        registry.unregister(DuckDBTarget(), GIQLDisjoin)
+        assert (DuckDBTarget(), GIQLDisjoin) not in registry
+
+    def test_public_teardown_seam_resets_process_registry(self):
+        """Test that the public seam tears a custom registration off REGISTRY.
+
+        Given:
+            A custom expander registered on the process-wide REGISTRY via the
+            decorator (the public extension hook).
+        When:
+            Tearing it down through the public seam — unregister, then clear —
+            without touching private state.
+        Then:
+            The key resolves to None and REGISTRY is empty again, so the leak
+            guard's post-test assertion holds (the seam is a supported reset).
+        """
+
+        # Arrange
+        @register(DuckDBTarget, GIQLDisjoin)
+        def _expander(node, ctx):
+            return exp.column("x")
+
+        assert (DuckDBTarget(), GIQLDisjoin) in REGISTRY
+
+        # Act
+        REGISTRY.unregister(DuckDBTarget(), GIQLDisjoin)
+        REGISTRY.clear()
+
+        # Assert
+        assert REGISTRY.resolve(DuckDBTarget(), GIQLDisjoin) is None
+        assert (DuckDBTarget(), GIQLDisjoin) not in REGISTRY
+
+
 class TestRegisterDecorator:
     """Tests for the @register extension-hook decorator."""
 
@@ -319,6 +482,154 @@ class TestRegisterDecorator:
         # Assert
         assert clean_registry.resolve(DuckDBTarget(), GIQLDisjoin) is _expander
 
+    def test_register_class_and_instance_land_on_same_entry(self, clean_registry):
+        """Test that the class and an instance form key the same registry entry.
+
+        Given:
+            A registration via the class form @register(DuckDBTarget, op).
+        When:
+            Registering again via the instance form @register(DuckDBTarget(), op).
+        Then:
+            The second lands on the same entry and overrides the first (the
+            decorator instantiates the class to a value-equal target key).
+        """
+
+        # Arrange
+        @register(DuckDBTarget, GIQLDisjoin)
+        def _first(node, ctx):
+            return exp.Literal.string("first")
+
+        # Act
+        @register(DuckDBTarget(), GIQLDisjoin)
+        def _second(node, ctx):
+            return exp.Literal.string("second")
+
+        # Assert
+        assert clean_registry.resolve(DuckDBTarget(), GIQLDisjoin) is _second
+
+    def test_register_stacks_one_expander_for_two_targets(self, clean_registry):
+        """Test that stacking the decorator registers one expander for two targets.
+
+        Given:
+            An expander decorated with @register for both DuckDB and DataFusion.
+        When:
+            Resolving each target's key.
+        Then:
+            Both resolve to the same single expander object.
+        """
+
+        # Arrange & act
+        @register(DuckDBTarget, GIQLDisjoin)
+        @register(DataFusionTarget, GIQLDisjoin)
+        def _shared(node, ctx):
+            return exp.Literal.string("shared")
+
+        # Assert
+        assert clean_registry.resolve(DuckDBTarget(), GIQLDisjoin) is _shared
+        assert clean_registry.resolve(DataFusionTarget(), GIQLDisjoin) is _shared
+
+    def test_register_overrides_through_decorator(self, clean_registry):
+        """Test that a second @register for one key overrides the first.
+
+        Given:
+            Two expanders decorated for the same (target, op) key in order.
+        When:
+            Resolving the key.
+        Then:
+            It resolves to the second (last-write-wins through the decorator).
+        """
+
+        # Arrange
+        @register(GenericTarget, GIQLDisjoin)
+        def _first(node, ctx):
+            return exp.Literal.string("first")
+
+        # Act
+        @register(GenericTarget, GIQLDisjoin)
+        def _second(node, ctx):
+            return exp.Literal.string("second")
+
+        # Assert
+        assert clean_registry.resolve(GenericTarget(), GIQLDisjoin) is _second
+
+    def test_register_accepts_object_form_through_decorator(self, clean_registry):
+        """Test that the decorator accepts an OperatorExpander object.
+
+        Given:
+            An OperatorExpander object passed to the @register decorator.
+        When:
+            Resolving the key and invoking it.
+        Then:
+            It resolves to a callable delegating to the object's expand method.
+        """
+
+        # Arrange
+        class _Obj:
+            def expand(self, node, ctx):
+                return exp.Literal.string("obj-form")
+
+        obj = _Obj()
+
+        # Act
+        register(GenericTarget, GIQLDisjoin)(obj)
+        resolved = clean_registry.resolve(GenericTarget(), GIQLDisjoin)
+
+        # Assert
+        assert resolved(None, None) == exp.Literal.string("obj-form")
+
+    def test_register_rejects_non_callable_through_decorator(self, clean_registry):
+        """Test that decorating a non-callable, non-expander raises TypeError.
+
+        Given:
+            A plain object that is neither callable nor an OperatorExpander.
+        When:
+            Passing it through the @register decorator.
+        Then:
+            It raises TypeError (the same guard as direct registration, proven
+            through the public decorator).
+        """
+        # Arrange & act & assert
+        with pytest.raises(TypeError):
+            register(GenericTarget, GIQLDisjoin)(object())
+
+    def test_register_does_not_leak_across_targets(self, clean_registry):
+        """Test that registering for one target leaves another target unaffected.
+
+        Given:
+            An expander registered for (DuckDBTarget, op) only.
+        When:
+            Resolving (DataFusionTarget, op), with no generic fallback present.
+        Then:
+            It resolves to None (no cross-target leakage).
+        """
+
+        # Arrange & act
+        @register(DuckDBTarget, GIQLDisjoin)
+        def _expander(node, ctx):
+            return exp.Literal.string("duck")
+
+        # Assert
+        assert clean_registry.resolve(DataFusionTarget(), GIQLDisjoin) is None
+
+    def test_register_returns_callable_decorated_function(self, clean_registry):
+        """Test that the bare decorated function stays callable standalone.
+
+        Given:
+            A function decorated with @register.
+        When:
+            Calling the decorated function directly (outside the pass).
+        Then:
+            It runs and returns its expansion, unchanged by decoration.
+        """
+
+        # Arrange & act
+        @register(GenericTarget, GIQLDisjoin)
+        def _expander(node, ctx):
+            return exp.Literal.string("callable")
+
+        # Assert
+        assert _expander(None, None) == exp.Literal.string("callable")
+
 
 class TestExpansionContext:
     """Tests for the ExpansionContext value object."""
@@ -365,6 +676,124 @@ class TestExpansionContext:
         assert first != second
         assert first.startswith(EXPAND_ALIAS_PREFIX)
         assert second.startswith(EXPAND_ALIAS_PREFIX)
+
+    def test_resolution_none_is_tolerated(self):
+        """Test that a None resolution is a tolerated first-class context state.
+
+        Given:
+            A context constructed with resolution=None.
+        When:
+            Reading its resolution attribute.
+        Then:
+            It is None without error (an un-annotated node is representable).
+        """
+        # Arrange
+        ctx = ExpansionContext(exp.true(), None, GenericTarget(), Tables())
+
+        # Act & assert
+        assert ctx.resolution is None
+
+    def test_tables_attribute_is_the_passed_container(self):
+        """Test that the context exposes the tables container it was built with.
+
+        Given:
+            A context built with a specific Tables container.
+        When:
+            Reading its tables attribute.
+        Then:
+            It is that same container (identity), threaded for the expander.
+        """
+        # Arrange
+        tables = _tables()
+        ctx = ExpansionContext(exp.true(), None, GenericTarget(), tables)
+
+        # Act & assert
+        assert ctx.tables is tables
+
+    def test_alias_uses_reserved_prefix_format(self):
+        """Test that minted aliases carry the reserved expander prefix.
+
+        Given:
+            A fresh context.
+        When:
+            Minting an alias.
+        Then:
+            It starts with the EXPAND_ALIAS_PREFIX reserved namespace.
+        """
+        # Arrange
+        ctx = ExpansionContext(exp.true(), None, GenericTarget(), Tables())
+
+        # Act
+        alias = ctx.alias()
+
+        # Assert
+        assert alias.startswith(EXPAND_ALIAS_PREFIX)
+
+    def test_alias_is_monotonic_within_one_context(self):
+        """Test that successive aliases in one context are all distinct.
+
+        Given:
+            A single context.
+        When:
+            Minting several aliases.
+        Then:
+            They are all distinct (a monotonic sequence, no repeats).
+        """
+        # Arrange
+        ctx = ExpansionContext(exp.true(), None, GenericTarget(), Tables())
+
+        # Act
+        names = [ctx.alias() for _ in range(5)]
+
+        # Assert
+        assert len(set(names)) == 5
+
+    def test_alias_continues_across_contexts_sharing_a_sequence(self):
+        """Test that two contexts sharing one sequence mint non-colliding aliases.
+
+        Given:
+            Two contexts built with the same shared name_sequence callable.
+        When:
+            Each mints an alias.
+        Then:
+            The aliases differ (the sequence threads continuity across the
+            per-node contexts of one run, preventing __giql_x_ collisions).
+        """
+        # Arrange
+        from sqlglot.helper import name_sequence
+
+        shared = name_sequence(EXPAND_ALIAS_PREFIX)
+        ctx_a = ExpansionContext(exp.true(), None, GenericTarget(), Tables(), shared)
+        ctx_b = ExpansionContext(exp.true(), None, GenericTarget(), Tables(), shared)
+
+        # Act
+        a = ctx_a.alias()
+        b = ctx_b.alias()
+
+        # Assert
+        assert a != b
+
+    def test_capabilities_delegates_on_second_target(self):
+        """Test that capabilities delegates to a different target's capability set.
+
+        Given:
+            A context built with a DataFusionTarget.
+        When:
+            Reading its capabilities property.
+        Then:
+            It is the DataFusion target's Capabilities (delegation is per-target,
+            not hardcoded to one engine).
+        """
+        # Arrange
+        target = DataFusionTarget()
+        ctx = ExpansionContext(exp.true(), None, target, Tables())
+
+        # Act
+        caps = ctx.capabilities
+
+        # Assert
+        assert caps is target.capabilities
+        assert caps.supports_lateral is False
 
 
 # A fake custom target standing in for a user-defined engine: the extension-hook
@@ -567,6 +996,731 @@ class TestNoOpWhenInert:
         # Assert
         assert actual == expected
         assert EXPAND_ALIAS_PREFIX not in actual
+
+
+# The nine GIQL operator expression classes the ExpandOperators pass inspects.
+# Every one must ship opted out (GIQL_EXPAND=False) at this step so the pass is a
+# strict no-op until a later migration flips one alongside its expander.
+from giql.expressions import Contains  # noqa: E402
+from giql.expressions import GIQLCluster  # noqa: E402
+from giql.expressions import GIQLDistance  # noqa: E402
+from giql.expressions import GIQLNearest  # noqa: E402
+from giql.expressions import SpatialSetPredicate  # noqa: E402
+from giql.expressions import Within  # noqa: E402
+
+_OPERATOR_CLASSES = (
+    Intersects,
+    Contains,
+    Within,
+    SpatialSetPredicate,
+    GIQLDistance,
+    GIQLNearest,
+    GIQLDisjoin,
+    GIQLCluster,
+    GIQLMerge,
+)
+
+
+class TestOperatorOptOut:
+    """Every operator ships opted out of the ExpandOperators pass at this step."""
+
+    @pytest.mark.parametrize("operator", _OPERATOR_CLASSES, ids=lambda c: c.__name__)
+    def test_operator_class_ships_expand_disabled(self, operator):
+        """Test that each operator class ships GIQL_EXPAND=False.
+
+        Given:
+            One of the nine GIQL operator expression classes.
+        When:
+            Reading its GIQL_EXPAND class attribute.
+        Then:
+            It should be False (no operator opts into expansion yet).
+        """
+        # Arrange & act
+        flag = operator.GIQL_EXPAND
+
+        # Assert
+        assert flag is False
+
+    def test_expand_sentinel_is_false(self):
+        """Test that the shared _EXPAND opt-out sentinel is False.
+
+        Given:
+            The expressions module's _EXPAND sentinel that every operator's
+            GIQL_EXPAND defaults to.
+        When:
+            Reading it.
+        Then:
+            It should be False, the single source the per-class flags inherit.
+        """
+        # Arrange & act
+        from giql.expressions import _EXPAND
+
+        # Assert
+        assert _EXPAND is False
+
+
+class TestOptedInRestoresFlag:
+    """The _opted_in helper restores GIQL_EXPAND even when its body raises."""
+
+    def test_opted_in_restores_flag_after_exception(self):
+        """Test that _opted_in restores GIQL_EXPAND when the body raises.
+
+        Given:
+            An operator class at its default GIQL_EXPAND=False.
+        When:
+            Its _opted_in body raises an exception.
+        Then:
+            The flag should be restored to False (the manager is exception-safe,
+            so a raising expansion test cannot leak an opt-in into a later test).
+        """
+        # Arrange
+        assert GIQLMerge.GIQL_EXPAND is False
+
+        # Act
+        with pytest.raises(RuntimeError):
+            with _opted_in(GIQLMerge):
+                assert GIQLMerge.GIQL_EXPAND is True
+                raise RuntimeError("boom")
+
+        # Assert
+        assert GIQLMerge.GIQL_EXPAND is False
+
+
+class TestIEJoinEarlyReturnSkipsExpansion:
+    """Pin Finding 2: the duckdb IEJoin early return skips the ExpandOperators pass."""
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="#141: the duckdb IEJoin early return in transpile() emits before "
+        "ExpandOperators runs, so a flagged operator on an IEJoin-eligible query "
+        "is not expanded. Flips to pass when #141 runs expansion before the "
+        "early return (or defers the IEJoin transformer to the registry).",
+    )
+    def test_iejoin_query_expands_flagged_operator(self, clean_registry):
+        """Test that an IEJoin-eligible duckdb query expands a flagged operator.
+
+        Given:
+            A column-to-column INTERSECTS join eligible for the duckdb IEJoin
+            path, with Intersects flagged GIQL_EXPAND and an expander registered.
+        When:
+            Transpiling with dialect='duckdb'.
+        Then:
+            The expander's sentinel should appear (currently it does NOT — the
+            IEJoin early return skips the pass; this xfail flips when #141 lands).
+        """
+        # Arrange
+        clean_registry.register(
+            DuckDBTarget(), Intersects, lambda n, c: exp.column("__giql_iejoin_sentinel")
+        )
+        query = (
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        with _opted_in(Intersects):
+            sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "__giql_iejoin_sentinel" in sql
+
+    def test_iejoin_query_emits_legacy_sql_unchanged(self, clean_registry):
+        """Test that the legacy IEJoin SQL is emitted regardless of a flagged op.
+
+        Given:
+            The same IEJoin-eligible duckdb query with Intersects flagged and an
+            expander registered.
+        When:
+            Transpiling with dialect='duckdb'.
+        Then:
+            The legacy IEJoin SET VARIABLE SQL is emitted and the expander's
+            sentinel is absent (characterizing the current skip; the companion
+            xfail surfaces when #141 fixes it).
+        """
+        # Arrange
+        clean_registry.register(
+            DuckDBTarget(), Intersects, lambda n, c: exp.column("__giql_iejoin_sentinel")
+        )
+        query = (
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        with _opted_in(Intersects):
+            sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert "__giql_iejoin_sentinel" not in sql
+
+
+class TestTranspileExpanderDispatch:
+    """Dispatch driven through the public transpile() entry point."""
+
+    def test_target_entry_dispatches_for_matching_dialect(self, clean_registry):
+        """Test that a (DuckDBTarget, op) entry dispatches for dialect='duckdb'.
+
+        Given:
+            An expander registered for (DuckDBTarget, GIQLDisjoin) and the
+            operator flagged.
+        When:
+            Transpiling a DISJOIN query with dialect='duckdb'.
+        Then:
+            The expander's sentinel should reach the generated SQL.
+        """
+        # Arrange
+        clean_registry.register(
+            DuckDBTarget(), GIQLDisjoin, lambda n, c: exp.column("DUCK_SENTINEL")
+        )
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            sql = transpile(
+                "SELECT * FROM DISJOIN(variants)", tables=["variants"], dialect="duckdb"
+            )
+
+        # Assert
+        assert "DUCK_SENTINEL" in sql
+
+    @pytest.mark.parametrize("dialect", [None, "datafusion"])
+    def test_target_entry_falls_through_for_other_dialects(
+        self, clean_registry, dialect
+    ):
+        """Test that a target-specific entry does not fire for other dialects.
+
+        Given:
+            An expander registered only for (DuckDBTarget, GIQLDisjoin), flagged.
+        When:
+            Transpiling with dialect=None or 'datafusion'.
+        Then:
+            The sentinel should be absent and the legacy SQL emitted (the
+            target-specific entry does not resolve for a different target).
+        """
+        # Arrange
+        clean_registry.register(
+            DuckDBTarget(), GIQLDisjoin, lambda n, c: exp.column("DUCK_SENTINEL")
+        )
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            sql = transpile(
+                "SELECT * FROM DISJOIN(variants)", tables=["variants"], dialect=dialect
+            )
+
+        # Assert
+        assert "DUCK_SENTINEL" not in sql
+
+    @pytest.mark.parametrize("dialect", [None, "duckdb", "datafusion"])
+    def test_generic_entry_covers_all_dialects(self, clean_registry, dialect):
+        """Test that a (GenericTarget, op) entry dispatches via fallback everywhere.
+
+        Given:
+            An expander registered only for (GenericTarget, GIQLDisjoin), flagged.
+        When:
+            Transpiling with each of the three dialects.
+        Then:
+            The generic expander's sentinel should reach the SQL in every case
+            (the fallback chain routes every target to the generic entry).
+        """
+        # Arrange
+        clean_registry.register(
+            GenericTarget(), GIQLDisjoin, lambda n, c: exp.column("GENERIC_SENTINEL")
+        )
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            sql = transpile(
+                "SELECT * FROM DISJOIN(variants)", tables=["variants"], dialect=dialect
+            )
+
+        # Assert
+        assert "GENERIC_SENTINEL" in sql
+
+    def test_target_entry_shadows_generic_per_dialect(self, clean_registry):
+        """Test that a target entry shadows the generic entry for its dialect only.
+
+        Given:
+            Both a (DuckDBTarget, op) and a (GenericTarget, op) expander, flagged.
+        When:
+            Transpiling with dialect='duckdb' versus dialect=None.
+        Then:
+            The duckdb path uses the target sentinel; the generic path uses the
+            generic sentinel (per-dialect shadowing through transpile()).
+        """
+        # Arrange
+        clean_registry.register(
+            DuckDBTarget(), GIQLDisjoin, lambda n, c: exp.column("DUCK_SENTINEL")
+        )
+        clean_registry.register(
+            GenericTarget(), GIQLDisjoin, lambda n, c: exp.column("GENERIC_SENTINEL")
+        )
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            duck_sql = transpile(
+                "SELECT * FROM DISJOIN(variants)", tables=["variants"], dialect="duckdb"
+            )
+            generic_sql = transpile(
+                "SELECT * FROM DISJOIN(variants)", tables=["variants"], dialect=None
+            )
+
+        # Assert
+        assert "DUCK_SENTINEL" in duck_sql and "GENERIC_SENTINEL" not in duck_sql
+        assert "GENERIC_SENTINEL" in generic_sql and "DUCK_SENTINEL" not in generic_sql
+
+    def test_context_target_matches_resolved_dialect(self, clean_registry):
+        """Test that ctx.target equals resolve_target(dialect) at dispatch.
+
+        Given:
+            A flagged DISJOIN and an expander capturing its context.
+        When:
+            Transpiling with dialect='datafusion'.
+        Then:
+            The captured ctx.target should equal resolve_target('datafusion').
+        """
+        # Arrange
+        from giql.targets import resolve_target
+
+        captured = {}
+
+        def _capture(node, ctx):
+            captured["target"] = ctx.target
+            return exp.column("ok")
+
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _capture)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            transpile(
+                "SELECT * FROM DISJOIN(variants)",
+                tables=["variants"],
+                dialect="datafusion",
+            )
+
+        # Assert
+        assert captured["target"] == resolve_target("datafusion")
+
+    def test_throwing_expander_wraps_in_expansion_error(self, clean_registry):
+        """Test that an unexpected expander error is wrapped as an Expansion error.
+
+        Given:
+            A flagged DISJOIN whose expander raises a non-ValueError.
+        When:
+            Transpiling.
+        Then:
+            transpile() should raise ValueError whose message starts with
+            'Expansion error: ' (the stage boundary wraps unexpected errors).
+        """
+
+        # Arrange
+        def _boom(node, ctx):
+            raise RuntimeError("kaboom")
+
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _boom)
+
+        # Act & assert
+        with _opted_in(GIQLDisjoin):
+            with pytest.raises(ValueError, match=r"^Expansion error: "):
+                transpile("SELECT * FROM DISJOIN(variants)", tables=["variants"])
+
+    def test_value_error_from_expander_passes_verbatim(self, clean_registry):
+        """Test that a ValueError raised by an expander propagates unwrapped.
+
+        Given:
+            A flagged DISJOIN whose expander raises a ValueError with a targeted
+            diagnostic.
+        When:
+            Transpiling.
+        Then:
+            The same ValueError message should propagate verbatim (the boundary
+            lets user-facing ValueErrors through untouched).
+        """
+
+        # Arrange
+        def _raise(node, ctx):
+            raise ValueError("a targeted diagnostic")
+
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _raise)
+
+        # Act & assert
+        with _opted_in(GIQLDisjoin):
+            with pytest.raises(ValueError, match=r"^a targeted diagnostic$"):
+                transpile("SELECT * FROM DISJOIN(variants)", tables=["variants"])
+
+    def test_expander_sees_canonicalized_operands(self, clean_registry):
+        """Test that expansion runs after canonicalization (pass ordering).
+
+        Given:
+            A flagged DISJOIN with a non-canonical (1-based) target table, which
+            pass 2 wraps in a __giql_canon_ CTE, and an expander capturing its
+            node's resolution at dispatch.
+        When:
+            Transpiling.
+        Then:
+            The expander runs after canonicalization, so the surviving query
+            already carries the canonical wrapper CTE (expansion sees pass-2
+            output, not the raw AST).
+        """
+        # Arrange
+        captured = {}
+
+        def _capture(node, ctx):
+            captured["resolution"] = ctx.resolution
+            # Returning the node unchanged leaves the canonical CTE in the tree.
+            return node
+
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _capture)
+        one_based = Table("variants", coordinate_system="1based")
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            sql = transpile("SELECT * FROM DISJOIN(variants)", tables=[one_based])
+
+        # Assert
+        assert captured["resolution"] is not None
+        assert "__giql_canon_" in sql
+
+    def test_replacement_reaches_generator(self, clean_registry):
+        """Test that the expander's replacement node is what the generator renders.
+
+        Given:
+            A flagged DISJOIN and an expander returning a distinctive sentinel.
+        When:
+            Transpiling.
+        Then:
+            The sentinel appears in the final SQL and no DISJOIN remains, so the
+            replacement reached the generator (end-to-end).
+        """
+        # Arrange
+        clean_registry.register(
+            GenericTarget(), GIQLDisjoin, lambda n, c: exp.column("REACHED_GENERATOR")
+        )
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            sql = transpile("SELECT * FROM DISJOIN(variants)", tables=["variants"])
+
+        # Assert
+        assert "REACHED_GENERATOR" in sql
+        assert "DISJOIN" not in sql.upper()
+
+    def test_unknown_dialect_raises_before_dispatch(self, clean_registry):
+        """Test that an unknown dialect raises before any expander dispatches.
+
+        Given:
+            A flagged DISJOIN and a generic expander that would record a call.
+        When:
+            Transpiling with an unrecognized dialect.
+        Then:
+            transpile() raises ValueError for the unknown dialect and the
+            expander never runs (dialect resolution precedes dispatch).
+        """
+        # Arrange
+        counting = _CountingExpander()
+        clean_registry.register(GenericTarget(), GIQLDisjoin, counting)
+
+        # Act & assert
+        with _opted_in(GIQLDisjoin):
+            with pytest.raises(ValueError, match="Unknown dialect"):
+                transpile(
+                    "SELECT * FROM DISJOIN(variants)",
+                    tables=["variants"],
+                    dialect="postgres",
+                )
+        assert counting.calls == []
+
+
+class TestExpandOperatorsWalk:
+    """Real-AST walk behavior of the ExpandOperators pass."""
+
+    def test_walk_visits_every_sibling_operator(self, clean_registry):
+        """Test that the pass dispatches once per sibling operator and clears them.
+
+        Given:
+            A query with two sibling DISJOIN operators, flagged, and a counting
+            expander.
+        When:
+            Running the pass.
+        Then:
+            The expander is called exactly twice and no DISJOIN node remains.
+        """
+        # Arrange
+        counting = _CountingExpander()
+        clean_registry.register(GenericTarget(), GIQLDisjoin, counting)
+        tables = _tables(("variants", "genes"))
+        ast = _prepare(
+            "SELECT * FROM DISJOIN(variants) UNION ALL SELECT * FROM DISJOIN(genes)",
+            tables,
+        )
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            result = pass_.transform(ast)
+
+        # Assert
+        assert len(counting.calls) == 2
+        assert not list(result.find_all(GIQLDisjoin))
+
+    def test_walk_reaches_nested_operator(self, clean_registry):
+        """Test that the walk reaches an operator nested in a derived table.
+
+        Given:
+            A DISJOIN nested inside a derived table, flagged, with a counting
+            expander.
+        When:
+            Running the pass.
+        Then:
+            The nested operator is dispatched exactly once.
+        """
+        # Arrange
+        counting = _CountingExpander()
+        clean_registry.register(GenericTarget(), GIQLDisjoin, counting)
+        tables = _tables()
+        ast = _prepare("SELECT * FROM (SELECT * FROM DISJOIN(variants)) t", tables)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            pass_.transform(ast)
+
+        # Assert
+        assert len(counting.calls) == 1
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1-100'",
+            "SELECT * FROM peaks a JOIN genes b ON a.interval INTERSECTS 'chr1:1-100'",
+            "SELECT * FROM (SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1-100') t",
+            "WITH d AS (SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1-100') "
+            "SELECT * FROM d",
+        ],
+        ids=["where", "join_on", "subquery", "cte"],
+    )
+    def test_walk_reaches_operator_in_each_location(self, clean_registry, query):
+        """Test that the walk reaches an operator in any clause location.
+
+        Given:
+            An INTERSECTS predicate placed in a WHERE, JOIN-ON, subquery, or CTE,
+            flagged, with a counting expander.
+        When:
+            Running the pass.
+        Then:
+            The operator is dispatched exactly once regardless of location.
+        """
+        # Arrange
+        counting = _CountingExpander()
+        clean_registry.register(GenericTarget(), Intersects, counting)
+        tables = _tables(("peaks", "genes"))
+        ast = _prepare(query, tables)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(Intersects):
+            pass_.transform(ast)
+
+        # Assert
+        assert len(counting.calls) == 1
+
+    def test_walk_replacement_serializes_through_generator(self, clean_registry):
+        """Test that the pass's replacement serializes cleanly to SQL.
+
+        Given:
+            A flagged DISJOIN and an expander returning a column sentinel.
+        When:
+            Running the pass and serializing the result with BaseGIQLGenerator.
+        Then:
+            The sentinel appears in the serialized SQL (replacement integrity).
+        """
+        # Arrange
+        clean_registry.register(
+            GenericTarget(), GIQLDisjoin, lambda n, c: exp.column("WALK_SENTINEL")
+        )
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            result = pass_.transform(ast)
+        sql = BaseGIQLGenerator(tables=tables).generate(result)
+
+        # Assert
+        assert "WALK_SENTINEL" in sql
+
+    def test_walk_identity_return_leaves_node_in_place(self, clean_registry):
+        """Test that an expander returning the node itself triggers no replacement.
+
+        Given:
+            A flagged DISJOIN whose expander returns the node unchanged.
+        When:
+            Running the pass.
+        Then:
+            The DISJOIN node remains in the tree (the identity-return guard skips
+            the replace call).
+        """
+        # Arrange
+        clean_registry.register(GenericTarget(), GIQLDisjoin, lambda n, c: n)
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            result = pass_.transform(ast)
+
+        # Assert
+        assert list(result.find_all(GIQLDisjoin))
+
+    def test_walk_dispatches_mixed_operator_types_per_type(self, clean_registry):
+        """Test that the walk dispatches each operator type to its own expander.
+
+        Given:
+            A query containing both a DISJOIN and an INTERSECTS, both flagged,
+            each with its own counting expander.
+        When:
+            Running the pass.
+        Then:
+            Each expander is called once, dispatched by operator type.
+        """
+        # Arrange
+        disjoin_counter = _CountingExpander("disjoin")
+        intersects_counter = _CountingExpander("intersects")
+        clean_registry.register(GenericTarget(), GIQLDisjoin, disjoin_counter)
+        clean_registry.register(GenericTarget(), Intersects, intersects_counter)
+        tables = _tables(("variants", "peaks"))
+        ast = _prepare(
+            "SELECT * FROM DISJOIN(variants) "
+            "WHERE EXISTS (SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1-100')",
+            tables,
+        )
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            with _opted_in(Intersects):
+                pass_.transform(ast)
+
+        # Assert
+        assert len(disjoin_counter.calls) == 1
+        assert len(intersects_counter.calls) == 1
+
+    def test_walk_partial_opt_in_replaces_only_flagged_type(self, clean_registry):
+        """Test that only the flagged operator type is replaced when both registered.
+
+        Given:
+            A DISJOIN and an INTERSECTS, both with registered expanders, but only
+            INTERSECTS flagged GIQL_EXPAND.
+        When:
+            Running the pass.
+        Then:
+            The INTERSECTS is replaced while the DISJOIN node remains (the gate is
+            per-type).
+        """
+        # Arrange
+        clean_registry.register(
+            GenericTarget(), GIQLDisjoin, lambda n, c: exp.column("DJ")
+        )
+        clean_registry.register(
+            GenericTarget(), Intersects, lambda n, c: exp.column("IX")
+        )
+        tables = _tables(("variants", "peaks"))
+        ast = _prepare(
+            "SELECT * FROM DISJOIN(variants) "
+            "WHERE EXISTS (SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1-100')",
+            tables,
+        )
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(Intersects):
+            result = pass_.transform(ast)
+
+        # Assert
+        assert list(result.find_all(GIQLDisjoin))
+        assert not list(result.find_all(Intersects))
+
+    def test_walk_shares_alias_sequence_across_sibling_expanders(self, clean_registry):
+        """Test that sibling expanders draw from one alias sequence (no collision).
+
+        Given:
+            Two sibling DISJOIN operators, flagged, with an expander that mints an
+            alias per call and records it.
+        When:
+            Running the pass.
+        Then:
+            The two minted aliases differ (the run threads a single
+            name_sequence across every per-node context, so no __giql_x_
+            collision).
+        """
+        # Arrange
+        seen = []
+
+        def _mint(node, ctx):
+            seen.append(ctx.alias())
+            return exp.column("c")
+
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _mint)
+        tables = _tables(("variants", "genes"))
+        ast = _prepare(
+            "SELECT * FROM DISJOIN(variants) UNION ALL SELECT * FROM DISJOIN(genes)",
+            tables,
+        )
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            pass_.transform(ast)
+
+        # Assert
+        assert len(seen) == 2
+        assert seen[0] != seen[1]
+        assert all(a.startswith(EXPAND_ALIAS_PREFIX) for a in seen)
+
+    def test_lazy_import_has_no_cycle_in_fresh_process(self):
+        """Test that importing the expander module standalone raises no cycle.
+
+        Given:
+            A fresh Python process with nothing pre-imported.
+        When:
+            Importing giql.expander and calling its lazy operator accessor.
+        Then:
+            It imports and resolves the nine operator classes without an import
+            cycle (the lazy _giql_operators import breaks the module cycle).
+        """
+        # Arrange
+        import os
+        import subprocess
+        import sys
+
+        code = (
+            "import giql.expander as e; "
+            "ops = e._giql_operators(); "
+            "assert len(ops) == 9, ops; "
+            "print('ok')"
+        )
+        # Strip coverage's subprocess auto-start hooks so the child is a genuinely
+        # clean interpreter exercising only the import (not the parent run's
+        # coverage instrumentation, which is irrelevant to the cycle check).
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if not k.startswith("COV_CORE") and k != "COVERAGE_PROCESS_START"
+        }
+
+        # Act
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+        # Assert
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "ok"
 
 
 def _tables(names=("variants",)) -> Tables:

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -1,0 +1,599 @@
+"""Tests for the operator-expander registry and the ``ExpandOperators`` pass.
+
+These tests pin the dispatch infrastructure of epic #137, step 2:
+
+* the :class:`~giql.expander.ExpanderRegistry` resolves an expander through the
+  ``(target, op)`` → ``(generic, op)`` → ``None`` (legacy) fallback chain, and a
+  later registration overrides an earlier one;
+* the :func:`~giql.expander.register` decorator writes to the process-wide
+  registry and returns the expander unchanged;
+* the :class:`~giql.expander.ExpandOperators` pass dispatches an opted-in
+  operator to its registered expander — including a *fake* custom target plus a
+  fake operator, the public extension hook;
+* with nothing flagged and an empty registry the pass is a strict no-op and the
+  emitted SQL is byte-identical.
+"""
+
+from dataclasses import dataclass
+
+import pytest
+from sqlglot import exp
+from sqlglot import parse_one
+
+from giql.dialect import GIQLDialect
+from giql.expander import EXPAND_ALIAS_PREFIX
+from giql.expander import REGISTRY
+from giql.expander import ExpanderRegistry
+from giql.expander import ExpandOperators
+from giql.expander import ExpansionContext
+from giql.expander import OperatorExpander
+from giql.expander import expand_operators
+from giql.expander import register
+from giql.expressions import GIQLDisjoin
+from giql.resolver import resolve_operator_refs
+from giql.table import Table
+from giql.table import Tables
+from giql.targets import Capabilities
+from giql.targets import DataFusionTarget
+from giql.targets import DuckDBTarget
+from giql.targets import GenericTarget
+from giql.targets import Target
+from giql.transpile import transpile
+
+
+def _record(label: str):
+    """Build an expander function that replaces a node with a tagged literal."""
+
+    def _expander(node: exp.Expression, ctx: ExpansionContext) -> exp.Expression:
+        return exp.Literal.string(label)
+
+    return _expander
+
+
+@pytest.fixture
+def clean_registry():
+    """Isolate the process-wide REGISTRY, restoring its contents afterward."""
+    saved = dict(REGISTRY._expanders)
+    REGISTRY.clear()
+    yield REGISTRY
+    REGISTRY.clear()
+    REGISTRY._expanders.update(saved)
+
+
+class TestExpanderRegistry:
+    """Tests for ExpanderRegistry registration and fallback resolution."""
+
+    def test_resolve_returns_registered_target_expander(self):
+        """Test that resolve returns the exact-target expander.
+
+        Given:
+            A registry with an expander registered for (DuckDBTarget, op).
+        When:
+            Resolving (DuckDBTarget(), op).
+        Then:
+            It should return that exact-target expander.
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        fn = _record("duckdb")
+        registry.register(DuckDBTarget(), GIQLDisjoin, fn)
+
+        # Act
+        resolved = registry.resolve(DuckDBTarget(), GIQLDisjoin)
+
+        # Assert
+        assert resolved is fn
+
+    def test_resolve_falls_back_to_generic_expander(self):
+        """Test that resolve falls back from a target to the generic expander.
+
+        Given:
+            A registry with an expander registered only for (GenericTarget, op).
+        When:
+            Resolving (DuckDBTarget(), op), for which no exact entry exists.
+        Then:
+            It should fall back to the generic expander.
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        generic_fn = _record("generic")
+        registry.register(GenericTarget(), GIQLDisjoin, generic_fn)
+
+        # Act
+        resolved = registry.resolve(DuckDBTarget(), GIQLDisjoin)
+
+        # Assert
+        assert resolved is generic_fn
+
+    def test_resolve_prefers_target_over_generic(self):
+        """Test that an exact-target entry shadows the generic fallback.
+
+        Given:
+            A registry with both a (DuckDBTarget, op) and a (GenericTarget, op)
+            expander registered.
+        When:
+            Resolving (DuckDBTarget(), op).
+        Then:
+            It should return the exact-target expander, not the generic one.
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        duckdb_fn = _record("duckdb")
+        generic_fn = _record("generic")
+        registry.register(DuckDBTarget(), GIQLDisjoin, duckdb_fn)
+        registry.register(GenericTarget(), GIQLDisjoin, generic_fn)
+
+        # Act
+        resolved = registry.resolve(DuckDBTarget(), GIQLDisjoin)
+
+        # Assert
+        assert resolved is duckdb_fn
+
+    def test_resolve_returns_none_for_legacy_fallback(self):
+        """Test that resolve returns None when no expander is registered.
+
+        Given:
+            An empty registry.
+        When:
+            Resolving any (target, op).
+        Then:
+            It should return None, signalling the legacy *_sql emitter fallback.
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+
+        # Act
+        resolved = registry.resolve(DuckDBTarget(), GIQLDisjoin)
+
+        # Assert
+        assert resolved is None
+
+    def test_resolve_generic_target_does_not_self_fallback(self):
+        """Test that a generic-target resolve does not double-check generic.
+
+        Given:
+            An empty registry.
+        When:
+            Resolving (GenericTarget(), op).
+        Then:
+            It should return None without raising (no redundant generic lookup).
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+
+        # Act
+        resolved = registry.resolve(GenericTarget(), GIQLDisjoin)
+
+        # Assert
+        assert resolved is None
+
+    def test_register_overrides_existing_entry(self):
+        """Test that a later registration overrides an earlier one.
+
+        Given:
+            A registry with an expander already registered for (target, op).
+        When:
+            Registering a second expander for the same key.
+        Then:
+            It should resolve to the second expander (last-write-wins).
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        first = _record("first")
+        second = _record("second")
+        registry.register(DuckDBTarget(), GIQLDisjoin, first)
+
+        # Act
+        registry.register(DuckDBTarget(), GIQLDisjoin, second)
+
+        # Assert
+        assert registry.resolve(DuckDBTarget(), GIQLDisjoin) is second
+
+    def test_register_keys_on_target_value_not_identity(self):
+        """Test that the registry keys on the frozen target value.
+
+        Given:
+            An expander registered against one DuckDBTarget() instance.
+        When:
+            Resolving against a distinct, freshly built DuckDBTarget() instance.
+        Then:
+            It should hit the same entry (frozen value-equal target keys).
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+        fn = _record("duckdb")
+        registry.register(DuckDBTarget(), GIQLDisjoin, fn)
+
+        # Act
+        resolved = registry.resolve(DuckDBTarget(), GIQLDisjoin)
+
+        # Assert
+        assert DuckDBTarget() is not DuckDBTarget()
+        assert resolved is fn
+
+    def test_register_accepts_expander_object(self):
+        """Test that an OperatorExpander object registers and resolves.
+
+        Given:
+            An object with an expand method (an OperatorExpander).
+        When:
+            Registering it and resolving the key.
+        Then:
+            It should resolve to a callable that delegates to expand.
+        """
+
+        # Arrange
+        class _Expander:
+            def expand(self, node, ctx):
+                return exp.Literal.string("object")
+
+        registry = ExpanderRegistry()
+        obj = _Expander()
+        assert isinstance(obj, OperatorExpander)
+        registry.register(GenericTarget(), GIQLDisjoin, obj)
+
+        # Act
+        resolved = registry.resolve(GenericTarget(), GIQLDisjoin)
+        result = resolved(None, None)
+
+        # Assert
+        assert result == exp.Literal.string("object")
+
+    def test_register_rejects_non_callable(self):
+        """Test that registering a non-callable, non-expander raises.
+
+        Given:
+            A value that is neither callable nor an OperatorExpander.
+        When:
+            Registering it.
+        Then:
+            It should raise TypeError.
+        """
+        # Arrange
+        registry = ExpanderRegistry()
+
+        # Act & assert
+        with pytest.raises(TypeError):
+            registry.register(GenericTarget(), GIQLDisjoin, object())
+
+
+class TestRegisterDecorator:
+    """Tests for the @register extension-hook decorator."""
+
+    def test_register_writes_to_process_registry(self, clean_registry):
+        """Test that the decorator registers in the process-wide registry.
+
+        Given:
+            The decorator applied to an expander for (DuckDBTarget, op).
+        When:
+            Resolving that key against the process-wide registry.
+        Then:
+            It should resolve to the decorated expander.
+        """
+
+        # Arrange & act
+        @register(DuckDBTarget, GIQLDisjoin)
+        def _expander(node, ctx):
+            return exp.Literal.string("decorated")
+
+        # Assert
+        assert clean_registry.resolve(DuckDBTarget(), GIQLDisjoin) is _expander
+
+    def test_register_returns_expander_unchanged(self, clean_registry):
+        """Test that the decorator returns its target unchanged.
+
+        Given:
+            An expander function.
+        When:
+            Decorating it with @register.
+        Then:
+            It should return the same function object (usable standalone).
+        """
+
+        # Arrange
+        def _expander(node, ctx):
+            return exp.Literal.string("x")
+
+        # Act
+        decorated = register(GenericTarget, GIQLDisjoin)(_expander)
+
+        # Assert
+        assert decorated is _expander
+
+    def test_register_accepts_target_instance(self, clean_registry):
+        """Test that the decorator accepts a target instance, not just a class.
+
+        Given:
+            The decorator applied with an explicit DuckDBTarget() instance.
+        When:
+            Resolving that key.
+        Then:
+            It should resolve to the decorated expander.
+        """
+
+        # Arrange & act
+        @register(DuckDBTarget(), GIQLDisjoin)
+        def _expander(node, ctx):
+            return exp.Literal.string("instance")
+
+        # Assert
+        assert clean_registry.resolve(DuckDBTarget(), GIQLDisjoin) is _expander
+
+
+class TestExpansionContext:
+    """Tests for the ExpansionContext value object."""
+
+    def test_capabilities_returns_target_capabilities(self):
+        """Test that capabilities exposes the active target's capability set.
+
+        Given:
+            A context built with a DuckDBTarget.
+        When:
+            Reading its capabilities property.
+        Then:
+            It should be the target's Capabilities.
+        """
+        # Arrange
+        target = DuckDBTarget()
+        ctx = ExpansionContext(exp.true(), None, target, Tables())
+
+        # Act
+        caps = ctx.capabilities
+
+        # Assert
+        assert isinstance(caps, Capabilities)
+        assert caps is target.capabilities
+
+    def test_alias_mints_unique_prefixed_names(self):
+        """Test that alias mints distinct names under the reserved prefix.
+
+        Given:
+            A single ExpansionContext.
+        When:
+            Minting two aliases.
+        Then:
+            They should differ and both carry the expander prefix.
+        """
+        # Arrange
+        ctx = ExpansionContext(exp.true(), None, GenericTarget(), Tables())
+
+        # Act
+        first = ctx.alias()
+        second = ctx.alias()
+
+        # Assert
+        assert first != second
+        assert first.startswith(EXPAND_ALIAS_PREFIX)
+        assert second.startswith(EXPAND_ALIAS_PREFIX)
+
+
+# A fake custom target standing in for a user-defined engine: the extension-hook
+# seam must dispatch to it exactly as to the built-in targets.
+@dataclass(frozen=True)
+class _FakeTarget(Target):
+    name: str = "fake"
+    sqlglot_dialect: str | None = None
+    capabilities: Capabilities = Capabilities(
+        supports_lateral=True,
+        supports_star_replace=False,
+        supports_qualify=False,
+        range_join_strategy="binned",
+    )
+
+
+class TestExpandOperatorsPass:
+    """Tests for the ExpandOperators dispatch pass."""
+
+    def test_transform_dispatches_to_registered_expander(self, clean_registry):
+        """Test that the pass replaces an opted-in node via its expander.
+
+        Given:
+            A DISJOIN AST whose operator is flagged GIQL_EXPAND and an expander
+            registered for (GenericTarget, GIQLDisjoin).
+        When:
+            Running the ExpandOperators pass.
+        Then:
+            The DISJOIN node should be replaced by the expander's output.
+        """
+        # Arrange
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _record("expanded"))
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            result = pass_.transform(ast)
+
+        # Assert
+        assert not list(result.find_all(GIQLDisjoin))
+        assert result.find(exp.Literal).this == "expanded"
+
+    def test_transform_dispatches_to_fake_custom_target(self, clean_registry):
+        """Test that the pass dispatches to a user-defined custom target.
+
+        Given:
+            A fake user target and an expander registered for it via @register,
+            plus an opted-in DISJOIN operator.
+        When:
+            Running ExpandOperators with the fake target as active.
+        Then:
+            The pass should dispatch to the fake target's expander (the public
+            extension hook works end to end).
+        """
+
+        # Arrange
+        @register(_FakeTarget, GIQLDisjoin)
+        def _fake_expander(node, ctx):
+            assert ctx.target == _FakeTarget()
+            return exp.Literal.string("fake-target")
+
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        pass_ = ExpandOperators(_FakeTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            result = pass_.transform(ast)
+
+        # Assert
+        assert result.find(exp.Literal).this == "fake-target"
+
+    def test_transform_passes_resolution_and_target_in_context(self, clean_registry):
+        """Test that the expander receives the pass-1 metadata and active target.
+
+        Given:
+            An opted-in DISJOIN with a registered expander that captures its ctx.
+        When:
+            Running the pass with a DataFusionTarget.
+        Then:
+            The context should carry the operator's resolution metadata, the
+            active target, and the registered tables.
+        """
+        # Arrange
+        captured = {}
+
+        def _expander(node, ctx):
+            captured["ctx"] = ctx
+            return exp.Literal.string("ok")
+
+        clean_registry.register(DataFusionTarget(), GIQLDisjoin, _expander)
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        pass_ = ExpandOperators(DataFusionTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            pass_.transform(ast)
+
+        # Assert
+        ctx = captured["ctx"]
+        assert ctx.target == DataFusionTarget()
+        assert ctx.tables is tables
+        assert ctx.resolution is not None
+        assert ctx.resolution.operator == "GIQLDisjoin"
+
+    def test_transform_skips_unflagged_operator(self, clean_registry):
+        """Test that an unflagged operator is left untouched even when registered.
+
+        Given:
+            An expander registered for (GenericTarget, GIQLDisjoin) but the
+            operator's GIQL_EXPAND flag left at its default False.
+        When:
+            Running the pass.
+        Then:
+            The DISJOIN node should remain in the tree (gate requires both).
+        """
+        # Arrange
+        clean_registry.register(GenericTarget(), GIQLDisjoin, _record("expanded"))
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act (GIQL_EXPAND is False by default — no opt-in context)
+        result = pass_.transform(ast)
+
+        # Assert
+        assert list(result.find_all(GIQLDisjoin))
+
+    def test_transform_skips_flagged_operator_with_no_expander(self, clean_registry):
+        """Test that a flagged operator with no expander is left untouched.
+
+        Given:
+            An opted-in DISJOIN but an empty registry (no expander resolves).
+        When:
+            Running the pass.
+        Then:
+            The DISJOIN node should remain (gate requires a registered expander).
+        """
+        # Arrange
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+        pass_ = ExpandOperators(GenericTarget(), tables, clean_registry)
+
+        # Act
+        with _opted_in(GIQLDisjoin):
+            result = pass_.transform(ast)
+
+        # Assert
+        assert list(result.find_all(GIQLDisjoin))
+
+
+class TestNoOpWhenInert:
+    """The pass touches nothing while no operator opts in and the registry is empty."""
+
+    def test_expand_operators_is_identity_when_registry_empty(self):
+        """Test that the standalone pass returns the AST unchanged when inert.
+
+        Given:
+            A DISJOIN AST, no operator flagged, and an empty registry.
+        When:
+            Running expand_operators directly.
+        Then:
+            The same AST is returned with the DISJOIN node intact.
+        """
+        # Arrange
+        tables = _tables()
+        ast = _prepare("SELECT * FROM DISJOIN(variants)", tables)
+
+        # Act
+        result = expand_operators(ast, GenericTarget(), tables, ExpanderRegistry())
+
+        # Assert
+        assert result is ast
+        assert list(result.find_all(GIQLDisjoin))
+
+    def test_transpile_sql_unchanged_with_pass_inert(self):
+        """Test that transpile output is byte-identical with the pass inert.
+
+        Given:
+            A DISJOIN query, the default (empty) registry, and no operator flagged.
+        When:
+            Transpiling with the wired-in pass versus a pass-bypassed reference.
+        Then:
+            The SQL should match exactly and carry no expander alias prefix.
+        """
+        # Arrange
+        query = "SELECT * FROM DISJOIN(variants)"
+        tables = _tables()
+        ast = _prepare(query, tables)
+        from giql.generators import BaseGIQLGenerator
+
+        expected = BaseGIQLGenerator(tables=tables).generate(ast)
+
+        # Act
+        actual = transpile(query, tables=[Table("variants")])
+
+        # Assert
+        assert actual == expected
+        assert EXPAND_ALIAS_PREFIX not in actual
+
+
+def _tables(names=("variants",)) -> Tables:
+    """Build a Tables container registering each name with default encoding."""
+    container = Tables()
+    for name in names:
+        container.register(name, Table(name))
+    return container
+
+
+def _prepare(query: str, tables: Tables) -> exp.Expression:
+    """Parse *query* and run pass 1 (resolution) over the resulting AST."""
+    ast = parse_one(query, dialect=GIQLDialect)
+    return resolve_operator_refs(ast, tables)
+
+
+class _opted_in:
+    """Context manager opting an operator class into GIQL_EXPAND for a test."""
+
+    def __init__(self, operator: type) -> None:
+        self._operator = operator
+        self._prior = operator.__dict__.get("GIQL_EXPAND", False)
+
+    def __enter__(self):
+        self._operator.GIQL_EXPAND = True
+        return self._operator
+
+    def __exit__(self, *exc):
+        self._operator.GIQL_EXPAND = self._prior
+        return False


### PR DESCRIPTION
## Summary

Introduce the dispatch infrastructure for epic #137: an `OperatorExpander` protocol, an `ExpansionContext`, an `ExpanderRegistry` keyed by `(target, operator)` with a `(target, op) → (generic, op) → legacy *_sql` fallback chain, a public `@register(Target, Operator)` decorator, and an `ExpandOperators` pass wired into `transpile()` after `CanonicalizeCoordinates`. Registry keys are the frozen-dataclass `Target`s from #132, so a resolved target is a stable value key.

The mechanism is a strict no-op until operators opt in: no operator sets `GIQL_EXPAND` and the registry ships empty, so the pass leaves the AST untouched and transpile output stays byte-identical (verified against the snapshot suite). Each later operator migration (#140–#144) flips one `GIQL_EXPAND` flag and registers its expander.

Harden the pass against the failure modes the first real expander will hit: reject a non-`Expression` replacement, require resolved pass-1 metadata, and replace nodes deepest-first so nested flagged operators all expand. One sequencing constraint is documented rather than fixed: the `dialect="duckdb"` IEJoin early-return in `transpile()` returns before the pass runs, so a future DuckDB-pathed operator must run expansion before that early-return (or have the IEJoin transformer defer to the registry); this is left to #141 and pinned by a strict-xfail that flips when #141 addresses it. The public-surface ergonomics (a stable export path; whether to collapse the protocol/callable duality) are deferred to #146, which finalizes and documents the hook.

Closes #138
Closes #154

## Proposed changes

### Registry, context, and pass (`src/giql/expander.py`)
- `OperatorExpander` protocol (`expand(node, ctx) -> exp.Expression`), accepting either a protocol object — whose `expand` must be callable — or a bare callable.
- `ExpansionContext` carries the pass-1 `OperatorResolution`, the active `Target`/`Capabilities`, the registered `Tables`, and alias minting (a single `name_sequence` threaded across the pass run).
- `ExpanderRegistry` resolves the `(target → generic → legacy)` chain and exposes `register`/`unregister`/`clear`/`__contains__` plus `__len__`/`__bool__` as the supported teardown and introspection seam, so callers never reach into private state. `register(TargetClass)` raises a clear error when the class is not default-constructible.
- `ExpandOperators` collects opted-in nodes, then replaces each deepest-first via `node.replace`, guarding the replacement type and requiring a resolved operand.

### Operator opt-in flag (`src/giql/expressions.py`)
- A `GIQL_EXPAND` class attribute (mirroring `GIQL_CANONICALIZE`) on all nine operator classes, defaulting `False`. CLUSTER and MERGE carry the flag for forward-consistency with #144 even though their transformers rewrite those nodes before the pass runs today.

### Pipeline wiring (`src/giql/transpile.py`)
- Run `ExpandOperators(target, tables).transform(ast)` after `canonicalize_coordinates`, inside an "Expansion error" reraise boundary, and document the IEJoin early-return skip.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestExpanderRegistry` / `TestExpanderRegistryFallbackGaps` | A registry with `(target, op)` and `(generic, op)` entries | An expander is resolved | Exact target shadows generic, a miss falls back to generic then to `None`, and a non-callable expander is rejected | Registry fallback chain and validation |
| 2 | `TestRegisterDecorator` | A target class or instance and an operator | An expander is registered via `@register` | It writes to the process registry, returns the expander unchanged, and keys by target value | Public extension hook |
| 3 | `TestExpansionContext` | A node, resolution, target, and tables | A context is constructed | It exposes capabilities and mints unique prefixed aliases | Expander input contract |
| 4 | `TestExpandOperatorsPass` / `TestExpandOperatorsWalk` | A flagged operator and a registered expander | The pass runs over single, sibling, nested, and subquery/CTE/JOIN/WHERE ASTs | Each node is replaced deepest-first and the result serializes, and a nested inner operator is not dropped | Dispatch and deepest-first walk |
| 5 | `TestTranspileExpanderDispatch` | A registered expander and a flagged operator | `transpile()` is called per dialect | Dispatch follows the resolved target, a bad return raises, and errors wrap as "Expansion error" while `ValueError` passes verbatim | End-to-end dispatch and guards |
| 6 | `TestOperatorOptOut` / `TestNoOpWhenInert` | No operator flagged and an empty registry | `transpile()` is called | Every operator ships `GIQL_EXPAND` false and output is byte-identical to the legacy path | Strict no-op invariant |
| 7 | `TestOptedInRestoresFlag` | A test that flips an operator flag and registers an expander | The flag context exits and the registry guard runs | Both the flag and the process registry are restored at each boundary | Test isolation |
| 8 | `TestIEJoinEarlyReturnSkipsExpansion` | A flagged operator on an IEJoin-eligible duckdb query | `transpile(dialect="duckdb")` is called | The legacy IEJoin SQL is emitted unchanged, pinned by a strict xfail pending #141 | Documented sequencing gap |
