### PR TITLE
Add the cross-target result oracle and DataFusion integration lane — Closes #139

### DIFF
--- a/tests/integration/_oracle.py
+++ b/tests/integration/_oracle.py
@@ -66,6 +66,11 @@ def scalar(value):
             return None
         if isinstance(value, float) and math.isnan(value):
             return None
+    # DataFusion promotes int64 -> float64 on NULL-bearing columns (1 -> 1.0).
+    # Coerce an integral float back to int so a NULL-bearing column compares
+    # type-stably against DuckDB's plain ints in the multiset.
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
     return value
 
 
@@ -77,7 +82,11 @@ def normalize(rows) -> list[tuple]:
     scalars so DuckDB and DataFusion (pandas) rows compare equal.
     """
     out = [tuple(scalar(v) for v in row) for row in rows]
-    return sorted(out, key=lambda r: tuple((v is None, v) for v in r))
+    # Include ``type(v).__name__`` in the key so a column carrying mixed scalar
+    # types sorts on a total order instead of raising ``TypeError`` on an
+    # ``int`` < ``str`` comparison. A genuine type divergence then surfaces as a
+    # clean multiset inequality rather than a crash.
+    return sorted(out, key=lambda r: tuple((v is None, type(v).__name__, v) for v in r))
 
 
 def resolve_routing(targets, engines=None) -> dict[str, tuple[str, str | None]]:
@@ -108,6 +117,10 @@ def resolve_routing(targets, engines=None) -> dict[str, tuple[str, str | None]]:
         If a target name is not a known target, or an override routes to an
         unknown engine.
     """
+    # Normalize to a tuple so a one-shot generator is not exhausted here and
+    # then silently empty when the fixture iterates ``targets`` again.
+    targets = tuple(targets)
+
     engine_for = dict(TARGET_ENGINE)
     if engines:
         for target, engine in engines.items():
@@ -159,6 +172,10 @@ def assert_cross_target(results, expected, sql_by_target=None) -> None:
     """
     sql_by_target = sql_by_target or {}
     run_targets = list(results)
+
+    # Guard against a vacuous pass: an empty ``results`` would skip both phases
+    # and never check ``expected`` at all.
+    assert run_targets, "oracle invoked with no targets"
 
     # Phase 1: engines must agree with each other (the differential oracle).
     if len(run_targets) > 1:

--- a/tests/integration/_oracle.py
+++ b/tests/integration/_oracle.py
@@ -188,11 +188,22 @@ def register_record_batches(ctx, name, rows, schema, columns) -> None:
     The single pyarrow loader dance shared by :func:`run_datafusion` and the
     #132 ``datafusion_ctx`` fixture (Finding 8). ``columns`` is the
     ``(name, kind)`` schema; ``schema`` is the matching :class:`pyarrow.Schema`.
+
+    Empty ``rows`` need care: ``pa.table(...).to_batches()`` yields an EMPTY
+    batch *list* for zero rows, and ``SessionContext.register_record_batches``
+    PANICS on an empty partition (``index out of bounds`` in DataFusion's Rust
+    core). DuckDB sidesteps this with an ``if rows`` guard in :func:`run_duckdb`;
+    DataFusion has no such guard, so this helper synthesizes a single empty
+    record batch with the declared schema instead. This keeps empty-input cases
+    runnable on DataFusion (T4 pins both the panic and this guard).
     """
     import pyarrow as pa
 
     arrays = {col: [r[idx] for r in rows] for idx, (col, _kind) in enumerate(columns)}
-    ctx.register_record_batches(name, [pa.table(arrays, schema=schema).to_batches()])
+    batches = pa.table(arrays, schema=schema).to_batches()
+    if not batches:
+        batches = [pa.RecordBatch.from_pylist([], schema=schema)]
+    ctx.register_record_batches(name, [batches])
 
 
 def arrow_schema(columns):

--- a/tests/integration/_oracle.py
+++ b/tests/integration/_oracle.py
@@ -1,0 +1,245 @@
+"""Engine-free internals for the cross-target result oracle (epic #137, #139).
+
+This is an importable, *non-test* module: it holds the pure helpers the
+``cross_target_oracle`` fixture (``tests/integration/conftest.py``) wraps, so
+they can be unit-tested directly without spinning up DuckDB or DataFusion.
+
+Layout:
+
+* :func:`normalize` / :func:`scalar` -- coerce engine rows into a sorted,
+  order-free, type-normalized multiset for comparison.
+* :func:`resolve_routing` -- the *pure* routing decision (target -> engine +
+  transpile dialect), pulled out of the run loop so it is unit-testable and so
+  unknown targets / engines raise a clear error rather than a bare ``KeyError``
+  (Finding 7).
+* :func:`assert_cross_target` -- the comparison core (Finding 1): assert the
+  engines agree *with each other* first, then assert the agreed result equals
+  ``expected``. Both assertions are genuinely reachable.
+* :func:`register_record_batches` -- the single pyarrow loader dance reused by
+  :func:`run_datafusion` and the #132 ``datafusion_ctx`` fixture (Finding 8).
+* :func:`run_duckdb` / :func:`run_datafusion` -- the per-engine runners.
+"""
+
+from __future__ import annotations
+
+import math
+
+# Target -> the engine the target's SQL is meant to execute on.
+TARGET_ENGINE: dict[str, str] = {
+    "generic": "datafusion",
+    "datafusion": "datafusion",
+    "duckdb": "duckdb",
+}
+
+# transpile() dialect argument per target name.
+TARGET_DIALECT: dict[str, str | None] = {
+    "generic": None,
+    "datafusion": "datafusion",
+    "duckdb": "duckdb",
+}
+
+# The engines a target may be routed onto.
+KNOWN_ENGINES: frozenset[str] = frozenset({"duckdb", "datafusion"})
+
+
+def scalar(value):
+    """Coerce an engine-specific scalar to a comparable plain Python value.
+
+    ``None`` and any NaN (whether a ``float`` subclass or a numpy scalar that
+    only reveals its NaN-ness after ``.item()``) both collapse to ``None`` so
+    nullable integers from DataFusion compare equal to DuckDB's ``NULL`` and
+    can never reach the ``(is_none, value)`` sort key as a bare NaN.
+    """
+    if value is None:
+        return None
+    # Fast path: a plain float NaN.
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    if hasattr(value, "item"):
+        try:
+            value = value.item()
+        except (ValueError, AttributeError):
+            return value
+        # Re-check NaN AFTER .item(): a numpy NaN unwraps to a float NaN that
+        # must not survive as a sort key (Finding 6).
+        if value is None:
+            return None
+        if isinstance(value, float) and math.isnan(value):
+            return None
+    return value
+
+
+def normalize(rows) -> list[tuple]:
+    """Return a row multiset as a sorted list of tuples for order-free compare.
+
+    A list (not a set) preserves multiplicity so duplicate-row bugs surface;
+    sorting strips engine result ordering. Values are coerced to plain Python
+    scalars so DuckDB and DataFusion (pandas) rows compare equal.
+    """
+    out = [tuple(scalar(v) for v in row) for row in rows]
+    return sorted(out, key=lambda r: tuple((v is None, v) for v in r))
+
+
+def resolve_routing(targets, engines=None) -> dict[str, tuple[str, str | None]]:
+    """Resolve each target to its ``(engine, transpile_dialect)`` pair.
+
+    This is the pure routing decision lifted out of the oracle run loop so it
+    can be unit-tested without engines (Finding 7).
+
+    Parameters
+    ----------
+    targets : iterable of str
+        Target names to route (e.g. ``"generic"``, ``"datafusion"``,
+        ``"duckdb"``).
+    engines : dict[str, str] | None
+        Optional ``{target: engine}`` overrides for the default routing. Use
+        this to execute a target's portable SQL on a different engine (e.g.
+        route ``generic`` to DuckDB so a LATERAL operator can still be
+        compared).
+
+    Returns
+    -------
+    dict[str, tuple[str, str | None]]
+        ``{target: (engine, transpile_dialect)}`` for each requested target.
+
+    Raises
+    ------
+    ValueError
+        If a target name is not a known target, or an override routes to an
+        unknown engine.
+    """
+    engine_for = dict(TARGET_ENGINE)
+    if engines:
+        for target, engine in engines.items():
+            if target not in TARGET_ENGINE:
+                raise ValueError(
+                    f"Unknown target {target!r} in engines override. "
+                    f"Known targets: {sorted(TARGET_ENGINE)}."
+                )
+            engine_for[target] = engine
+
+    routing: dict[str, tuple[str, str | None]] = {}
+    for target in targets:
+        if target not in TARGET_ENGINE:
+            raise ValueError(
+                f"Unknown target {target!r}. Known targets: {sorted(TARGET_ENGINE)}."
+            )
+        engine = engine_for[target]
+        if engine not in KNOWN_ENGINES:
+            raise ValueError(
+                f"Unknown engine {engine!r} for target {target!r}. "
+                f"Known engines: {sorted(KNOWN_ENGINES)}."
+            )
+        routing[target] = (engine, TARGET_DIALECT[target])
+    return routing
+
+
+def assert_cross_target(results, expected, sql_by_target=None) -> None:
+    """Assert every target agrees with the others and with ``expected``.
+
+    The comparison runs in two genuinely-reachable phases (Finding 1):
+
+    1. **Differential oracle** -- assert the engines agree *with each other*,
+       independent of ``expected``. With every engine's output already
+       collected, a disagreement yields a clear "engines disagree" message
+       naming both targets and showing both result sets.
+    2. **Expectation check** -- assert the (now agreed) result equals the
+       expected multiset.
+
+    Parameters
+    ----------
+    results : dict[str, list[tuple]]
+        ``{target: normalized_rows}`` -- every target's already-normalized
+        result. Collected in full *before* any assertion so the first failing
+        target no longer short-circuits the cross-target comparison.
+    expected : list[tuple]
+        The normalized expected multiset.
+    sql_by_target : dict[str, str] | None
+        Optional ``{target: sql}`` for richer diagnostics.
+    """
+    sql_by_target = sql_by_target or {}
+    run_targets = list(results)
+
+    # Phase 1: engines must agree with each other (the differential oracle).
+    if len(run_targets) > 1:
+        reference = run_targets[0]
+        ref_rows = results[reference]
+        for other in run_targets[1:]:
+            assert results[other] == ref_rows, (
+                f"engines disagree: target {reference!r} returned "
+                f"{ref_rows!r} but target {other!r} returned "
+                f"{results[other]!r}\n"
+                f"{reference} SQL: {sql_by_target.get(reference, '<n/a>')}\n"
+                f"{other} SQL: {sql_by_target.get(other, '<n/a>')}"
+            )
+
+    # Phase 2: the agreed result must equal the expectation.
+    for target in run_targets:
+        assert results[target] == expected, (
+            f"target {target!r} returned {results[target]!r}, "
+            f"expected {expected!r}\n"
+            f"SQL: {sql_by_target.get(target, '<n/a>')}"
+        )
+
+
+def register_record_batches(ctx, name, rows, schema, columns) -> None:
+    """Register ``rows`` as a record-batch table on a DataFusion context.
+
+    The single pyarrow loader dance shared by :func:`run_datafusion` and the
+    #132 ``datafusion_ctx`` fixture (Finding 8). ``columns`` is the
+    ``(name, kind)`` schema; ``schema`` is the matching :class:`pyarrow.Schema`.
+    """
+    import pyarrow as pa
+
+    arrays = {col: [r[idx] for r in rows] for idx, (col, _kind) in enumerate(columns)}
+    ctx.register_record_batches(name, [pa.table(arrays, schema=schema).to_batches()])
+
+
+def arrow_schema(columns):
+    """Build a :class:`pyarrow.Schema` from a ``(name, kind)`` column spec."""
+    import pyarrow as pa
+
+    fields = [
+        (col, pa.utf8() if kind == "utf8" else pa.int64()) for col, kind in columns
+    ]
+    return pa.schema(fields)
+
+
+def run_duckdb(sql: str, table_data: dict, columns) -> list[tuple]:
+    """Register tables in an in-memory DuckDB and return normalized result rows."""
+    import duckdb
+
+    conn = duckdb.connect(":memory:")
+    try:
+        for name, rows in table_data.items():
+            cols_ddl = ", ".join(
+                f'"{col}" {"VARCHAR" if kind == "utf8" else "BIGINT"}'
+                for col, kind in columns
+            )
+            conn.execute(f"CREATE TABLE {name} ({cols_ddl})")
+            if rows:
+                placeholders = ", ".join("?" for _ in columns)
+                conn.executemany(
+                    f"INSERT INTO {name} VALUES ({placeholders})",
+                    [tuple(r) for r in rows],
+                )
+        return normalize(conn.execute(sql).fetchall())
+    finally:
+        conn.close()
+
+
+def run_datafusion(sql: str, table_data: dict, columns) -> list[tuple]:
+    """Register tables in a DataFusion context and return normalized result rows."""
+    from datafusion import SessionContext
+
+    schema = arrow_schema(columns)
+    ctx = SessionContext()
+    for name, rows in table_data.items():
+        register_record_batches(ctx, name, rows, schema, columns)
+    return normalize(ctx.sql(sql).to_pandas().itertuples(index=False, name=None))
+
+
+ENGINE_RUNNERS = {
+    "duckdb": run_duckdb,
+    "datafusion": run_datafusion,
+}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,6 +21,18 @@ Adding a new operator case is trivial: write one ``oracle(...)`` call with the
 query, the table data, and the expected rows. Cases where a target cannot run
 an operator yet (e.g. correlated ``LATERAL`` on DataFusion) restrict the run to
 the supported targets via the ``targets`` argument.
+
+The engine-free internals live in :mod:`tests.integration._oracle` (an
+importable, non-test module) so they can be unit-tested without engines; this
+fixture is a thin wrapper around them.
+
+This lane is deliberately kept an **explicit-case fixture**. It does NOT use
+the SDLC guide's pairwise / Scenario-model / Hypothesis apparatus: each case is
+a hand-written ``(query, data, expected)`` triple so a regression points at a
+named operator scenario, and the cross-engine differential oracle -- not a
+generator -- is what makes the cases load-bearing. The coordinate-encoding
+sweep (``coordinate_space`` / #145) and strand (the schema here is
+``chrom``/``start``/``end`` only) are out of scope by design.
 """
 
 from __future__ import annotations
@@ -30,6 +42,11 @@ import pytest
 from giql import Table
 from giql import transpile
 
+from ._oracle import ENGINE_RUNNERS
+from ._oracle import assert_cross_target
+from ._oracle import normalize
+from ._oracle import resolve_routing
+
 # Default per-target schema: GIQL's default interval columns. Reserved words
 # (``end``) are quoted by the loaders below, mirroring ``test_binned_join.py``.
 DEFAULT_COLUMNS: tuple[tuple[str, str], ...] = (
@@ -38,103 +55,8 @@ DEFAULT_COLUMNS: tuple[tuple[str, str], ...] = (
     ("end", "int64"),
 )
 
-# Target -> the engine the target's SQL is meant to execute on.
-TARGET_ENGINE: dict[str, str] = {
-    "generic": "datafusion",
-    "datafusion": "datafusion",
-    "duckdb": "duckdb",
-}
-
 # Default target spread: every target executed on its intended engine.
 DEFAULT_TARGETS: tuple[str, ...] = ("generic", "datafusion", "duckdb")
-
-# transpile() dialect argument per target name.
-_TARGET_DIALECT: dict[str, str | None] = {
-    "generic": None,
-    "datafusion": "datafusion",
-    "duckdb": "duckdb",
-}
-
-
-def _normalize(rows) -> list[tuple]:
-    """Return a row multiset as a sorted list of tuples for order-free compare.
-
-    A list (not a set) preserves multiplicity so duplicate-row bugs surface;
-    sorting strips engine result ordering. Values are coerced to plain Python
-    scalars so DuckDB and DataFusion (pandas) rows compare equal.
-    """
-    out = []
-    for row in rows:
-        out.append(tuple(_scalar(v) for v in row))
-    return sorted(out, key=lambda r: tuple((v is None, v) for v in r))
-
-
-def _scalar(value):
-    """Coerce engine-specific scalars to comparable plain Python values."""
-    if value is None:
-        return None
-    # pandas / numpy nullable integers and NaN surface from DataFusion.
-    try:
-        import math
-
-        if isinstance(value, float) and math.isnan(value):
-            return None
-    except (TypeError, ValueError):
-        pass
-    if hasattr(value, "item"):
-        try:
-            return value.item()
-        except (ValueError, AttributeError):
-            return value
-    return value
-
-
-def _run_duckdb(sql: str, table_data: dict, columns) -> list[tuple]:
-    """Register tables in an in-memory DuckDB and return normalized result rows."""
-    import duckdb
-
-    conn = duckdb.connect(":memory:")
-    try:
-        for name, rows in table_data.items():
-            cols_ddl = ", ".join(
-                f'"{col}" {"VARCHAR" if kind == "utf8" else "BIGINT"}'
-                for col, kind in columns
-            )
-            conn.execute(f"CREATE TABLE {name} ({cols_ddl})")
-            if rows:
-                placeholders = ", ".join("?" for _ in columns)
-                conn.executemany(
-                    f"INSERT INTO {name} VALUES ({placeholders})",
-                    [tuple(r) for r in rows],
-                )
-        return _normalize(conn.execute(sql).fetchall())
-    finally:
-        conn.close()
-
-
-def _run_datafusion(sql: str, table_data: dict, columns) -> list[tuple]:
-    """Register tables in a DataFusion context and return normalized result rows."""
-    import pyarrow as pa
-    from datafusion import SessionContext
-
-    pa_fields = [
-        (col, pa.utf8() if kind == "utf8" else pa.int64()) for col, kind in columns
-    ]
-    schema = pa.schema(pa_fields)
-
-    ctx = SessionContext()
-    for name, rows in table_data.items():
-        arrays = {
-            col: [r[idx] for r in rows] for idx, (col, _kind) in enumerate(columns)
-        }
-        ctx.register_record_batches(name, [pa.table(arrays, schema=schema).to_batches()])
-    return _normalize(ctx.sql(sql).to_pandas().itertuples(index=False, name=None))
-
-
-_ENGINE_RUNNERS = {
-    "duckdb": _run_duckdb,
-    "datafusion": _run_datafusion,
-}
 
 
 @pytest.fixture
@@ -150,6 +72,7 @@ def cross_target_oracle():
             tables=None,
             columns=DEFAULT_COLUMNS,
             targets=DEFAULT_TARGETS,
+            engines=None,
             **table_data,
         )
 
@@ -165,7 +88,8 @@ def cross_target_oracle():
     ``columns``
         The ``(name, kind)`` schema (``kind`` in ``{"utf8", "int64"}``) used to
         register ``table_data`` into both engines. Defaults to the GIQL default
-        ``chrom``/``start``/``end`` interval schema.
+        ``chrom``/``start``/``end`` interval schema, where ``chrom`` is ``utf8``
+        and ``start``/``end`` are ``int64``.
     ``targets``
         The target names to exercise. Defaults to all three. Restrict this when
         a target cannot run the operator on its engine yet (e.g. NEAREST's
@@ -174,7 +98,7 @@ def cross_target_oracle():
         Optional ``{target: engine}`` overrides for the default routing
         (``generic``/``datafusion`` -> DataFusion, ``duckdb`` -> DuckDB). Use
         this when a target's *portable* SQL must be executed on a different
-        engine for the case at hand — e.g. routing ``generic`` to DuckDB so a
+        engine for the case at hand -- e.g. routing ``generic`` to DuckDB so a
         LATERAL-based operator can still be compared against the duckdb target.
     ``**table_data``
         ``name=[row, ...]`` table contents, where each row is a tuple matching
@@ -197,39 +121,26 @@ def cross_target_oracle():
         if tables is None:
             tables = [_default_table(name, columns) for name in table_data]
 
-        engine_for = dict(TARGET_ENGINE)
-        if engines:
-            engine_for.update(engines)
+        routing = resolve_routing(targets, engines)
 
-        expected_rows = _normalize(expected)
+        expected_rows = normalize(expected)
         results: dict[str, list[tuple]] = {}
+        sql_by_target: dict[str, str] = {}
 
+        # Collect ALL target results first; defer every assertion to
+        # assert_cross_target so the first divergent target can no longer
+        # short-circuit the cross-target comparison (Finding 1).
         for target in targets:
-            engine = engine_for[target]
-            importorskip = pytest.importorskip
-            importorskip("duckdb" if engine == "duckdb" else "datafusion")
+            engine, dialect = routing[target]
+            pytest.importorskip("duckdb" if engine == "duckdb" else "datafusion")
             if engine == "datafusion":
-                importorskip("pyarrow")
+                pytest.importorskip("pyarrow")
 
-            sql = transpile(query, tables=tables, dialect=_TARGET_DIALECT[target])
-            rows = _ENGINE_RUNNERS[engine](sql, table_data, columns)
-            results[target] = rows
+            sql = transpile(query, tables=tables, dialect=dialect)
+            sql_by_target[target] = sql
+            results[target] = ENGINE_RUNNERS[engine](sql, table_data, columns)
 
-            assert rows == expected_rows, (
-                f"target {target!r} on engine {engine!r} returned {rows!r}, "
-                f"expected {expected_rows!r}\nSQL: {sql}"
-            )
-
-        # Cross-target identity: every executed target agrees row-for-row.
-        run_targets = list(results)
-        if len(run_targets) > 1:
-            reference = run_targets[0]
-            for other in run_targets[1:]:
-                assert results[other] == results[reference], (
-                    f"targets {reference!r} and {other!r} disagree: "
-                    f"{results[reference]!r} != {results[other]!r}"
-                )
-
+        assert_cross_target(results, expected_rows, sql_by_target)
         return results
 
     return _oracle

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -119,6 +119,13 @@ def cross_target_oracle():
         **table_data,
     ) -> dict[str, list[tuple]]:
         if tables is None:
+            if columns != DEFAULT_COLUMNS:
+                raise ValueError(
+                    "Custom 'columns' require an explicit 'tables=' list: the "
+                    "default table mapping registers chrom/start/end, which "
+                    "would silently mis-register the custom column names. Pass "
+                    "tables=[Table(name, ...)] for each table."
+                )
             tables = [_default_table(name, columns) for name in table_data]
 
         routing = resolve_routing(targets, engines)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,254 @@
+"""Cross-target result-oracle fixture for the operator-expansion epic (#137).
+
+The oracle is the verification backbone every later operator migration
+(#140-#144) consumes: it transpiles one GIQL query for each registered target
+(``Generic`` via ``dialect=None``, ``DuckDB`` via ``dialect="duckdb"``,
+``DataFusion`` via ``dialect="datafusion"``), executes each target's SQL on the
+engine that target is meant for, and asserts that every target's result set is
+identical to the others and equal to an expected set.
+
+It compares ROWS, not SQL strings, on purpose: the DuckDB IEJoin SQL
+(``SET VARIABLE`` / ``getvariable``) is DuckDB-only and will not even parse on
+DataFusion. Result identity is the contract that survives that divergence.
+
+Engine routing per target:
+
+* ``"generic"`` (``dialect=None``) emits portable SQL -> executed on DataFusion.
+* ``"datafusion"`` emits the DataFusion target SQL -> executed on DataFusion.
+* ``"duckdb"`` emits the DuckDB-specific IEJoin SQL -> executed on DuckDB.
+
+Adding a new operator case is trivial: write one ``oracle(...)`` call with the
+query, the table data, and the expected rows. Cases where a target cannot run
+an operator yet (e.g. correlated ``LATERAL`` on DataFusion) restrict the run to
+the supported targets via the ``targets`` argument.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from giql import Table
+from giql import transpile
+
+# Default per-target schema: GIQL's default interval columns. Reserved words
+# (``end``) are quoted by the loaders below, mirroring ``test_binned_join.py``.
+DEFAULT_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("chrom", "utf8"),
+    ("start", "int64"),
+    ("end", "int64"),
+)
+
+# Target -> the engine the target's SQL is meant to execute on.
+TARGET_ENGINE: dict[str, str] = {
+    "generic": "datafusion",
+    "datafusion": "datafusion",
+    "duckdb": "duckdb",
+}
+
+# Default target spread: every target executed on its intended engine.
+DEFAULT_TARGETS: tuple[str, ...] = ("generic", "datafusion", "duckdb")
+
+# transpile() dialect argument per target name.
+_TARGET_DIALECT: dict[str, str | None] = {
+    "generic": None,
+    "datafusion": "datafusion",
+    "duckdb": "duckdb",
+}
+
+
+def _normalize(rows) -> list[tuple]:
+    """Return a row multiset as a sorted list of tuples for order-free compare.
+
+    A list (not a set) preserves multiplicity so duplicate-row bugs surface;
+    sorting strips engine result ordering. Values are coerced to plain Python
+    scalars so DuckDB and DataFusion (pandas) rows compare equal.
+    """
+    out = []
+    for row in rows:
+        out.append(tuple(_scalar(v) for v in row))
+    return sorted(out, key=lambda r: tuple((v is None, v) for v in r))
+
+
+def _scalar(value):
+    """Coerce engine-specific scalars to comparable plain Python values."""
+    if value is None:
+        return None
+    # pandas / numpy nullable integers and NaN surface from DataFusion.
+    try:
+        import math
+
+        if isinstance(value, float) and math.isnan(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+    if hasattr(value, "item"):
+        try:
+            return value.item()
+        except (ValueError, AttributeError):
+            return value
+    return value
+
+
+def _run_duckdb(sql: str, table_data: dict, columns) -> list[tuple]:
+    """Register tables in an in-memory DuckDB and return normalized result rows."""
+    import duckdb
+
+    conn = duckdb.connect(":memory:")
+    try:
+        for name, rows in table_data.items():
+            cols_ddl = ", ".join(
+                f'"{col}" {"VARCHAR" if kind == "utf8" else "BIGINT"}'
+                for col, kind in columns
+            )
+            conn.execute(f"CREATE TABLE {name} ({cols_ddl})")
+            if rows:
+                placeholders = ", ".join("?" for _ in columns)
+                conn.executemany(
+                    f"INSERT INTO {name} VALUES ({placeholders})",
+                    [tuple(r) for r in rows],
+                )
+        return _normalize(conn.execute(sql).fetchall())
+    finally:
+        conn.close()
+
+
+def _run_datafusion(sql: str, table_data: dict, columns) -> list[tuple]:
+    """Register tables in a DataFusion context and return normalized result rows."""
+    import pyarrow as pa
+    from datafusion import SessionContext
+
+    pa_fields = [
+        (col, pa.utf8() if kind == "utf8" else pa.int64()) for col, kind in columns
+    ]
+    schema = pa.schema(pa_fields)
+
+    ctx = SessionContext()
+    for name, rows in table_data.items():
+        arrays = {
+            col: [r[idx] for r in rows] for idx, (col, _kind) in enumerate(columns)
+        }
+        ctx.register_record_batches(name, [pa.table(arrays, schema=schema).to_batches()])
+    return _normalize(ctx.sql(sql).to_pandas().itertuples(index=False, name=None))
+
+
+_ENGINE_RUNNERS = {
+    "duckdb": _run_duckdb,
+    "datafusion": _run_datafusion,
+}
+
+
+@pytest.fixture
+def cross_target_oracle():
+    """Return a callable asserting cross-target result identity for a GIQL query.
+
+    The callable signature::
+
+        oracle(
+            query,
+            *,
+            expected,
+            tables=None,
+            columns=DEFAULT_COLUMNS,
+            targets=DEFAULT_TARGETS,
+            **table_data,
+        )
+
+    ``query``
+        The GIQL query string.
+    ``expected``
+        The expected result as an iterable of row tuples (order-free; compared
+        as a sorted multiset).
+    ``tables``
+        Optional list of table names or :class:`giql.Table` specs passed to
+        :func:`giql.transpile`. Defaults to the keys of ``table_data`` using the
+        default column mapping.
+    ``columns``
+        The ``(name, kind)`` schema (``kind`` in ``{"utf8", "int64"}``) used to
+        register ``table_data`` into both engines. Defaults to the GIQL default
+        ``chrom``/``start``/``end`` interval schema.
+    ``targets``
+        The target names to exercise. Defaults to all three. Restrict this when
+        a target cannot run the operator on its engine yet (e.g. NEAREST's
+        correlated LATERAL has no DataFusion physical plan).
+    ``engines``
+        Optional ``{target: engine}`` overrides for the default routing
+        (``generic``/``datafusion`` -> DataFusion, ``duckdb`` -> DuckDB). Use
+        this when a target's *portable* SQL must be executed on a different
+        engine for the case at hand — e.g. routing ``generic`` to DuckDB so a
+        LATERAL-based operator can still be compared against the duckdb target.
+    ``**table_data``
+        ``name=[row, ...]`` table contents, where each row is a tuple matching
+        ``columns``.
+
+    Returns the per-target normalized result so callers may make extra
+    assertions.
+    """
+
+    def _oracle(
+        query: str,
+        *,
+        expected,
+        tables=None,
+        columns=DEFAULT_COLUMNS,
+        targets=DEFAULT_TARGETS,
+        engines=None,
+        **table_data,
+    ) -> dict[str, list[tuple]]:
+        if tables is None:
+            tables = [_default_table(name, columns) for name in table_data]
+
+        engine_for = dict(TARGET_ENGINE)
+        if engines:
+            engine_for.update(engines)
+
+        expected_rows = _normalize(expected)
+        results: dict[str, list[tuple]] = {}
+
+        for target in targets:
+            engine = engine_for[target]
+            importorskip = pytest.importorskip
+            importorskip("duckdb" if engine == "duckdb" else "datafusion")
+            if engine == "datafusion":
+                importorskip("pyarrow")
+
+            sql = transpile(query, tables=tables, dialect=_TARGET_DIALECT[target])
+            rows = _ENGINE_RUNNERS[engine](sql, table_data, columns)
+            results[target] = rows
+
+            assert rows == expected_rows, (
+                f"target {target!r} on engine {engine!r} returned {rows!r}, "
+                f"expected {expected_rows!r}\nSQL: {sql}"
+            )
+
+        # Cross-target identity: every executed target agrees row-for-row.
+        run_targets = list(results)
+        if len(run_targets) > 1:
+            reference = run_targets[0]
+            for other in run_targets[1:]:
+                assert results[other] == results[reference], (
+                    f"targets {reference!r} and {other!r} disagree: "
+                    f"{results[reference]!r} != {results[other]!r}"
+                )
+
+        return results
+
+    return _oracle
+
+
+def _default_table(name, columns) -> Table:
+    """Build a :class:`giql.Table` mapping the canonical interval columns.
+
+    The default chrom/start/end column names match :class:`giql.Table`'s own
+    defaults; any extra columns ride along as plain data columns the query can
+    still project. Custom column schemas should pass an explicit ``tables`` list
+    to the oracle instead.
+    """
+    names = {col for col, _ in columns}
+    kwargs = {}
+    if "chrom" in names:
+        kwargs["chrom_col"] = "chrom"
+    if "start" in names:
+        kwargs["start_col"] = "start"
+    if "end" in names:
+        kwargs["end_col"] = "end"
+    return Table(name, **kwargs)

--- a/tests/integration/datafusion/conftest.py
+++ b/tests/integration/datafusion/conftest.py
@@ -12,6 +12,12 @@ pytest.importorskip("pyarrow")
 
 pytestmark = pytest.mark.integration
 
+from .._oracle import arrow_schema  # noqa: E402
+from .._oracle import register_record_batches  # noqa: E402
+
+# The default GIQL interval schema, shared with the cross-target oracle.
+_INTERVAL_COLUMNS = (("chrom", "utf8"), ("start", "int64"), ("end", "int64"))
+
 
 @pytest.fixture
 def datafusion_ctx():
@@ -21,29 +27,19 @@ def datafusion_ctx():
     arguments and yields a DataFusion ``SessionContext`` with each table
     registered under the default ``chrom``/``start``/``end`` schema (matching
     the default :class:`giql.Table` column mapping).
+
+    The pyarrow loader dance is the one shared helper in
+    :mod:`tests.integration._oracle` (Finding 8), so this fixture and the
+    cross-target oracle register tables identically.
     """
-    import pyarrow as pa
     from datafusion import SessionContext
 
-    schema = pa.schema(
-        [
-            ("chrom", pa.utf8()),
-            ("start", pa.int64()),
-            ("end", pa.int64()),
-        ]
-    )
+    schema = arrow_schema(_INTERVAL_COLUMNS)
 
     def _build(**tables):
         ctx = SessionContext()
         for name, rows in tables.items():
-            arrays = {
-                "chrom": [r[0] for r in rows],
-                "start": [r[1] for r in rows],
-                "end": [r[2] for r in rows],
-            }
-            ctx.register_record_batches(
-                name, [pa.table(arrays, schema=schema).to_batches()]
-            )
+            register_record_batches(ctx, name, rows, schema, _INTERVAL_COLUMNS)
         return ctx
 
     return _build

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -8,8 +8,10 @@ expander registry yet (epic #137), so this lane locks in the verification path
 every later migration (#140-#144) will consume.
 
 NEAREST's expansion uses a correlated ``LATERAL`` subquery, which DataFusion has
-no physical plan for today; its case therefore restricts the oracle to the
-DuckDB-executed targets and is the one documented cross-target gap.
+no physical plan for today; its generic-vs-duckdb equivalence case runs both on
+DuckDB, and the full three-target oracle is pinned as a strict xfail (#142) that
+auto-promotes when DataFusion gains correlated LATERAL — the one documented
+cross-target gap.
 """
 
 import pytest
@@ -17,6 +19,8 @@ import pytest
 pytest.importorskip("duckdb")
 pytest.importorskip("datafusion")
 pytest.importorskip("pyarrow")
+
+from giql import Table  # noqa: E402
 
 pytestmark = pytest.mark.integration
 
@@ -229,3 +233,427 @@ class TestCrossTargetOracleNearest:
                 f"unexpected DataFusion error, not the LATERAL gap: {exc!r}"
             )
             raise
+
+
+class TestCrossTargetOracleIntersectsAnyAll:
+    """INTERSECTS ANY/ALL identity across all targets (T2)."""
+
+    def test_intersects_any_returns_rows_matching_either_range(
+        self, cross_target_oracle
+    ):
+        """Test INTERSECTS ANY returns rows overlapping at least one range.
+
+        Given:
+            Peaks overlapping the first range, the second range, neither, and a
+            different chromosome.
+        When:
+            An INTERSECTS ANY query over two ranges runs on every target.
+        Then:
+            Every target should return exactly the two peaks overlapping a
+            listed range, in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval INTERSECTS ANY('chr1:1000-2000', 'chr1:5000-6000')",
+            peaks=[
+                ("chr1", 1500, 1800),
+                ("chr1", 5500, 5600),
+                ("chr1", 3000, 3100),
+                ("chr2", 1500, 1800),
+            ],
+            expected=[("chr1", 1500, 1800), ("chr1", 5500, 5600)],
+        )
+
+    def test_intersects_any_no_match_returns_zero_rows(self, cross_target_oracle):
+        """Test INTERSECTS ANY with no overlapping peak returns zero rows.
+
+        Given:
+            A peak overlapping neither listed range.
+        When:
+            The INTERSECTS ANY query runs on every target.
+        Then:
+            Every target should return zero rows in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval INTERSECTS ANY('chr1:1000-2000', 'chr1:5000-6000')",
+            peaks=[("chr1", 8000, 8100)],
+            expected=[],
+        )
+
+    def test_intersects_all_returns_rows_matching_every_range(self, cross_target_oracle):
+        """Test INTERSECTS ALL returns rows overlapping every listed range.
+
+        Given:
+            One peak overlapping both ranges and one overlapping neither.
+        When:
+            An INTERSECTS ALL query over two ranges runs on every target.
+        Then:
+            Every target should return only the peak overlapping both ranges.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval INTERSECTS ALL('chr1:1000-2000', 'chr1:1500-1700')",
+            peaks=[("chr1", 1400, 1800), ("chr1", 100, 200)],
+            expected=[("chr1", 1400, 1800)],
+        )
+
+    def test_intersects_all_no_full_match_returns_zero_rows(self, cross_target_oracle):
+        """Test INTERSECTS ALL returns zero rows when no peak overlaps all ranges.
+
+        Given:
+            Peaks each overlapping only one of the two ranges.
+        When:
+            The INTERSECTS ALL query runs on every target.
+        Then:
+            Every target should return zero rows in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval INTERSECTS ALL('chr1:1000-1200', 'chr1:5000-6000')",
+            peaks=[("chr1", 1050, 1100), ("chr1", 5050, 5100)],
+            expected=[],
+        )
+
+
+class TestCrossTargetOracleDistance:
+    """DISTANCE column-to-column identity across all targets (T2)."""
+
+    def test_distance_column_to_column_filters_near_pairs(self, cross_target_oracle):
+        """Test a column-to-column DISTANCE predicate agrees across targets.
+
+        Given:
+            A peak and two genes: one within the distance threshold and one far
+            beyond it on the same chromosome.
+        When:
+            A DISTANCE(a, b) < threshold join runs on every target.
+        Then:
+            Every target should return only the near pair.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.chrom = b.chrom "
+            "WHERE DISTANCE(a.interval, b.interval) < 100",
+            peaks=[("chr1", 100, 200)],
+            genes=[("chr1", 250, 300), ("chr1", 5000, 5100)],
+            expected=[(100, 250)],
+        )
+
+    def test_distance_no_pair_within_threshold_returns_zero_rows(
+        self, cross_target_oracle
+    ):
+        """Test a column-to-column DISTANCE predicate with no near pair is empty.
+
+        Given:
+            A peak and a single gene beyond the distance threshold.
+        When:
+            The DISTANCE join runs on every target.
+        Then:
+            Every target should return zero rows in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.chrom = b.chrom "
+            "WHERE DISTANCE(a.interval, b.interval) < 5",
+            peaks=[("chr1", 100, 200)],
+            genes=[("chr1", 5000, 5100)],
+            expected=[],
+        )
+
+
+class TestCrossTargetOracleCluster:
+    """CLUSTER identity across all targets (T2)."""
+
+    def test_cluster_assigns_shared_ids_to_overlapping_runs(self, cross_target_oracle):
+        """Test CLUSTER assigns identical run ids across targets.
+
+        Given:
+            Two overlapping intervals and one isolated interval on chr1.
+        When:
+            A CLUSTER(interval) projection runs on every target.
+        Then:
+            Every target should assign cluster id 1 to the overlapping run and 2
+            to the isolated interval, in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end", CLUSTER(interval) AS cid FROM peaks',
+            peaks=[
+                ("chr1", 100, 200),
+                ("chr1", 150, 300),
+                ("chr1", 5000, 6000),
+            ],
+            expected=[
+                ("chr1", 100, 200, 1),
+                ("chr1", 150, 300, 1),
+                ("chr1", 5000, 6000, 2),
+            ],
+        )
+
+    def test_cluster_empty_input_returns_zero_rows(self, cross_target_oracle):
+        """Test CLUSTER over an empty table returns zero rows on every target.
+
+        Given:
+            An empty peaks table.
+        When:
+            The CLUSTER projection runs on every target (DataFusion via the
+            synthesized empty record batch).
+        Then:
+            Every target should return zero rows in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end", CLUSTER(interval) AS cid FROM peaks',
+            peaks=[],
+            expected=[],
+        )
+
+
+class TestCrossTargetOracleMerge:
+    """MERGE identity across all targets (T2)."""
+
+    def test_merge_collapses_overlapping_intervals(self, cross_target_oracle):
+        """Test MERGE collapses overlapping intervals identically across targets.
+
+        Given:
+            Two overlapping intervals and one isolated interval on chr1.
+        When:
+            A MERGE(interval) query runs on every target.
+        Then:
+            Every target should return the merged span and the isolated
+            interval, in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT MERGE(interval) FROM peaks",
+            tables=[Table("peaks")],
+            peaks=[
+                ("chr1", 100, 200),
+                ("chr1", 150, 300),
+                ("chr1", 5000, 6000),
+            ],
+            expected=[("chr1", 100, 300), ("chr1", 5000, 6000)],
+        )
+
+    def test_merge_empty_input_returns_zero_rows(self, cross_target_oracle):
+        """Test MERGE over an empty table returns zero rows on every target.
+
+        Given:
+            An empty peaks table.
+        When:
+            The MERGE query runs on every target (DataFusion via the synthesized
+            empty record batch).
+        Then:
+            Every target should return zero rows in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT MERGE(interval) FROM peaks",
+            tables=[Table("peaks")],
+            peaks=[],
+            expected=[],
+        )
+
+
+class TestCrossTargetOracleDisjoin:
+    """DISJOIN behaviour: a DuckDB-only case plus the DataFusion duplicate-end gap."""
+
+    def test_disjoin_splits_overlaps_on_duckdb(self, cross_target_oracle):
+        """Test DISJOIN splits overlapping intervals at breakpoints on DuckDB.
+
+        Given:
+            Two overlapping intervals on chr1.
+        When:
+            A DISJOIN query runs on the duckdb target only.
+        Then:
+            DuckDB should return each original interval paired with the
+            sub-segments cut at every breakpoint.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end", disjoin_start, disjoin_end FROM DISJOIN(peaks)',
+            tables=[Table("peaks")],
+            peaks=[("chr1", 0, 100), ("chr1", 50, 150)],
+            expected=[
+                ("chr1", 0, 100, 0, 50),
+                ("chr1", 0, 100, 50, 100),
+                ("chr1", 50, 150, 50, 100),
+                ("chr1", 50, 150, 100, 150),
+            ],
+            targets=("duckdb",),
+        )
+
+    @pytest.mark.xfail(
+        strict=True,
+        raises=Exception,
+        reason='DISJOIN CTE * passthrough emits duplicate t."end" columns — #145',
+    )
+    def test_disjoin_full_oracle_xfails_on_datafusion_duplicate_end(
+        self, cross_target_oracle
+    ):
+        """Test the full DISJOIN oracle xfails on DataFusion's duplicate-end names.
+
+        Given:
+            The same two overlapping intervals.
+        When:
+            The oracle runs all three targets — the datafusion target executes
+            DISJOIN's CTE ``*`` passthrough, which projects ``t."end"`` twice.
+        Then:
+            DataFusion should reject the projection for non-unique expression
+            names (DuckDB tolerates it). This is a strict xfail that promotes
+            when DISJOIN's passthrough is de-duplicated; an unrelated DataFusion
+            error escapes and fails loudly. Note: the cause is the duplicate
+            output-column name, NOT canonicalization or ``* REPLACE`` (no
+            ``* REPLACE`` is emitted today).
+        """
+        # Arrange / Act
+        try:
+            cross_target_oracle(
+                'SELECT chrom, start, "end", disjoin_start, disjoin_end '
+                "FROM DISJOIN(peaks)",
+                tables=[Table("peaks")],
+                peaks=[("chr1", 0, 100), ("chr1", 50, 150)],
+                expected=[
+                    ("chr1", 0, 100, 0, 50),
+                    ("chr1", 0, 100, 50, 100),
+                    ("chr1", 50, 150, 50, 100),
+                    ("chr1", 50, 150, 100, 150),
+                ],
+            )
+        except Exception as exc:  # noqa: BLE001
+            message = str(exc).lower()
+            # Assert: narrow to the duplicate-column-name signature so unrelated
+            # DataFusion failures escape and fail the test loudly.
+            assert "unique" in message and "name" in message, (
+                f"unexpected DataFusion error, not the duplicate-end gap: {exc!r}"
+            )
+            raise
+
+
+class TestCrossTargetOracleDataShapes:
+    """Data-shape coverage for the oracle (T3)."""
+
+    def test_multi_chrom_join_does_not_cross_chromosomes(self, cross_target_oracle):
+        """Test a multi-chromosome join keeps overlaps within each chromosome.
+
+        Given:
+            Peaks on chr1 and chr2 and genes on chr1, chr2, and chr3 where only
+            same-chromosome pairs overlap by coordinate.
+        When:
+            A column-to-column INTERSECTS join runs on every target.
+        Then:
+            Every target should return only the same-chromosome overlaps and
+            never a cross-chromosome pair.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.chrom AS chrom, a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+            peaks=[("chr1", 100, 500), ("chr2", 100, 500)],
+            genes=[("chr1", 300, 400), ("chr2", 300, 400), ("chr3", 300, 400)],
+            expected=[("chr1", 100, 300), ("chr2", 100, 300)],
+        )
+
+    def test_join_path_with_no_overlap_returns_zero_rows(self, cross_target_oracle):
+        """Test the JOIN path returns zero rows when nothing overlaps.
+
+        Given:
+            A peak and a gene that do not overlap.
+        When:
+            A column-to-column INTERSECTS join runs on every target.
+        Then:
+            Every target should return zero rows in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+            peaks=[("chr1", 100, 200)],
+            genes=[("chr1", 5000, 6000)],
+            expected=[],
+        )
+
+    def test_empty_input_table_returns_zero_rows(self, cross_target_oracle):
+        """Test an empty input table yields zero rows on every target.
+
+        Given:
+            An empty peaks table.
+        When:
+            A literal INTERSECTS query runs on every target — DataFusion
+            registers the empty table via the synthesized empty record batch.
+        Then:
+            Every target should return zero rows in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval INTERSECTS 'chr1:1000-2000'",
+            peaks=[],
+            expected=[],
+        )
+
+    def test_half_open_touching_intervals_do_not_overlap(self, cross_target_oracle):
+        """Test half-open adjacent intervals (end == start) do not overlap.
+
+        Given:
+            A peak ending exactly where a gene begins (half-open adjacency).
+        When:
+            A column-to-column INTERSECTS join runs on every target.
+        Then:
+            Every target should return zero rows — touching is not overlap under
+            half-open semantics.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+            peaks=[("chr1", 100, 200)],
+            genes=[("chr1", 200, 300)],
+            expected=[],
+        )
+
+    def test_one_base_pair_overlap_matches(self, cross_target_oracle):
+        """Test a single-base-pair overlap is counted as an overlap.
+
+        Given:
+            A peak extending one base past a gene's start.
+        When:
+            A column-to-column INTERSECTS join runs on every target.
+        Then:
+            Every target should return the single overlapping pair.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+            peaks=[("chr1", 100, 201)],
+            genes=[("chr1", 200, 300)],
+            expected=[(100, 200)],
+        )
+
+    def test_large_interval_spanning_bins_is_not_duplicated(self, cross_target_oracle):
+        """Test a multi-bin interval yields one pair, not duplicates.
+
+        Given:
+            A peak spanning many join bins and a single gene inside it.
+        When:
+            A column-to-column INTERSECTS join runs on every target.
+        Then:
+            Every target should return exactly one pair — the binned join must
+            dedup the cross-bin candidates, the oracle's multiset compare being
+            what would catch a duplicate-row regression.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+            peaks=[("chr1", 0, 500000)],
+            genes=[("chr1", 250000, 250100)],
+            expected=[(0, 250000)],
+        )

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -1,0 +1,213 @@
+"""Cross-target result-identity tests via the ``cross_target_oracle`` fixture.
+
+These exercise the reusable oracle (``tests/integration/conftest.py``) over the
+operators that already emit identical generic SQL across Generic and DataFusion
+and run correctly on DuckDB: INTERSECTS (literal + column-to-column join),
+CONTAINS, WITHIN, and standalone NEAREST. No operator has been migrated to the
+expander registry yet (epic #137), so this lane locks in the verification path
+every later migration (#140-#144) will consume.
+
+NEAREST's expansion uses a correlated ``LATERAL`` subquery, which DataFusion has
+no physical plan for today; its case therefore restricts the oracle to the
+DuckDB-executed targets and is the one documented cross-target gap.
+"""
+
+import pytest
+
+pytest.importorskip("duckdb")
+pytest.importorskip("datafusion")
+pytest.importorskip("pyarrow")
+
+pytestmark = pytest.mark.integration
+
+
+class TestCrossTargetOracleIntersects:
+    """INTERSECTS identity across Generic, DataFusion, and DuckDB."""
+
+    def test_literal_intersects_returns_overlapping_rows(self, cross_target_oracle):
+        """Test a literal INTERSECTS yields identical rows on every target.
+
+        Given:
+            A peaks table with one interval overlapping chr1:1000-2000, one
+            non-overlapping interval on chr1, and one on chr2.
+        When:
+            A literal-range INTERSECTS query runs through every target on its
+            engine.
+        Then:
+            Each target should return exactly the overlapping chr1 row and all
+            targets should agree.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval INTERSECTS 'chr1:1000-2000'",
+            peaks=[
+                ("chr1", 1500, 1800),
+                ("chr1", 5000, 6000),
+                ("chr2", 1500, 1800),
+            ],
+            expected=[("chr1", 1500, 1800)],
+        )
+
+    def test_literal_intersects_no_overlap_returns_zero_rows(self, cross_target_oracle):
+        """Test a non-overlapping literal INTERSECTS yields no rows on any target.
+
+        Given:
+            A peaks table whose intervals do not overlap the query range.
+        When:
+            The literal INTERSECTS query runs through every target.
+        Then:
+            Every target should return zero rows in agreement.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval INTERSECTS 'chr1:1000-2000'",
+            peaks=[
+                ("chr1", 5000, 6000),
+                ("chr2", 1500, 1800),
+            ],
+            expected=[],
+        )
+
+    def test_column_to_column_intersects_join_agrees(self, cross_target_oracle):
+        """Test a column-to-column INTERSECTS join agrees across all targets.
+
+        Given:
+            Peaks and genes tables where one peak overlaps one gene on chr1 and
+            other intervals do not overlap or sit on another chromosome.
+        When:
+            A column-to-column INTERSECTS join runs — generic/datafusion via the
+            binned equi-join on DataFusion and duckdb via the IEJoin on DuckDB.
+        Then:
+            Every target should return the single overlapping pair, proving the
+            structurally different DuckDB IEJoin SQL yields identical rows.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.chrom, a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+            peaks=[
+                ("chr1", 100, 500),
+                ("chr1", 1000, 2000),
+                ("chr2", 100, 500),
+            ],
+            genes=[
+                ("chr1", 300, 600),
+                ("chr1", 5000, 6000),
+                ("chr2", 9000, 9500),
+            ],
+            expected=[("chr1", 100, 300)],
+        )
+
+
+class TestCrossTargetOracleContainsWithin:
+    """CONTAINS and WITHIN identity across all targets."""
+
+    def test_contains_returns_enclosing_rows(self, cross_target_oracle):
+        """Test CONTAINS yields identical enclosing rows across targets.
+
+        Given:
+            A peaks table with one interval enclosing chr1:1200-1300, one that
+            only partially overlaps it, and one on chr2.
+        When:
+            A literal CONTAINS query runs through every target.
+        Then:
+            Every target should return only the fully-enclosing chr1 row.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval CONTAINS 'chr1:1200-1300'",
+            peaks=[
+                ("chr1", 1000, 2000),
+                ("chr1", 1250, 1400),
+                ("chr2", 1000, 2000),
+            ],
+            expected=[("chr1", 1000, 2000)],
+        )
+
+    def test_within_returns_enclosed_rows(self, cross_target_oracle):
+        """Test WITHIN yields identical enclosed rows across targets.
+
+        Given:
+            A peaks table with one interval fully inside chr1:1000-2000, one that
+            spills past it, and one on chr2.
+        When:
+            A literal WITHIN query runs through every target.
+        Then:
+            Every target should return only the fully-enclosed chr1 row.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end" FROM peaks '
+            "WHERE interval WITHIN 'chr1:1000-2000'",
+            peaks=[
+                ("chr1", 1200, 1800),
+                ("chr1", 1500, 2500),
+                ("chr2", 1200, 1800),
+            ],
+            expected=[("chr1", 1200, 1800)],
+        )
+
+
+class TestCrossTargetOracleNearest:
+    """Standalone NEAREST identity on the targets whose engine supports LATERAL."""
+
+    def test_standalone_nearest_k1_agrees_on_duckdb_targets(self, cross_target_oracle):
+        """Test standalone NEAREST k=1 agrees across the LATERAL-capable targets.
+
+        Given:
+            A single-row peaks table and three candidate genes at varying
+            distances on chr1.
+        When:
+            A correlated ``CROSS JOIN LATERAL NEAREST(..., k := 1)`` query runs
+            on the generic and duckdb targets, both executed on DuckDB.
+        Then:
+            Both targets should return the single nearest gene and agree.
+
+        The generic target is routed to DuckDB here (not its default DataFusion
+        engine): the correlated LATERAL this expansion emits has no DataFusion
+        physical plan — the one documented cross-target gap.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.chrom, a.start AS a_start, b.start AS b_start "
+            "FROM peaks a "
+            "CROSS JOIN LATERAL NEAREST(genes, reference := a.interval, k := 1) b",
+            peaks=[("chr1", 200, 300)],
+            genes=[
+                ("chr1", 1000, 1100),
+                ("chr1", 50, 60),
+                ("chr1", 280, 290),
+            ],
+            expected=[("chr1", 200, 280)],
+            targets=("generic", "duckdb"),
+            engines={"generic": "duckdb"},
+        )
+
+    def test_nearest_on_datafusion_lateral_is_unsupported(self, cross_target_oracle):
+        """Test the NEAREST LATERAL expansion has no DataFusion physical plan.
+
+        Given:
+            The same single-row NEAREST query.
+        When:
+            The oracle is asked to run only the datafusion target on DataFusion.
+        Then:
+            DataFusion should reject the correlated LATERAL, pinning the gap that
+            justifies excluding it from the identity assertion above.
+        """
+        # Arrange / Act
+        with pytest.raises(Exception) as excinfo:
+            cross_target_oracle(
+                "SELECT a.chrom, a.start AS a_start, b.start AS b_start "
+                "FROM peaks a "
+                "CROSS JOIN LATERAL NEAREST(genes, reference := a.interval, k := 1) b",
+                peaks=[("chr1", 200, 300)],
+                genes=[("chr1", 280, 290)],
+                expected=[("chr1", 200, 280)],
+                targets=("datafusion",),
+            )
+
+        # Assert
+        assert "not implemented" in str(excinfo.value).lower()

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -7,11 +7,20 @@ CONTAINS, WITHIN, and standalone NEAREST. No operator has been migrated to the
 expander registry yet (epic #137), so this lane locks in the verification path
 every later migration (#140-#144) will consume.
 
+For the non-join operators (DISTANCE, CONTAINS, WITHIN, ANY/ALL, CLUSTER,
+MERGE) the generic and datafusion targets emit byte-identical SQL and both run
+on the DataFusion engine, so the load-bearing comparison there is
+DataFusion-vs-DuckDB. Only the column-to-column INTERSECTS join produces
+genuinely divergent SQL across targets (the DuckDB IEJoin vs. the binned
+equi-join).
+
 NEAREST's expansion uses a correlated ``LATERAL`` subquery, which DataFusion has
 no physical plan for today; its generic-vs-duckdb equivalence case runs both on
-DuckDB, and the full three-target oracle is pinned as a strict xfail (#142) that
-auto-promotes when DataFusion gains correlated LATERAL — the one documented
-cross-target gap.
+DuckDB, and the full three-target oracle is pinned by a
+``pytest.raises(match="OuterReferenceColumn")`` test (#142) that fails loudly on
+an unrelated error and trips "DID NOT RAISE" — forcing conversion to a real
+identity test — when DataFusion gains correlated LATERAL. DISJOIN has an
+analogous pending-#153 gap (duplicate ``end`` output names).
 """
 
 import pytest
@@ -195,13 +204,8 @@ class TestCrossTargetOracleNearest:
             engines={"generic": "duckdb"},
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        raises=Exception,
-        reason="DataFusion lacks correlated LATERAL (OuterReferenceColumn) — #142",
-    )
-    def test_nearest_full_oracle_xfails_on_datafusion_lateral(self, cross_target_oracle):
-        """Test the full NEAREST oracle xfails on DataFusion's missing LATERAL.
+    def test_nearest_on_datafusion_unsupported_pending_142(self, cross_target_oracle):
+        """Test the full NEAREST oracle raises DataFusion's missing-LATERAL error.
 
         Given:
             The single-row NEAREST query and a candidate gene on chr1.
@@ -210,13 +214,14 @@ class TestCrossTargetOracleNearest:
             the correlated LATERAL on DataFusion, which has no physical plan.
         Then:
             DataFusion should raise its ``OuterReferenceColumn`` "not
-            implemented" error, pinning the gap as a strict xfail that
-            auto-promotes (XPASS -> fail) when #142 lands. An UNRELATED
-            DataFusion error must still fail loudly, so the match is narrowed
-            to the LATERAL signature before re-raising.
+            implemented" error. This pins the known #142 gap: the ``match``
+            narrows to the LATERAL signature so an unrelated/reworded DataFusion
+            error fails loudly, and a closed gap (no exception) trips pytest's
+            "DID NOT RAISE", forcing this to be converted into a real
+            cross-target identity test when DataFusion gains correlated LATERAL.
         """
-        # Arrange / Act
-        try:
+        # Arrange / Act / Assert
+        with pytest.raises(Exception, match="OuterReferenceColumn"):
             cross_target_oracle(
                 "SELECT a.chrom, a.start AS a_start, b.start AS b_start "
                 "FROM peaks a "
@@ -225,14 +230,6 @@ class TestCrossTargetOracleNearest:
                 genes=[("chr1", 280, 290)],
                 expected=[("chr1", 200, 280)],
             )
-        except Exception as exc:  # noqa: BLE001
-            message = str(exc).lower()
-            # Assert: narrow the xfail to the documented LATERAL gap so any
-            # unrelated DataFusion failure escapes and fails the test loudly.
-            assert "outerreferencecolumn" in message or "not implemented" in message, (
-                f"unexpected DataFusion error, not the LATERAL gap: {exc!r}"
-            )
-            raise
 
 
 class TestCrossTargetOracleIntersectsAnyAll:
@@ -342,6 +339,49 @@ class TestCrossTargetOracleDistance:
             peaks=[("chr1", 100, 200)],
             genes=[("chr1", 250, 300), ("chr1", 5000, 5100)],
             expected=[(100, 250)],
+        )
+
+    def test_distance_upstream_gap_b_precedes_a(self, cross_target_oracle):
+        """Test DISTANCE measures the upstream gap when B precedes A.
+
+        Given:
+            A peak and a gene that ends before the peak begins on the same
+            chromosome, exercising the ``ELSE`` (upstream-gap) CASE branch.
+        When:
+            A DISTANCE(a, b) < threshold join runs on every target.
+        Then:
+            Every target should return the pair, the gap being measured from B's
+            end to A's start.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.chrom = b.chrom "
+            "WHERE DISTANCE(a.interval, b.interval) < 100",
+            peaks=[("chr1", 250, 300)],
+            genes=[("chr1", 100, 200)],
+            expected=[(250, 100)],
+        )
+
+    def test_distance_overlapping_pair_is_zero(self, cross_target_oracle):
+        """Test DISTANCE is zero for overlapping intervals.
+
+        Given:
+            A peak and a gene that overlap on the same chromosome, exercising the
+            overlap (``THEN 0``) CASE branch.
+        When:
+            A DISTANCE(a, b) < threshold join runs on every target.
+        Then:
+            Every target should return the pair, the overlap yielding distance 0.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.start AS a_start, b.start AS b_start "
+            "FROM peaks a JOIN genes b ON a.chrom = b.chrom "
+            "WHERE DISTANCE(a.interval, b.interval) < 100",
+            peaks=[("chr1", 100, 300)],
+            genes=[("chr1", 200, 400)],
+            expected=[(100, 200)],
         )
 
     def test_distance_no_pair_within_threshold_returns_zero_rows(
@@ -462,7 +502,12 @@ class TestCrossTargetOracleMerge:
 
 
 class TestCrossTargetOracleDisjoin:
-    """DISJOIN behaviour: a DuckDB-only case plus the DataFusion duplicate-end gap."""
+    """DISJOIN: a DuckDB-only case plus the DataFusion duplicate-``end`` gap (#153).
+
+    The DataFusion gap is the unaliased duplicate ``t."end"`` columns in the
+    ``__giql_dj_cuts`` CTE UNION branches, which DataFusion rejects as non-unique
+    projection names (DuckDB tolerates them).
+    """
 
     def test_disjoin_splits_overlaps_on_duckdb(self, cross_target_oracle):
         """Test DISJOIN splits overlapping intervals at breakpoints on DuckDB.
@@ -489,31 +534,28 @@ class TestCrossTargetOracleDisjoin:
             targets=("duckdb",),
         )
 
-    @pytest.mark.xfail(
-        strict=True,
-        raises=Exception,
-        reason='DISJOIN CTE * passthrough emits duplicate t."end" columns — #145',
-    )
-    def test_disjoin_full_oracle_xfails_on_datafusion_duplicate_end(
-        self, cross_target_oracle
-    ):
-        """Test the full DISJOIN oracle xfails on DataFusion's duplicate-end names.
+    def test_disjoin_on_datafusion_unsupported_pending_153(self, cross_target_oracle):
+        """Test the full DISJOIN oracle raises DataFusion's duplicate-name error.
 
         Given:
             The same two overlapping intervals.
         When:
             The oracle runs all three targets — the datafusion target executes
-            DISJOIN's CTE ``*`` passthrough, which projects ``t."end"`` twice.
+            DISJOIN's ``__giql_dj_cuts`` CTE, whose UNION branches project the
+            unaliased ``t."end"`` column twice.
         Then:
             DataFusion should reject the projection for non-unique expression
-            names (DuckDB tolerates it). This is a strict xfail that promotes
-            when DISJOIN's passthrough is de-duplicated; an unrelated DataFusion
-            error escapes and fails loudly. Note: the cause is the duplicate
-            output-column name, NOT canonicalization or ``* REPLACE`` (no
-            ``* REPLACE`` is emitted today).
+            names (DuckDB tolerates it). This pins the known #153 gap: the
+            ``match`` narrows to the duplicate-output-name signature so an
+            unrelated/reworded DataFusion error fails loudly, and a closed gap
+            (no exception) trips pytest's "DID NOT RAISE", forcing this to be
+            converted into a real cross-target identity test when the duplicate
+            ``end`` columns in the ``__giql_dj_cuts`` UNION branches are aliased.
         """
-        # Arrange / Act
-        try:
+        # Arrange / Act / Assert
+        with pytest.raises(
+            Exception, match="Projections require unique expression names"
+        ):
             cross_target_oracle(
                 'SELECT chrom, start, "end", disjoin_start, disjoin_end '
                 "FROM DISJOIN(peaks)",
@@ -526,14 +568,6 @@ class TestCrossTargetOracleDisjoin:
                     ("chr1", 50, 150, 100, 150),
                 ],
             )
-        except Exception as exc:  # noqa: BLE001
-            message = str(exc).lower()
-            # Assert: narrow to the duplicate-column-name signature so unrelated
-            # DataFusion failures escape and fail the test loudly.
-            assert "unique" in message and "name" in message, (
-                f"unexpected DataFusion error, not the duplicate-end gap: {exc!r}"
-            )
-            raise
 
 
 class TestCrossTargetOracleDataShapes:
@@ -638,22 +672,25 @@ class TestCrossTargetOracleDataShapes:
         )
 
     def test_large_interval_spanning_bins_is_not_duplicated(self, cross_target_oracle):
-        """Test a multi-bin interval yields one pair, not duplicates.
+        """Test two intervals sharing many bins yield one pair, not duplicates.
 
         Given:
-            A peak spanning many join bins and a single gene inside it.
+            A peak (0-500000) and a gene (5000-495000) that co-occupy dozens of
+            shared join bins (the bin width is 10000), so the binned candidate
+            join produces the same pair once per shared bin.
         When:
             A column-to-column INTERSECTS join runs on every target.
         Then:
-            Every target should return exactly one pair — the binned join must
-            dedup the cross-bin candidates, the oracle's multiset compare being
-            what would catch a duplicate-row regression.
+            Every target should return exactly one pair — the binned join's
+            ``SELECT DISTINCT`` must collapse the duplicate cross-bin candidates,
+            and the oracle's multiset compare is what would catch a stripped
+            DISTINCT as a duplicate-row regression.
         """
         # Arrange / Act / Assert
         cross_target_oracle(
             "SELECT a.start AS a_start, b.start AS b_start "
             "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
             peaks=[("chr1", 0, 500000)],
-            genes=[("chr1", 250000, 250100)],
-            expected=[(0, 250000)],
+            genes=[("chr1", 5000, 495000)],
+            expected=[(0, 5000)],
         )

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -154,21 +154,26 @@ class TestCrossTargetOracleContainsWithin:
 class TestCrossTargetOracleNearest:
     """Standalone NEAREST identity on the targets whose engine supports LATERAL."""
 
-    def test_standalone_nearest_k1_agrees_on_duckdb_targets(self, cross_target_oracle):
-        """Test standalone NEAREST k=1 agrees across the LATERAL-capable targets.
+    def test_standalone_nearest_k1_agrees_generic_vs_duckdb_on_duckdb(
+        self, cross_target_oracle
+    ):
+        """Test NEAREST k=1 generic and duckdb SQL agree when both run on DuckDB.
 
         Given:
             A single-row peaks table and three candidate genes at varying
             distances on chr1.
         When:
             A correlated ``CROSS JOIN LATERAL NEAREST(..., k := 1)`` query runs
-            on the generic and duckdb targets, both executed on DuckDB.
+            for the generic and duckdb targets, both executed on DuckDB (the
+            generic target routed via ``engines={"generic": "duckdb"}``).
         Then:
-            Both targets should return the single nearest gene and agree.
+            The generic and duckdb SQL should both return the single nearest
+            gene and agree.
 
-        The generic target is routed to DuckDB here (not its default DataFusion
-        engine): the correlated LATERAL this expansion emits has no DataFusion
-        physical plan — the one documented cross-target gap.
+        This is a generic-vs-duckdb *equivalence* check, not a cross-target
+        identity check: DataFusion is never run here. The generic target is
+        routed to DuckDB because the correlated LATERAL this expansion emits has
+        no DataFusion physical plan — the one documented cross-target gap.
         """
         # Arrange / Act / Assert
         cross_target_oracle(
@@ -186,19 +191,28 @@ class TestCrossTargetOracleNearest:
             engines={"generic": "duckdb"},
         )
 
-    def test_nearest_on_datafusion_lateral_is_unsupported(self, cross_target_oracle):
-        """Test the NEAREST LATERAL expansion has no DataFusion physical plan.
+    @pytest.mark.xfail(
+        strict=True,
+        raises=Exception,
+        reason="DataFusion lacks correlated LATERAL (OuterReferenceColumn) — #142",
+    )
+    def test_nearest_full_oracle_xfails_on_datafusion_lateral(self, cross_target_oracle):
+        """Test the full NEAREST oracle xfails on DataFusion's missing LATERAL.
 
         Given:
-            The same single-row NEAREST query.
+            The single-row NEAREST query and a candidate gene on chr1.
         When:
-            The oracle is asked to run only the datafusion target on DataFusion.
+            The oracle runs all three targets — the datafusion target executes
+            the correlated LATERAL on DataFusion, which has no physical plan.
         Then:
-            DataFusion should reject the correlated LATERAL, pinning the gap that
-            justifies excluding it from the identity assertion above.
+            DataFusion should raise its ``OuterReferenceColumn`` "not
+            implemented" error, pinning the gap as a strict xfail that
+            auto-promotes (XPASS -> fail) when #142 lands. An UNRELATED
+            DataFusion error must still fail loudly, so the match is narrowed
+            to the LATERAL signature before re-raising.
         """
         # Arrange / Act
-        with pytest.raises(Exception) as excinfo:
+        try:
             cross_target_oracle(
                 "SELECT a.chrom, a.start AS a_start, b.start AS b_start "
                 "FROM peaks a "
@@ -206,8 +220,12 @@ class TestCrossTargetOracleNearest:
                 peaks=[("chr1", 200, 300)],
                 genes=[("chr1", 280, 290)],
                 expected=[("chr1", 200, 280)],
-                targets=("datafusion",),
             )
-
-        # Assert
-        assert "not implemented" in str(excinfo.value).lower()
+        except Exception as exc:  # noqa: BLE001
+            message = str(exc).lower()
+            # Assert: narrow the xfail to the documented LATERAL gap so any
+            # unrelated DataFusion failure escapes and fails the test loudly.
+            assert "outerreferencecolumn" in message or "not implemented" in message, (
+                f"unexpected DataFusion error, not the LATERAL gap: {exc!r}"
+            )
+            raise

--- a/tests/integration/datafusion/test_oracle_runners.py
+++ b/tests/integration/datafusion/test_oracle_runners.py
@@ -1,0 +1,275 @@
+"""Runner-internals tests for the cross-target oracle (#139, T4).
+
+These exercise :func:`run_duckdb` / :func:`run_datafusion` directly with trivial
+``SELECT ... FROM t`` SQL (no ``transpile``) so any failure localizes to the
+runner -- schema construction, type mapping, reserved-word quoting, the
+empty-table handling that differs between engines, custom columns, and
+cross-runner output-shape parity.
+"""
+
+import pytest
+
+pytest.importorskip("duckdb")
+pytest.importorskip("datafusion")
+pytest.importorskip("pyarrow")
+
+from tests.integration._oracle import arrow_schema  # noqa: E402
+from tests.integration._oracle import run_datafusion  # noqa: E402
+from tests.integration._oracle import run_duckdb  # noqa: E402
+
+pytestmark = pytest.mark.integration
+
+_INTERVAL_COLUMNS = (("chrom", "utf8"), ("start", "int64"), ("end", "int64"))
+
+
+class TestRunDuckDB:
+    """`run_duckdb` schema, types, quoting, and empty handling."""
+
+    def test_run_duckdb_returns_normalized_rows(self):
+        """Test run_duckdb registers a table and returns normalized rows.
+
+        Given:
+            A two-row interval table and a plain SELECT.
+        When:
+            run_duckdb executes the SQL.
+        Then:
+            It should return both rows as sorted plain-tuple values.
+        """
+        # Arrange / Act
+        rows = run_duckdb(
+            'SELECT chrom, start, "end" FROM t',
+            {"t": [("chr2", 5, 6), ("chr1", 1, 2)]},
+            _INTERVAL_COLUMNS,
+        )
+
+        # Assert
+        assert rows == [("chr1", 1, 2), ("chr2", 5, 6)]
+
+    def test_run_duckdb_maps_utf8_and_int64_types(self):
+        """Test run_duckdb maps utf8 to VARCHAR and int64 to BIGINT.
+
+        Given:
+            A row whose chrom is a string and coordinates are ints.
+        When:
+            run_duckdb executes a SELECT.
+        Then:
+            The returned values should preserve str and int Python types.
+        """
+        # Arrange / Act
+        rows = run_duckdb(
+            "SELECT chrom, start FROM t", {"t": [("chr1", 1, 2)]}, _INTERVAL_COLUMNS
+        )
+
+        # Assert
+        assert isinstance(rows[0][0], str)
+        assert isinstance(rows[0][1], int)
+
+    def test_run_duckdb_quotes_reserved_end_column(self):
+        """Test run_duckdb quotes the reserved ``end`` column.
+
+        Given:
+            A table with the reserved-word ``end`` column.
+        When:
+            run_duckdb selects the quoted column.
+        Then:
+            It should return the end value without a parse error.
+        """
+        # Arrange / Act
+        rows = run_duckdb(
+            'SELECT "end" FROM t', {"t": [("chr1", 1, 99)]}, _INTERVAL_COLUMNS
+        )
+
+        # Assert
+        assert rows == [(99,)]
+
+    def test_run_duckdb_empty_table_returns_zero_rows(self):
+        """Test run_duckdb tolerates an empty table via its ``if rows`` guard.
+
+        Given:
+            An empty interval table.
+        When:
+            run_duckdb selects from it.
+        Then:
+            It should return zero rows (the guard skips the INSERT).
+        """
+        # Arrange / Act
+        rows = run_duckdb("SELECT chrom FROM t", {"t": []}, _INTERVAL_COLUMNS)
+
+        # Assert
+        assert rows == []
+
+    def test_run_duckdb_custom_columns(self):
+        """Test run_duckdb registers a custom column schema.
+
+        Given:
+            A table with a custom ``(name, score)`` schema.
+        When:
+            run_duckdb selects from it.
+        Then:
+            It should map the custom utf8/int64 columns and return the row.
+        """
+        # Arrange / Act
+        rows = run_duckdb(
+            "SELECT name, score FROM t",
+            {"t": [("gene1", 42)]},
+            (("name", "utf8"), ("score", "int64")),
+        )
+
+        # Assert
+        assert rows == [("gene1", 42)]
+
+
+class TestRunDataFusion:
+    """`run_datafusion` schema, types, quoting, and empty handling."""
+
+    def test_run_datafusion_returns_normalized_rows(self):
+        """Test run_datafusion registers a table and returns normalized rows.
+
+        Given:
+            A two-row interval table and a plain SELECT.
+        When:
+            run_datafusion executes the SQL.
+        Then:
+            It should return both rows as sorted plain-tuple values.
+        """
+        # Arrange / Act
+        rows = run_datafusion(
+            'SELECT chrom, start, "end" FROM t',
+            {"t": [("chr2", 5, 6), ("chr1", 1, 2)]},
+            _INTERVAL_COLUMNS,
+        )
+
+        # Assert
+        assert rows == [("chr1", 1, 2), ("chr2", 5, 6)]
+
+    def test_run_datafusion_maps_utf8_and_int64_types(self):
+        """Test run_datafusion maps utf8 to pyarrow utf8 and int64 to int64.
+
+        Given:
+            A row whose chrom is a string and coordinates are ints.
+        When:
+            run_datafusion executes a SELECT.
+        Then:
+            The returned values should be plain str and int after coercion.
+        """
+        # Arrange / Act
+        rows = run_datafusion(
+            "SELECT chrom, start FROM t", {"t": [("chr1", 1, 2)]}, _INTERVAL_COLUMNS
+        )
+
+        # Assert
+        assert isinstance(rows[0][0], str)
+        assert isinstance(rows[0][1], int)
+
+    def test_run_datafusion_quotes_reserved_end_column(self):
+        """Test run_datafusion quotes the reserved ``end`` column.
+
+        Given:
+            A table with the reserved-word ``end`` column.
+        When:
+            run_datafusion selects the quoted column.
+        Then:
+            It should return the end value without a parse error.
+        """
+        # Arrange / Act
+        rows = run_datafusion(
+            'SELECT "end" FROM t', {"t": [("chr1", 1, 99)]}, _INTERVAL_COLUMNS
+        )
+
+        # Assert
+        assert rows == [(99,)]
+
+    def test_run_datafusion_empty_table_returns_zero_rows(self):
+        """Test run_datafusion handles an empty table via a synthesized batch.
+
+        Given:
+            An empty interval table (which would panic raw
+            ``register_record_batches``).
+        When:
+            run_datafusion selects from it.
+        Then:
+            It should return zero rows, proving the loader synthesizes an empty
+            record batch where DuckDB instead skips the INSERT.
+        """
+        # Arrange / Act
+        rows = run_datafusion("SELECT chrom FROM t", {"t": []}, _INTERVAL_COLUMNS)
+
+        # Assert
+        assert rows == []
+
+    def test_run_datafusion_custom_columns(self):
+        """Test run_datafusion registers a custom column schema.
+
+        Given:
+            A table with a custom ``(name, score)`` schema.
+        When:
+            run_datafusion selects from it.
+        Then:
+            It should map the custom utf8/int64 columns and return the row.
+        """
+        # Arrange / Act
+        rows = run_datafusion(
+            "SELECT name, score FROM t",
+            {"t": [("gene1", 42)]},
+            (("name", "utf8"), ("score", "int64")),
+        )
+
+        # Assert
+        assert rows == [("gene1", 42)]
+
+
+class TestRawRegisterRecordBatchesEmpty:
+    """Pin the raw DataFusion empty-table panic the runner guards against."""
+
+    def test_raw_register_record_batches_panics_on_empty(self):
+        """Test raw register_record_batches panics on a truly-empty partition.
+
+        Given:
+            An empty pyarrow table whose ``to_batches()`` yields no batches.
+        When:
+            ``SessionContext.register_record_batches`` is called with it
+            directly (NOT via the oracle helper).
+        Then:
+            DataFusion should raise/panic on the empty partition, documenting
+            why :func:`run_datafusion` synthesizes an empty batch instead.
+        """
+        # Arrange
+        import pyarrow as pa
+        from datafusion import SessionContext
+
+        schema = arrow_schema(_INTERVAL_COLUMNS)
+        ctx = SessionContext()
+        empty_batches = pa.table(
+            {"chrom": [], "start": [], "end": []}, schema=schema
+        ).to_batches()
+        assert empty_batches == []  # no batches is the panic trigger
+
+        # Act / Assert
+        with pytest.raises(BaseException):
+            ctx.register_record_batches("t", [empty_batches])
+
+
+class TestCrossRunnerParity:
+    """Output-shape parity between the two runners on trivial SQL."""
+
+    def test_runners_agree_on_shape_and_values(self):
+        """Test both runners produce identical normalized output for one query.
+
+        Given:
+            The same table data and trivial SELECT for both engines.
+        When:
+            run_duckdb and run_datafusion each execute it.
+        Then:
+            Their normalized results should be identical -- the parity the
+            oracle relies on for its differential comparison.
+        """
+        # Arrange
+        data = {"t": [("chr1", 1, 2), ("chr2", 3, 4)]}
+        sql = 'SELECT chrom, start, "end" FROM t'
+
+        # Act
+        ddb = run_duckdb(sql, data, _INTERVAL_COLUMNS)
+        df = run_datafusion(sql, data, _INTERVAL_COLUMNS)
+
+        # Assert
+        assert ddb == df

--- a/tests/integration/datafusion/test_oracle_runners.py
+++ b/tests/integration/datafusion/test_oracle_runners.py
@@ -23,64 +23,7 @@ _INTERVAL_COLUMNS = (("chrom", "utf8"), ("start", "int64"), ("end", "int64"))
 
 
 class TestRunDuckDB:
-    """`run_duckdb` schema, types, quoting, and empty handling."""
-
-    def test_run_duckdb_returns_normalized_rows(self):
-        """Test run_duckdb registers a table and returns normalized rows.
-
-        Given:
-            A two-row interval table and a plain SELECT.
-        When:
-            run_duckdb executes the SQL.
-        Then:
-            It should return both rows as sorted plain-tuple values.
-        """
-        # Arrange / Act
-        rows = run_duckdb(
-            'SELECT chrom, start, "end" FROM t',
-            {"t": [("chr2", 5, 6), ("chr1", 1, 2)]},
-            _INTERVAL_COLUMNS,
-        )
-
-        # Assert
-        assert rows == [("chr1", 1, 2), ("chr2", 5, 6)]
-
-    def test_run_duckdb_maps_utf8_and_int64_types(self):
-        """Test run_duckdb maps utf8 to VARCHAR and int64 to BIGINT.
-
-        Given:
-            A row whose chrom is a string and coordinates are ints.
-        When:
-            run_duckdb executes a SELECT.
-        Then:
-            The returned values should preserve str and int Python types.
-        """
-        # Arrange / Act
-        rows = run_duckdb(
-            "SELECT chrom, start FROM t", {"t": [("chr1", 1, 2)]}, _INTERVAL_COLUMNS
-        )
-
-        # Assert
-        assert isinstance(rows[0][0], str)
-        assert isinstance(rows[0][1], int)
-
-    def test_run_duckdb_quotes_reserved_end_column(self):
-        """Test run_duckdb quotes the reserved ``end`` column.
-
-        Given:
-            A table with the reserved-word ``end`` column.
-        When:
-            run_duckdb selects the quoted column.
-        Then:
-            It should return the end value without a parse error.
-        """
-        # Arrange / Act
-        rows = run_duckdb(
-            'SELECT "end" FROM t', {"t": [("chr1", 1, 99)]}, _INTERVAL_COLUMNS
-        )
-
-        # Assert
-        assert rows == [(99,)]
+    """`run_duckdb` empty-table handling (its ``if rows`` guard)."""
 
     def test_run_duckdb_empty_table_returns_zero_rows(self):
         """Test run_duckdb tolerates an empty table via its ``if rows`` guard.
@@ -98,86 +41,9 @@ class TestRunDuckDB:
         # Assert
         assert rows == []
 
-    def test_run_duckdb_custom_columns(self):
-        """Test run_duckdb registers a custom column schema.
-
-        Given:
-            A table with a custom ``(name, score)`` schema.
-        When:
-            run_duckdb selects from it.
-        Then:
-            It should map the custom utf8/int64 columns and return the row.
-        """
-        # Arrange / Act
-        rows = run_duckdb(
-            "SELECT name, score FROM t",
-            {"t": [("gene1", 42)]},
-            (("name", "utf8"), ("score", "int64")),
-        )
-
-        # Assert
-        assert rows == [("gene1", 42)]
-
 
 class TestRunDataFusion:
-    """`run_datafusion` schema, types, quoting, and empty handling."""
-
-    def test_run_datafusion_returns_normalized_rows(self):
-        """Test run_datafusion registers a table and returns normalized rows.
-
-        Given:
-            A two-row interval table and a plain SELECT.
-        When:
-            run_datafusion executes the SQL.
-        Then:
-            It should return both rows as sorted plain-tuple values.
-        """
-        # Arrange / Act
-        rows = run_datafusion(
-            'SELECT chrom, start, "end" FROM t',
-            {"t": [("chr2", 5, 6), ("chr1", 1, 2)]},
-            _INTERVAL_COLUMNS,
-        )
-
-        # Assert
-        assert rows == [("chr1", 1, 2), ("chr2", 5, 6)]
-
-    def test_run_datafusion_maps_utf8_and_int64_types(self):
-        """Test run_datafusion maps utf8 to pyarrow utf8 and int64 to int64.
-
-        Given:
-            A row whose chrom is a string and coordinates are ints.
-        When:
-            run_datafusion executes a SELECT.
-        Then:
-            The returned values should be plain str and int after coercion.
-        """
-        # Arrange / Act
-        rows = run_datafusion(
-            "SELECT chrom, start FROM t", {"t": [("chr1", 1, 2)]}, _INTERVAL_COLUMNS
-        )
-
-        # Assert
-        assert isinstance(rows[0][0], str)
-        assert isinstance(rows[0][1], int)
-
-    def test_run_datafusion_quotes_reserved_end_column(self):
-        """Test run_datafusion quotes the reserved ``end`` column.
-
-        Given:
-            A table with the reserved-word ``end`` column.
-        When:
-            run_datafusion selects the quoted column.
-        Then:
-            It should return the end value without a parse error.
-        """
-        # Arrange / Act
-        rows = run_datafusion(
-            'SELECT "end" FROM t', {"t": [("chr1", 1, 99)]}, _INTERVAL_COLUMNS
-        )
-
-        # Assert
-        assert rows == [(99,)]
+    """`run_datafusion` empty-table handling (the synthesized-batch guard)."""
 
     def test_run_datafusion_empty_table_returns_zero_rows(self):
         """Test run_datafusion handles an empty table via a synthesized batch.
@@ -196,26 +62,6 @@ class TestRunDataFusion:
 
         # Assert
         assert rows == []
-
-    def test_run_datafusion_custom_columns(self):
-        """Test run_datafusion registers a custom column schema.
-
-        Given:
-            A table with a custom ``(name, score)`` schema.
-        When:
-            run_datafusion selects from it.
-        Then:
-            It should map the custom utf8/int64 columns and return the row.
-        """
-        # Arrange / Act
-        rows = run_datafusion(
-            "SELECT name, score FROM t",
-            {"t": [("gene1", 42)]},
-            (("name", "utf8"), ("score", "int64")),
-        )
-
-        # Assert
-        assert rows == [("gene1", 42)]
 
 
 class TestRawRegisterRecordBatchesEmpty:
@@ -245,7 +91,7 @@ class TestRawRegisterRecordBatchesEmpty:
         assert empty_batches == []  # no batches is the panic trigger
 
         # Act / Assert
-        with pytest.raises(BaseException):
+        with pytest.raises(BaseException, match="index out of bounds"):
             ctx.register_record_batches("t", [empty_batches])
 
 
@@ -265,6 +111,52 @@ class TestCrossRunnerParity:
         """
         # Arrange
         data = {"t": [("chr1", 1, 2), ("chr2", 3, 4)]}
+        sql = 'SELECT chrom, start, "end" FROM t'
+
+        # Act
+        ddb = run_duckdb(sql, data, _INTERVAL_COLUMNS)
+        df = run_datafusion(sql, data, _INTERVAL_COLUMNS)
+
+        # Assert
+        assert ddb == df
+
+    def test_runners_agree_on_empty_table(self):
+        """Test both runners produce identical output for an empty table.
+
+        Given:
+            An empty table and a trivial SELECT — DuckDB skips the INSERT while
+            DataFusion synthesizes an empty record batch.
+        When:
+            run_duckdb and run_datafusion each execute it.
+        Then:
+            Both should return zero rows, proving the two divergent empty-table
+            paths converge on identical normalized output.
+        """
+        # Arrange
+        data = {"t": []}
+        sql = "SELECT chrom FROM t"
+
+        # Act
+        ddb = run_duckdb(sql, data, _INTERVAL_COLUMNS)
+        df = run_datafusion(sql, data, _INTERVAL_COLUMNS)
+
+        # Assert
+        assert ddb == df == []
+
+    def test_runners_agree_on_null_round_trip(self):
+        """Test both runners normalize a NULL-bearing column identically.
+
+        Given:
+            A table with a NULL ``start`` in one row — DataFusion promotes the
+            int64 column to float64 around the NULL while DuckDB keeps ints.
+        When:
+            run_duckdb and run_datafusion each select it.
+        Then:
+            Their normalized output should be identical, proving the scalar
+            coercion collapses the NULL surrogate and the int/float promotion.
+        """
+        # Arrange
+        data = {"t": [("chr1", None, 2), ("chr2", 3, 4)]}
         sql = 'SELECT chrom, start, "end" FROM t'
 
         # Act

--- a/tests/integration/test_oracle_internals.py
+++ b/tests/integration/test_oracle_internals.py
@@ -129,7 +129,7 @@ class TestNormalize:
         # Assert
         assert result == [("chr1", 1, 2), ("chr1", 1, 2)]
 
-    def test_normalize_is_determinor_under_shuffle(self):
+    def test_normalize_is_deterministic_under_shuffle(self):
         """Test normalize yields an identical result under row shuffling.
 
         Given:

--- a/tests/integration/test_oracle_internals.py
+++ b/tests/integration/test_oracle_internals.py
@@ -1,0 +1,477 @@
+"""Engine-free unit tests for the cross-target oracle internals (#139, T1).
+
+These prove the oracle *itself* is sound before any engine runs: that
+:func:`normalize` / :func:`scalar` collapse engine quirks without hiding real
+differences, that :func:`assert_cross_target` genuinely raises on a wrong
+``expected`` and on engine disagreement, and that :func:`resolve_routing` maps
+and guards targets/engines. No DuckDB / DataFusion / pyarrow needed, so they
+run on every machine and localize oracle bugs away from engine bugs.
+"""
+
+import math
+
+import pytest
+
+from tests.integration._oracle import assert_cross_target
+from tests.integration._oracle import normalize
+from tests.integration._oracle import resolve_routing
+from tests.integration._oracle import scalar
+
+
+class _FakeNumpyScalar:
+    """A scalar that only reveals its value (and NaN-ness) after ``.item()``."""
+
+    def __init__(self, value):
+        self._value = value
+
+    def item(self):
+        return self._value
+
+
+class TestScalar:
+    """`scalar` coercion of engine-specific values."""
+
+    def test_scalar_none_returns_none(self):
+        """Test None passes through as None.
+
+        Given:
+            A None value.
+        When:
+            scalar() coerces it.
+        Then:
+            It should return None.
+        """
+        # Arrange / Act / Assert
+        assert scalar(None) is None
+
+    def test_scalar_plain_float_nan_returns_none(self):
+        """Test a plain float NaN collapses to None.
+
+        Given:
+            A bare float NaN as a DuckDB/DataFusion null surrogate.
+        When:
+            scalar() coerces it.
+        Then:
+            It should return None so it compares equal to a real NULL.
+        """
+        # Arrange / Act / Assert
+        assert scalar(float("nan")) is None
+
+    def test_scalar_numpy_nan_after_item_returns_none(self):
+        """Test a NaN that only surfaces after .item() collapses to None.
+
+        Given:
+            A numpy-like scalar whose .item() unwraps to a float NaN.
+        When:
+            scalar() coerces it and re-checks NaN AFTER .item() (Finding 6).
+        Then:
+            It should return None, never a bare NaN sort key.
+        """
+        # Arrange
+        value = _FakeNumpyScalar(float("nan"))
+
+        # Act
+        result = scalar(value)
+
+        # Assert
+        assert result is None
+
+    def test_scalar_numpy_int_returns_plain_int(self):
+        """Test a numpy-like int scalar unwraps to a plain Python int.
+
+        Given:
+            A numpy-like scalar wrapping an int.
+        When:
+            scalar() coerces it.
+        Then:
+            It should return the plain int value.
+        """
+        # Arrange / Act
+        result = scalar(_FakeNumpyScalar(42))
+
+        # Assert
+        assert result == 42
+        assert isinstance(result, int)
+
+
+class TestNormalize:
+    """`normalize` multiset construction."""
+
+    def test_normalize_sorts_rows_order_free(self):
+        """Test normalize returns a sorted, order-free row list.
+
+        Given:
+            Two rows supplied in descending order.
+        When:
+            normalize() builds the multiset.
+        Then:
+            The result should be sorted ascending regardless of input order.
+        """
+        # Arrange / Act
+        result = normalize([("chr2", 5, 6), ("chr1", 1, 2)])
+
+        # Assert
+        assert result == [("chr1", 1, 2), ("chr2", 5, 6)]
+
+    def test_normalize_preserves_multiplicity(self):
+        """Test normalize keeps duplicate rows (list, not set).
+
+        Given:
+            Two identical rows.
+        When:
+            normalize() builds the multiset.
+        Then:
+            Both copies should survive so duplicate-row bugs surface.
+        """
+        # Arrange / Act
+        result = normalize([("chr1", 1, 2), ("chr1", 1, 2)])
+
+        # Assert
+        assert result == [("chr1", 1, 2), ("chr1", 1, 2)]
+
+    def test_normalize_is_determinor_under_shuffle(self):
+        """Test normalize yields an identical result under row shuffling.
+
+        Given:
+            A row multiset and a reversed copy of it.
+        When:
+            normalize() is applied to both orderings.
+        Then:
+            The two normalized results should be identical (determinism
+            self-test), including for None-bearing rows.
+        """
+        # Arrange
+        rows = [
+            ("chr1", 1, 2),
+            ("chr1", None, 9),
+            ("chr2", 3, 4),
+            ("chr1", 1, 2),
+        ]
+
+        # Act
+        forward = normalize(rows)
+        reverse = normalize(list(reversed(rows)))
+
+        # Assert
+        assert forward == reverse
+
+    def test_normalize_treats_nan_and_none_alike(self):
+        """Test a NaN and a None sort into the same normalized position.
+
+        Given:
+            One row with a None and one with a float NaN in the same column.
+        When:
+            normalize() coerces both.
+        Then:
+            They should compare equal so engine null surrogates do not diverge.
+        """
+        # Arrange / Act
+        with_none = normalize([("chr1", None, 2)])
+        with_nan = normalize([("chr1", math.nan, 2)])
+
+        # Assert
+        assert with_none == with_nan
+
+
+class TestAssertCrossTarget:
+    """`assert_cross_target` differential + expectation phases."""
+
+    def test_passes_when_targets_agree_and_match_expected(self):
+        """Test no error when every target agrees and equals expected.
+
+        Given:
+            Two targets returning the same normalized rows and a matching
+            expected multiset.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should not raise.
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2)])
+        results = {"generic": rows, "duckdb": rows}
+
+        # Act / Assert
+        assert_cross_target(results, normalize([("chr1", 1, 2)]))
+
+    def test_raises_on_value_difference_from_expected(self):
+        """Test a value diff from expected raises in the expectation phase.
+
+        Given:
+            Agreeing targets whose value differs from expected.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise AssertionError naming the expectation mismatch.
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2)])
+        results = {"generic": rows, "duckdb": rows}
+
+        # Act / Assert
+        with pytest.raises(AssertionError):
+            assert_cross_target(results, normalize([("chr1", 1, 99)]))
+
+    def test_raises_on_extra_row_versus_expected(self):
+        """Test an extra row over expected raises.
+
+        Given:
+            Agreeing targets returning one more row than expected.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise AssertionError.
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2), ("chr1", 3, 4)])
+        results = {"generic": rows, "duckdb": rows}
+
+        # Act / Assert
+        with pytest.raises(AssertionError):
+            assert_cross_target(results, normalize([("chr1", 1, 2)]))
+
+    def test_raises_on_missing_row_versus_expected(self):
+        """Test a missing row versus expected raises.
+
+        Given:
+            Agreeing targets returning one fewer row than expected.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise AssertionError.
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2)])
+        results = {"generic": rows, "duckdb": rows}
+
+        # Act / Assert
+        with pytest.raises(AssertionError):
+            assert_cross_target(results, normalize([("chr1", 1, 2), ("chr1", 3, 4)]))
+
+    def test_raises_on_empty_versus_nonempty_expected(self):
+        """Test an empty result against a non-empty expectation raises.
+
+        Given:
+            Agreeing targets returning zero rows but a non-empty expected set.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise AssertionError.
+        """
+        # Arrange
+        results = {"generic": [], "duckdb": []}
+
+        # Act / Assert
+        with pytest.raises(AssertionError):
+            assert_cross_target(results, normalize([("chr1", 1, 2)]))
+
+    def test_raises_on_nonempty_versus_empty_expected(self):
+        """Test a non-empty result against an empty expectation raises.
+
+        Given:
+            Agreeing targets returning a row but an empty expected set.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise AssertionError.
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2)])
+        results = {"generic": rows, "duckdb": rows}
+
+        # Act / Assert
+        with pytest.raises(AssertionError):
+            assert_cross_target(results, [])
+
+    def test_raises_on_multiset_multiplicity_divergence(self):
+        """Test differing duplicate counts raise (list-not-set semantics).
+
+        Given:
+            Agreeing targets returning a row twice but expected only once.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise because multiplicity is preserved, not collapsed.
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2), ("chr1", 1, 2)])
+        results = {"generic": rows, "duckdb": rows}
+
+        # Act / Assert
+        with pytest.raises(AssertionError):
+            assert_cross_target(results, normalize([("chr1", 1, 2)]))
+
+    def test_raises_on_none_versus_value_difference(self):
+        """Test a None where expected holds a value raises.
+
+        Given:
+            Agreeing targets with a None column but expected with a real value.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise: None and a value are genuinely distinct.
+        """
+        # Arrange
+        rows = normalize([("chr1", None, 2)])
+        results = {"generic": rows, "duckdb": rows}
+
+        # Act / Assert
+        with pytest.raises(AssertionError):
+            assert_cross_target(results, normalize([("chr1", 5, 2)]))
+
+    def test_coercion_normalizes_type_but_preserves_value_diff(self):
+        """Test type coercion does not mask a genuine value difference.
+
+        Given:
+            Targets whose values are numpy-like scalars equal to expected ints
+            in one case and differing in another.
+        When:
+            assert_cross_target() compares the coerced multisets.
+        Then:
+            The equal case passes and the differing case raises — coercion
+            normalizes type without hiding a real difference.
+        """
+        # Arrange
+        equal_rows = normalize([("chr1", _FakeNumpyScalar(1), _FakeNumpyScalar(2))])
+        diff_rows = normalize([("chr1", _FakeNumpyScalar(1), _FakeNumpyScalar(2))])
+
+        # Act / Assert
+        assert_cross_target(
+            {"generic": equal_rows, "duckdb": equal_rows}, normalize([("chr1", 1, 2)])
+        )
+        with pytest.raises(AssertionError):
+            assert_cross_target(
+                {"generic": diff_rows, "duckdb": diff_rows},
+                normalize([("chr1", 1, 99)]),
+            )
+
+    def test_raises_with_engines_disagree_message(self):
+        """Test two disagreeing engines trigger the differential assertion.
+
+        Given:
+            A results dict where the duckdb target returns a different row from
+            the generic target, both matching neither each other.
+        When:
+            assert_cross_target() runs (now reachable after Finding 1).
+        Then:
+            It should raise AssertionError whose message says the engines
+            disagree and names both targets — independent of expected.
+        """
+        # Arrange
+        generic_rows = normalize([("chr1", 1, 2)])
+        duckdb_rows = normalize([("chr1", 1, 3)])
+        results = {"generic": generic_rows, "duckdb": duckdb_rows}
+
+        # Act
+        with pytest.raises(AssertionError) as excinfo:
+            assert_cross_target(results, generic_rows)
+
+        # Assert
+        message = str(excinfo.value)
+        assert "engines disagree" in message
+        assert "generic" in message and "duckdb" in message
+
+    def test_disagreement_checked_before_expectation(self):
+        """Test the differential phase fires even when one target matches expected.
+
+        Given:
+            A generic target equal to expected and a duckdb target that differs,
+            so a mid-loop ``== expected`` design would have passed generic and
+            never compared the engines.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise the engines-disagree error first, proving Finding 1
+            made the cross-target assertion genuinely reachable.
+        """
+        # Arrange
+        expected = normalize([("chr1", 1, 2)])
+        results = {"generic": expected, "duckdb": normalize([("chr1", 9, 9)])}
+
+        # Act / Assert
+        with pytest.raises(AssertionError, match="engines disagree"):
+            assert_cross_target(results, expected)
+
+
+class TestResolveRouting:
+    """`resolve_routing` default map, overrides, and guards."""
+
+    def test_default_routing_maps_each_target_to_its_engine(self):
+        """Test the default routing maps targets to their intended engines.
+
+        Given:
+            All three default targets and no overrides.
+        When:
+            resolve_routing() resolves them.
+        Then:
+            generic/datafusion should route to DataFusion and duckdb to DuckDB,
+            each carrying its transpile dialect.
+        """
+        # Arrange / Act
+        routing = resolve_routing(("generic", "datafusion", "duckdb"))
+
+        # Assert
+        assert routing == {
+            "generic": ("datafusion", None),
+            "datafusion": ("datafusion", "datafusion"),
+            "duckdb": ("duckdb", "duckdb"),
+        }
+
+    def test_engines_override_reroutes_target(self):
+        """Test an engines override reroutes a target's engine but not its dialect.
+
+        Given:
+            The generic and duckdb targets with generic routed to duckdb.
+        When:
+            resolve_routing() applies the override.
+        Then:
+            generic should execute on duckdb while keeping its None dialect.
+        """
+        # Arrange / Act
+        routing = resolve_routing(("generic", "duckdb"), engines={"generic": "duckdb"})
+
+        # Assert
+        assert routing["generic"] == ("duckdb", None)
+        assert routing["duckdb"] == ("duckdb", "duckdb")
+
+    def test_unknown_target_raises_value_error(self):
+        """Test an unknown target name raises a clear ValueError (Finding 7).
+
+        Given:
+            A target name that is not a registered target.
+        When:
+            resolve_routing() resolves it.
+        Then:
+            It should raise ValueError, not a bare KeyError.
+        """
+        # Arrange / Act / Assert
+        with pytest.raises(ValueError, match="Unknown target"):
+            resolve_routing(("postgres",))
+
+    def test_unknown_engine_override_raises_value_error(self):
+        """Test an override to an unknown engine raises a clear ValueError.
+
+        Given:
+            A valid target rerouted to an engine the oracle cannot run.
+        When:
+            resolve_routing() resolves it.
+        Then:
+            It should raise ValueError naming the unknown engine.
+        """
+        # Arrange / Act / Assert
+        with pytest.raises(ValueError, match="Unknown engine"):
+            resolve_routing(("generic",), engines={"generic": "spark"})
+
+    def test_unknown_target_in_override_raises_value_error(self):
+        """Test an override keyed on an unknown target raises a clear ValueError.
+
+        Given:
+            An engines override naming a target that does not exist.
+        When:
+            resolve_routing() resolves it.
+        Then:
+            It should raise ValueError naming the unknown override target.
+        """
+        # Arrange / Act / Assert
+        with pytest.raises(ValueError, match="Unknown target"):
+            resolve_routing(("generic",), engines={"nope": "duckdb"})

--- a/tests/integration/test_oracle_internals.py
+++ b/tests/integration/test_oracle_internals.py
@@ -11,11 +11,15 @@ run on every machine and localize oracle bugs away from engine bugs.
 import math
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 
 from tests.integration._oracle import assert_cross_target
 from tests.integration._oracle import normalize
 from tests.integration._oracle import resolve_routing
 from tests.integration._oracle import scalar
+
+pytestmark = pytest.mark.integration
 
 
 class _FakeNumpyScalar:
@@ -319,29 +323,43 @@ class TestAssertCrossTarget:
         with pytest.raises(AssertionError):
             assert_cross_target(results, normalize([("chr1", 5, 2)]))
 
-    def test_coercion_normalizes_type_but_preserves_value_diff(self):
-        """Test type coercion does not mask a genuine value difference.
+    def test_coercion_passes_when_coerced_value_matches_expected(self):
+        """Test type coercion lets a coerced scalar compare equal to a plain int.
 
         Given:
-            Targets whose values are numpy-like scalars equal to expected ints
-            in one case and differing in another.
+            Targets whose values are numpy-like scalars equal to the expected
+            plain ints once coerced.
         When:
             assert_cross_target() compares the coerced multisets.
         Then:
-            The equal case passes and the differing case raises — coercion
-            normalizes type without hiding a real difference.
+            It should pass — coercion normalizes type so the values match.
         """
         # Arrange
-        equal_rows = normalize([("chr1", _FakeNumpyScalar(1), _FakeNumpyScalar(2))])
-        diff_rows = normalize([("chr1", _FakeNumpyScalar(1), _FakeNumpyScalar(2))])
+        rows = normalize([("chr1", _FakeNumpyScalar(1), _FakeNumpyScalar(2))])
 
         # Act / Assert
         assert_cross_target(
-            {"generic": equal_rows, "duckdb": equal_rows}, normalize([("chr1", 1, 2)])
+            {"generic": rows, "duckdb": rows}, normalize([("chr1", 1, 2)])
         )
+
+    def test_coercion_preserves_genuine_value_difference(self):
+        """Test type coercion does not mask a genuine value difference.
+
+        Given:
+            Targets whose coerced values genuinely differ from expected.
+        When:
+            assert_cross_target() compares the coerced multisets.
+        Then:
+            It should raise — coercion normalizes type without hiding a real
+            difference.
+        """
+        # Arrange
+        rows = normalize([("chr1", _FakeNumpyScalar(1), _FakeNumpyScalar(2))])
+
+        # Act / Assert
         with pytest.raises(AssertionError):
             assert_cross_target(
-                {"generic": diff_rows, "duckdb": diff_rows},
+                {"generic": rows, "duckdb": rows},
                 normalize([("chr1", 1, 99)]),
             )
 
@@ -370,6 +388,49 @@ class TestAssertCrossTarget:
         message = str(excinfo.value)
         assert "engines disagree" in message
         assert "generic" in message and "duckdb" in message
+
+    def test_three_targets_all_agree_passes(self):
+        """Test three agreeing targets pass, mirroring the production spread.
+
+        Given:
+            Three targets (generic, datafusion, duckdb) returning identical rows
+            and a matching expectation — the real three-target run shape.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should not raise.
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2)])
+        results = {"generic": rows, "datafusion": rows, "duckdb": rows}
+
+        # Act / Assert
+        assert_cross_target(results, normalize([("chr1", 1, 2)]))
+
+    def test_three_targets_last_diverges_raises(self):
+        """Test a divergence in only the LAST of three targets still raises.
+
+        Given:
+            Three targets where the first two agree but the last (duckdb)
+            returns a different row — the differential phase compares each target
+            against the reference, so a trailing divergence must not slip past.
+        When:
+            assert_cross_target() runs.
+        Then:
+            It should raise the engines-disagree error naming the divergent
+            target.
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2)])
+        results = {
+            "generic": rows,
+            "datafusion": rows,
+            "duckdb": normalize([("chr1", 9, 9)]),
+        }
+
+        # Act / Assert
+        with pytest.raises(AssertionError, match="engines disagree"):
+            assert_cross_target(results, rows)
 
     def test_disagreement_checked_before_expectation(self):
         """Test the differential phase fires even when one target matches expected.
@@ -475,3 +536,78 @@ class TestResolveRouting:
         # Arrange / Act / Assert
         with pytest.raises(ValueError, match="Unknown target"):
             resolve_routing(("generic",), engines={"nope": "duckdb"})
+
+
+# Per-column-HOMOGENEOUS row strategy: column 0 is always text, columns 1-2 are
+# nullable ints. This keeps each column type-homogeneous so the property tests
+# exercise normal multiset behaviour rather than the mixed-type sort-key edge.
+_interval_rows = st.lists(
+    st.tuples(
+        st.text(max_size=5),
+        st.integers() | st.none(),
+        st.integers() | st.none(),
+    ),
+    max_size=8,
+)
+
+
+class TestNormalizeProperties:
+    """Property-based invariants of `normalize` (Tier-3, Hypothesis)."""
+
+    @given(_interval_rows)
+    def test_normalize_is_order_invariant(self, rows):
+        """Test normalize is invariant to input row ordering.
+
+        Given:
+            An arbitrary list of type-homogeneous rows and a shuffled copy.
+        When:
+            normalize() is applied to both orderings.
+        Then:
+            The two results should be identical — order-free multiset semantics.
+        """
+        # Arrange
+        shuffled = list(reversed(rows))
+
+        # Act / Assert
+        assert normalize(rows) == normalize(shuffled)
+
+    @given(_interval_rows)
+    def test_normalize_is_idempotent(self, rows):
+        """Test normalize applied twice equals normalize applied once.
+
+        Given:
+            An arbitrary list of type-homogeneous rows.
+        When:
+            normalize() is applied, then applied again to its own output.
+        Then:
+            The second application should leave the result unchanged.
+        """
+        # Arrange / Act
+        once = normalize(rows)
+        twice = normalize(once)
+
+        # Assert
+        assert once == twice
+
+
+class TestResolveRoutingProperties:
+    """Property-based totality of `resolve_routing` (Tier-3, Hypothesis)."""
+
+    @given(st.lists(st.text(max_size=10), max_size=5))
+    def test_resolve_routing_returns_dict_or_raises_value_error(self, targets):
+        """Test resolve_routing is total: it returns a dict or raises ValueError.
+
+        Given:
+            An arbitrary list of target-name strings (known or unknown).
+        When:
+            resolve_routing() resolves them.
+        Then:
+            It should either return a dict or raise ValueError — never any other
+            exception type.
+        """
+        # Arrange / Act / Assert
+        try:
+            result = resolve_routing(targets)
+        except ValueError:
+            return
+        assert isinstance(result, dict)

--- a/tests/integration/test_oracle_lane.py
+++ b/tests/integration/test_oracle_lane.py
@@ -1,89 +1,20 @@
-"""Capability-truthing and lane/CI guards for the cross-target oracle (#139, T5).
+"""Lane purity guard for the cross-target oracle (#139, T5).
 
-These pin the invariants the oracle's routing and xfails depend on: the
-DataFusion target's declared capabilities (no LATERAL, no ``* REPLACE``), that
-the engine-free oracle internals are importable and reusable from a non-
-DataFusion lane, the skip-path behaviour when an engine is absent, and a
-version-floor guard for the optional engines so a too-old DuckDB / DataFusion
-fails with a clear message rather than a cryptic runtime error.
+This pins the one invariant the oracle's lane layout depends on that nothing
+else covers: :func:`resolve_routing` is a *pure* decision that resolves the full
+routing map with no engine installed or imported, so non-DataFusion lanes (e.g.
+bedtools / coordinate_space) can reuse the engine-free internals.
 """
-
-import importlib.util
 
 import pytest
 
-from giql.targets import DataFusionTarget
-from giql.targets import DuckDBTarget
-from tests.integration._oracle import assert_cross_target
-from tests.integration._oracle import normalize
 from tests.integration._oracle import resolve_routing
 
-
-class TestDataFusionCapabilityTruthing:
-    """The DataFusion capability flags the oracle's xfails rely on."""
-
-    def test_datafusion_does_not_support_lateral(self):
-        """Test DataFusionTarget declares no LATERAL support.
-
-        Given:
-            A DataFusionTarget instance.
-        When:
-            Its capabilities are inspected.
-        Then:
-            supports_lateral should be False, matching the NEAREST xfail (#142).
-        """
-        # Arrange / Act / Assert
-        assert DataFusionTarget().capabilities.supports_lateral is False
-
-    def test_datafusion_does_not_support_star_replace(self):
-        """Test DataFusionTarget declares no ``* REPLACE`` support.
-
-        Given:
-            A DataFusionTarget instance.
-        When:
-            Its capabilities are inspected.
-        Then:
-            supports_star_replace should be False (DataFusion has EXCEPT/EXCLUDE
-            only).
-        """
-        # Arrange / Act / Assert
-        assert DataFusionTarget().capabilities.supports_star_replace is False
-
-    def test_duckdb_supports_star_replace(self):
-        """Test DuckDBTarget declares ``* REPLACE`` support as a contrast.
-
-        Given:
-            A DuckDBTarget instance.
-        When:
-            Its capabilities are inspected.
-        Then:
-            supports_star_replace should be True, confirming the asymmetry the
-            DISJOIN note describes is about duplicate output names, not a
-            ``* REPLACE`` capability gap.
-        """
-        # Arrange / Act / Assert
-        assert DuckDBTarget().capabilities.supports_star_replace is True
+pytestmark = pytest.mark.integration
 
 
 class TestSharedOracleReuse:
-    """The engine-free internals are importable from any lane."""
-
-    def test_oracle_internals_reusable_without_engines(self):
-        """Test the comparison core works imported from a non-DataFusion lane.
-
-        Given:
-            Two agreeing normalized results assembled with no engine present.
-        When:
-            assert_cross_target compares them against a matching expectation.
-        Then:
-            It should pass, proving the shared module is reusable outside the
-            DataFusion lane (e.g. for the bedtools / coordinate_space lanes).
-        """
-        # Arrange
-        rows = normalize([("chr1", 1, 2)])
-
-        # Act / Assert
-        assert_cross_target({"a": rows, "b": rows}, normalize([("chr1", 1, 2)]))
+    """The engine-free routing decision is reusable from any lane."""
 
     def test_routing_resolves_without_engines(self):
         """Test resolve_routing is a pure function needing no engine import.
@@ -101,108 +32,3 @@ class TestSharedOracleReuse:
 
         # Assert
         assert set(routing) == {"generic", "datafusion", "duckdb"}
-
-
-class TestEngineSkipPaths:
-    """Skip / availability behaviour for the optional engines."""
-
-    def test_duckdb_available_or_skipped(self):
-        """Test the DuckDB skip-path: present engine imports, absent one skips.
-
-        Given:
-            The optional DuckDB dependency, which may or may not be installed.
-        When:
-            The lane probes for it via importorskip.
-        Then:
-            It should import when present (and otherwise skip cleanly), mirroring
-            the lane's module-level guard.
-        """
-        # Arrange / Act
-        duckdb = pytest.importorskip("duckdb")
-
-        # Assert
-        assert hasattr(duckdb, "connect")
-
-    def test_datafusion_available_or_skipped(self):
-        """Test the DataFusion skip-path: present engine imports, absent skips.
-
-        Given:
-            The optional DataFusion and pyarrow dependencies.
-        When:
-            The lane probes for them via importorskip.
-        Then:
-            They should import when present (and otherwise skip cleanly).
-        """
-        # Arrange / Act
-        datafusion = pytest.importorskip("datafusion")
-        pytest.importorskip("pyarrow")
-
-        # Assert
-        assert hasattr(datafusion, "SessionContext")
-
-
-class TestEngineVersionFloor:
-    """Version-floor guards for the optional engines."""
-
-    def test_duckdb_meets_version_floor(self):
-        """Test the installed DuckDB meets the lane's minimum version.
-
-        Given:
-            The optional DuckDB dependency.
-        When:
-            Its version tuple is compared to the floor the IEJoin SQL needs.
-        Then:
-            It should be at least the supported floor, failing loudly otherwise.
-        """
-        # Arrange
-        duckdb = pytest.importorskip("duckdb")
-        floor = (0, 9)
-
-        # Act
-        version = tuple(int(p) for p in duckdb.__version__.split(".")[:2])
-
-        # Assert
-        assert version >= floor, f"DuckDB {duckdb.__version__} below floor {floor}"
-
-    def test_datafusion_meets_version_floor(self):
-        """Test the installed DataFusion meets the lane's minimum version.
-
-        Given:
-            The optional DataFusion dependency.
-        When:
-            Its version tuple is compared to the floor the lane was validated on.
-        Then:
-            It should be at least the supported floor, failing loudly otherwise.
-        """
-        # Arrange
-        datafusion = pytest.importorskip("datafusion")
-        floor = (40, 0)
-
-        # Act
-        version = tuple(int(p) for p in datafusion.__version__.split(".")[:2])
-
-        # Assert
-        assert version >= floor, (
-            f"DataFusion {datafusion.__version__} below floor {floor}"
-        )
-
-
-class TestLaneCollection:
-    """A smoke check that the lane and oracle modules collect."""
-
-    def test_oracle_modules_are_importable(self):
-        """Test the oracle's importable modules resolve by spec.
-
-        Given:
-            The non-test ``_oracle`` module and the conftest-backed fixture.
-        When:
-            Their import specs are looked up.
-        Then:
-            The ``_oracle`` module should be findable, anchoring the lane's
-            shared-helper layout.
-        """
-        # Arrange / Act
-        spec = importlib.util.find_spec("tests.integration._oracle")
-
-        # Assert
-        assert spec is not None

--- a/tests/integration/test_oracle_lane.py
+++ b/tests/integration/test_oracle_lane.py
@@ -1,0 +1,208 @@
+"""Capability-truthing and lane/CI guards for the cross-target oracle (#139, T5).
+
+These pin the invariants the oracle's routing and xfails depend on: the
+DataFusion target's declared capabilities (no LATERAL, no ``* REPLACE``), that
+the engine-free oracle internals are importable and reusable from a non-
+DataFusion lane, the skip-path behaviour when an engine is absent, and a
+version-floor guard for the optional engines so a too-old DuckDB / DataFusion
+fails with a clear message rather than a cryptic runtime error.
+"""
+
+import importlib.util
+
+import pytest
+
+from giql.targets import DataFusionTarget
+from giql.targets import DuckDBTarget
+from tests.integration._oracle import assert_cross_target
+from tests.integration._oracle import normalize
+from tests.integration._oracle import resolve_routing
+
+
+class TestDataFusionCapabilityTruthing:
+    """The DataFusion capability flags the oracle's xfails rely on."""
+
+    def test_datafusion_does_not_support_lateral(self):
+        """Test DataFusionTarget declares no LATERAL support.
+
+        Given:
+            A DataFusionTarget instance.
+        When:
+            Its capabilities are inspected.
+        Then:
+            supports_lateral should be False, matching the NEAREST xfail (#142).
+        """
+        # Arrange / Act / Assert
+        assert DataFusionTarget().capabilities.supports_lateral is False
+
+    def test_datafusion_does_not_support_star_replace(self):
+        """Test DataFusionTarget declares no ``* REPLACE`` support.
+
+        Given:
+            A DataFusionTarget instance.
+        When:
+            Its capabilities are inspected.
+        Then:
+            supports_star_replace should be False (DataFusion has EXCEPT/EXCLUDE
+            only).
+        """
+        # Arrange / Act / Assert
+        assert DataFusionTarget().capabilities.supports_star_replace is False
+
+    def test_duckdb_supports_star_replace(self):
+        """Test DuckDBTarget declares ``* REPLACE`` support as a contrast.
+
+        Given:
+            A DuckDBTarget instance.
+        When:
+            Its capabilities are inspected.
+        Then:
+            supports_star_replace should be True, confirming the asymmetry the
+            DISJOIN note describes is about duplicate output names, not a
+            ``* REPLACE`` capability gap.
+        """
+        # Arrange / Act / Assert
+        assert DuckDBTarget().capabilities.supports_star_replace is True
+
+
+class TestSharedOracleReuse:
+    """The engine-free internals are importable from any lane."""
+
+    def test_oracle_internals_reusable_without_engines(self):
+        """Test the comparison core works imported from a non-DataFusion lane.
+
+        Given:
+            Two agreeing normalized results assembled with no engine present.
+        When:
+            assert_cross_target compares them against a matching expectation.
+        Then:
+            It should pass, proving the shared module is reusable outside the
+            DataFusion lane (e.g. for the bedtools / coordinate_space lanes).
+        """
+        # Arrange
+        rows = normalize([("chr1", 1, 2)])
+
+        # Act / Assert
+        assert_cross_target({"a": rows, "b": rows}, normalize([("chr1", 1, 2)]))
+
+    def test_routing_resolves_without_engines(self):
+        """Test resolve_routing is a pure function needing no engine import.
+
+        Given:
+            The default targets.
+        When:
+            resolve_routing resolves them with no engine installed or imported.
+        Then:
+            It should return the full routing map, confirming routing is a pure
+            decision (Finding 7).
+        """
+        # Arrange / Act
+        routing = resolve_routing(("generic", "datafusion", "duckdb"))
+
+        # Assert
+        assert set(routing) == {"generic", "datafusion", "duckdb"}
+
+
+class TestEngineSkipPaths:
+    """Skip / availability behaviour for the optional engines."""
+
+    def test_duckdb_available_or_skipped(self):
+        """Test the DuckDB skip-path: present engine imports, absent one skips.
+
+        Given:
+            The optional DuckDB dependency, which may or may not be installed.
+        When:
+            The lane probes for it via importorskip.
+        Then:
+            It should import when present (and otherwise skip cleanly), mirroring
+            the lane's module-level guard.
+        """
+        # Arrange / Act
+        duckdb = pytest.importorskip("duckdb")
+
+        # Assert
+        assert hasattr(duckdb, "connect")
+
+    def test_datafusion_available_or_skipped(self):
+        """Test the DataFusion skip-path: present engine imports, absent skips.
+
+        Given:
+            The optional DataFusion and pyarrow dependencies.
+        When:
+            The lane probes for them via importorskip.
+        Then:
+            They should import when present (and otherwise skip cleanly).
+        """
+        # Arrange / Act
+        datafusion = pytest.importorskip("datafusion")
+        pytest.importorskip("pyarrow")
+
+        # Assert
+        assert hasattr(datafusion, "SessionContext")
+
+
+class TestEngineVersionFloor:
+    """Version-floor guards for the optional engines."""
+
+    def test_duckdb_meets_version_floor(self):
+        """Test the installed DuckDB meets the lane's minimum version.
+
+        Given:
+            The optional DuckDB dependency.
+        When:
+            Its version tuple is compared to the floor the IEJoin SQL needs.
+        Then:
+            It should be at least the supported floor, failing loudly otherwise.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        floor = (0, 9)
+
+        # Act
+        version = tuple(int(p) for p in duckdb.__version__.split(".")[:2])
+
+        # Assert
+        assert version >= floor, f"DuckDB {duckdb.__version__} below floor {floor}"
+
+    def test_datafusion_meets_version_floor(self):
+        """Test the installed DataFusion meets the lane's minimum version.
+
+        Given:
+            The optional DataFusion dependency.
+        When:
+            Its version tuple is compared to the floor the lane was validated on.
+        Then:
+            It should be at least the supported floor, failing loudly otherwise.
+        """
+        # Arrange
+        datafusion = pytest.importorskip("datafusion")
+        floor = (40, 0)
+
+        # Act
+        version = tuple(int(p) for p in datafusion.__version__.split(".")[:2])
+
+        # Assert
+        assert version >= floor, (
+            f"DataFusion {datafusion.__version__} below floor {floor}"
+        )
+
+
+class TestLaneCollection:
+    """A smoke check that the lane and oracle modules collect."""
+
+    def test_oracle_modules_are_importable(self):
+        """Test the oracle's importable modules resolve by spec.
+
+        Given:
+            The non-test ``_oracle`` module and the conftest-backed fixture.
+        When:
+            Their import specs are looked up.
+        Then:
+            The ``_oracle`` module should be findable, anchoring the lane's
+            shared-helper layout.
+        """
+        # Arrange / Act
+        spec = importlib.util.find_spec("tests.integration._oracle")
+
+        # Assert
+        assert spec is not None


### PR DESCRIPTION
## Summary

Add a reusable cross-target result oracle and a first-class DataFusion integration lane for epic #137. The oracle transpiles one GIQL query for each target (Generic via `dialect=None`, DuckDB, DataFusion), executes each target's SQL on the engine it is meant for, and asserts the engines agree with each other and with an expected result — comparing rows, not SQL strings, since the engines emit structurally different SQL. Every later operator migration (#140–#144) consumes this harness to prove DuckDB ≡ DataFusion ≡ expected.

Extract the oracle internals into an importable `tests/integration/_oracle.py` so the load-bearing comparison logic stays unit-testable without engines. The comparison is differential: it asserts the engines agree with each other first (independent of `expected`), then against `expected`, so a genuine cross-engine divergence is caught and clearly reported.

Two operators carry real DataFusion engine limitations today, each pinned by a `pytest.raises(match=…)` gap test that fails loudly on an unrelated error and auto-promotes (DID NOT RAISE) when the gap closes: NEAREST (no DataFusion plan for the correlated `LATERAL`, pending #142) and DISJOIN (DataFusion rejects the duplicate `t."end"` output columns its CTE emits, pending #153).

Closes #139

## Proposed changes

### Oracle internals (`tests/integration/_oracle.py`)
- `normalize` / `scalar` reduce engine output to a sorted multiset of plain Python scalars (NaN → `None`, numpy `.item()` unwrap, integral floats coerced to `int`), with a type-total sort key so a genuine type divergence surfaces as a clean inequality rather than a crash.
- `resolve_routing` is a pure target→(engine, dialect) map that normalizes its input and raises a clear `ValueError` on an unknown target or engine.
- `assert_cross_target` collects every target's result, asserts the engines agree with each other, then asserts the agreed result equals `expected`, and raises on an empty target set.
- `register_record_batches` is a shared pyarrow loader (synthesizing an empty `RecordBatch` to sidestep a DataFusion panic on empty partitions); `run_duckdb` / `run_datafusion` execute a query on each engine.

### Fixture and lane (`tests/integration/conftest.py`, `tests/integration/datafusion/*`)
- `cross_target_oracle` is a thin wrapper over `_oracle.py` that raises when custom `columns` are passed without an explicit `tables` list. The #132 `datafusion_ctx` fixture now shares the extracted loader.
- The DataFusion lane covers the operator spread, the engine runners, and a cross-lane reuse guard.

### Operator and data-shape coverage
- Cross-target identity for INTERSECTS (literal, column-to-column join, ANY/ALL), CONTAINS, WITHIN, DISTANCE (column-to-column, all `CASE` branches), CLUSTER, and MERGE, plus data shapes (multi-chrom, empty, half-open boundary, 1bp overlap, bin-dedup).
- NEAREST (generic≡duckdb equivalence) and the DataFusion NEAREST / DISJOIN gaps as `pytest.raises(match=…)` tests pending #142 / #153.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestScalar` / `TestNormalize` / `TestNormalizeProperties` | Engine rows with NaN, None, duplicates, and mixed types | `normalize` reduces them | It yields an order-invariant, idempotent multiset that preserves multiplicity and never collapses a real difference | Result coercion core |
| 2 | `TestAssertCrossTarget` | Two- and three-target results that agree or diverge | `assert_cross_target` runs | It raises on engine disagreement, on an expected mismatch, and on an empty target set, and passes when all agree | Differential oracle |
| 3 | `TestResolveRouting` / `TestResolveRoutingProperties` | A target list and an optional engine override | `resolve_routing` runs | It maps each target to the right engine and raises `ValueError` on an unknown target or engine | Routing purity |
| 4 | `TestCrossTargetOracleIntersects` / `ContainsWithin` / `IntersectsAnyAll` | Interval tables and a predicate query | The oracle runs across all targets | Every engine returns identical rows equal to expected | Predicate cross-target identity |
| 5 | `TestCrossTargetOracleDistance` / `Cluster` / `Merge` | Interval tables and a DISTANCE/CLUSTER/MERGE query | The oracle runs across all targets | Every engine agrees across all branches and empty inputs | Scalar/window/aggregate identity |
| 6 | `TestCrossTargetOracleNearest` / `Disjoin` | A NEAREST or DISJOIN query on DataFusion | The oracle runs the full target set | DataFusion raises its documented limitation pending #142 / #153 while DuckDB returns the expected rows | Engine-gap pins |
| 7 | `TestCrossTargetOracleDataShapes` | Multi-chrom, empty, half-open boundary, and bin-spanning data | The oracle runs a join | Engines agree on every data shape, including 1bp overlap and bin-dedup multiplicity | Data-shape coverage |
| 8 | `TestRunDuckDB` / `TestRunDataFusion` / `TestRawRegisterRecordBatchesEmpty` / `TestCrossRunnerParity` | A table registered into each engine | The runners execute a trivial query | Schema, reserved-word quoting, empty tables, and output shape match across runners | Engine runner internals |
| 9 | `TestSharedOracleReuse` | The oracle helpers without an engine installed | They are imported and exercised | Routing and comparison run engine-free from any lane | Cross-lane reuse |
