### PR TITLE
Resolve genomic columns for CLUSTER/MERGE over a derived-table FROM — Closes #164

### DIFF
--- a/src/giql/expanders/_genomic.py
+++ b/src/giql/expanders/_genomic.py
@@ -3,9 +3,9 @@
 The CLUSTER (:mod:`giql.expanders.cluster`) and MERGE
 (:mod:`giql.expanders.merge`) expanders are both **whole-query rewrites** built
 on the same generic plumbing: resolve the genomic columns of an enclosing FROM
-table, locate the operator in a top-level projection, guard the shapes that have
-no coherent rewrite, and transplant a freshly-built SELECT onto the original in
-place. None of that plumbing is specific to either operator.
+source/relation, locate the operator in a top-level projection, guard the shapes
+that have no coherent rewrite, and transplant a freshly-built SELECT onto the
+original in place. None of that plumbing is specific to either operator.
 
 This module is that shared surface — "operator-neutral" in that no helper is
 specific to one operator. The lone exception proves the rule: the CLUSTER/MERGE
@@ -38,6 +38,7 @@ from giql.constants import DEFAULT_START_COL
 from giql.constants import DEFAULT_STRAND_COL
 from giql.expressions import GIQLCluster
 from giql.expressions import GIQLMerge
+from giql.table import Table
 from giql.table import Tables
 
 _T = TypeVar("_T", bound=exp.Expression)
@@ -57,35 +58,176 @@ class GenomicColumns(NamedTuple):
     strand: str
 
 
+_CANONICAL_COLUMNS = GenomicColumns(
+    DEFAULT_CHROM_COL, DEFAULT_START_COL, DEFAULT_END_COL, DEFAULT_STRAND_COL
+)
+
+
 def genomic_columns(select: exp.Select, tables: Tables) -> GenomicColumns:
-    """Return the ``(chrom, start, end, strand)`` columns for *select*'s FROM table.
+    """Return the ``(chrom, start, end, strand)`` columns for *select*'s FROM source.
 
-    Part of the shared, operator-neutral CLUSTER/MERGE expansion toolkit. Mirrors
-    the legacy ``ClusterTransformer._get_genomic_columns`` / ``_get_table_name``:
-    read the FROM-clause table name, look it up in *tables*, and use its configured
-    column names, falling back to the canonical defaults (and to the default strand
-    column when the table declares none).
+    Part of the shared, operator-neutral CLUSTER/MERGE expansion toolkit. Resolves
+    the physical genomic columns of the enclosing FROM relation: a bare registered
+    table yields its configured mapping (and the default strand column when the table
+    declares none); a derived table or CTE is resolved *through* to the underlying
+    table when the subquery passes its columns through unchanged (``SELECT *`` /
+    ``SELECT alias.*``). An unregistered table, an empty FROM, or a projection that
+    already exposes the canonical ``chrom`` / ``start`` / ``end`` columns falls back
+    to those defaults.
+
+    Unlike ``validate_projection_contracts`` / ``_resolve_disjoin_reference`` in
+    ``resolver.py``, which require canonical columns from an operator's reference
+    *operands*, this deliberately traces a star-passthrough FROM *source* to its
+    physical columns — CLUSTER/MERGE operate over the enclosing relation's own
+    coordinates, a different operator semantics. That FROM-source resolution lives in
+    the CLUSTER/MERGE toolkit rather than the pass-1 resolver because it serves the
+    whole-query rewrite's need to name the physical window/grouping columns, not the
+    resolver's reference-slot contract validation.
+
+    :raises ValueError: When the FROM source is an untraceable relation — a derived
+        table, CTE, ``VALUES``, table-valued function, or ``LATERAL`` — whose genomic
+        columns cannot be determined (it neither exposes the canonical columns nor
+        resolves to a single registered mapping), or when the FROM combines multiple
+        sources through a join. Silently defaulting to the canonical columns in these
+        cases would emit SQL referencing columns that do not exist, so the ambiguity
+        is surfaced instead (#164).
     """
-    table_name: str | None = None
+    if select.args.get("joins"):
+        # Only the query being rewritten carries a join that ``transplant`` would
+        # drop; a join nested inside a derived-table/CTE body is preserved intact,
+        # so the rejection guards the top-level FROM, not the recursive descent.
+        raise ValueError(
+            "CLUSTER/MERGE over a join is not supported; run it over a single "
+            "relation, or over a subquery."
+        )
+    mapping, opaque = _resolve_from_columns(select, tables, frozenset())
+    if mapping is not None:
+        return mapping
+    if opaque:
+        raise ValueError(
+            "Cannot resolve the genomic columns for CLUSTER/MERGE over this FROM "
+            "clause: it is a derived table or CTE that neither exposes the canonical "
+            f"{DEFAULT_CHROM_COL!r} / {DEFAULT_START_COL!r} / {DEFAULT_END_COL!r} "
+            "columns nor resolves to a single registered table. Alias the genomic "
+            "columns to their canonical names inside the subquery, or run "
+            "CLUSTER/MERGE directly over a registered table."
+        )
+    return _CANONICAL_COLUMNS
+
+
+def _resolve_from_columns(
+    select: exp.Select, tables: Tables, seen: frozenset[str]
+) -> tuple[GenomicColumns | None, bool]:
+    """Resolve *select*'s driving FROM source to a ``(mapping, opaque)`` result.
+
+    *mapping* is the resolved :class:`GenomicColumns` when a registered mapping backs
+    the source, else ``None``. *opaque* is ``True`` when the source is a derived
+    table/CTE whose columns could not be traced — a signal the caller turns into a
+    hard error rather than a silent canonical default.
+
+    Only the driving ``from_`` relation is resolved; any joins are ignored. A join on
+    the top-level rewrite target is rejected upstream in :func:`genomic_columns`,
+    while a join inside a traced-through derived-table/CTE body is preserved by the
+    rewrite, so its column list is taken from the driving relation as before (#164).
+    """
     from_clause = select.args.get("from_")
-    if from_clause is not None and isinstance(from_clause.this, exp.Table):
-        table_name = from_clause.this.name
+    if from_clause is None:
+        return None, False
+    return _resolve_source(from_clause.this, select, tables, seen)
 
-    chrom_col = DEFAULT_CHROM_COL
-    start_col = DEFAULT_START_COL
-    end_col = DEFAULT_END_COL
-    strand_col = DEFAULT_STRAND_COL
 
-    if table_name:
-        table = tables.get(table_name)
-        if table:
-            chrom_col = table.chrom_col
-            start_col = table.start_col
-            end_col = table.end_col
-            if table.strand_col:
-                strand_col = table.strand_col
+def _resolve_source(
+    source: exp.Expression,
+    enclosing: exp.Select,
+    tables: Tables,
+    seen: frozenset[str],
+) -> tuple[GenomicColumns | None, bool]:
+    """Resolve one FROM/JOIN *source* node to a ``(mapping, opaque)`` result."""
+    if isinstance(source, exp.Table):
+        name = source.name
+        cte_query = _find_cte(enclosing, name)
+        if cte_query is not None:
+            if name in seen:
+                # A CTE that (transitively) selects from itself: stop recursing and
+                # report it untraceable rather than looping forever.
+                return None, True
+            return _resolve_query(cte_query, tables, seen | {name})
+        table = tables.get(name)
+        if table is not None:
+            return _mapping_for(table), False
+        # An unregistered bare table is assumed to expose the canonical columns,
+        # matching how the resolver treats unknown relations elsewhere.
+        return None, False
+    if isinstance(source, exp.Subquery):
+        return _resolve_query(source.this, tables, seen)
+    # A LATERAL, VALUES, or table-valued function has no traceable table mapping.
+    return None, True
 
-    return GenomicColumns(chrom_col, start_col, end_col, strand_col)
+
+def _resolve_query(
+    query: exp.Expression, tables: Tables, seen: frozenset[str]
+) -> tuple[GenomicColumns | None, bool]:
+    """Resolve the columns a derived-table/CTE *query* exposes to ``(mapping, opaque)``.
+
+    Any projection *containing* a star — a bare ``*``, a qualified ``alias.*``, or a
+    star alongside other items (``SELECT r.*, 1 AS extra``) — passes its FROM
+    source's columns through, so the mapping is resolved from that source. An explicit
+    projection instead names the output columns directly: it is transparent only when
+    it re-exposes the canonical genomic columns, otherwise its genomic columns cannot
+    be named and the source is reported opaque.
+    """
+    if isinstance(query, exp.SetOperation):
+        # A set operation's arms share one column list; the left arm determines it.
+        return _resolve_query(query.left, tables, seen)
+    if not isinstance(query, exp.Select):
+        # Defensive: a parenthesized subquery / set-operation arm the grammar can
+        # reach is always a SELECT or a SetOperation (caught above, including
+        # INTERSECT / EXCEPT), so this total-function guard for any other body (e.g. a
+        # bare VALUES, which instead parses as an un-wrapped FROM source handled in
+        # _resolve_source) is not reachable via a GIQL query.
+        return None, True
+
+    projections = query.expressions
+    passes_through = any(
+        isinstance(projection, exp.Star)
+        or (isinstance(projection, exp.Column) and isinstance(projection.this, exp.Star))
+        for projection in projections
+    )
+    if passes_through:
+        return _resolve_from_columns(query, tables, seen)
+
+    output_names = {
+        projection.alias if isinstance(projection, exp.Alias) else projection.name
+        for projection in projections
+        if isinstance(projection, (exp.Alias, exp.Column))
+    }
+    canonical = {DEFAULT_CHROM_COL, DEFAULT_START_COL, DEFAULT_END_COL}
+    if canonical <= output_names:
+        return None, False
+    return None, True
+
+
+def _find_cte(select: exp.Select, name: str) -> exp.Expression | None:
+    """Return the query body of an enclosing CTE named *name*, or ``None``."""
+    node: exp.Expression | None = select
+    while node is not None:
+        with_clause = node.args.get("with_")
+        if with_clause is not None:
+            for cte in with_clause.expressions:
+                if cte.alias.lower() == name.lower():
+                    return cte.this
+        node = node.parent
+    return None
+
+
+def _mapping_for(table: Table) -> GenomicColumns:
+    """Return the genomic column mapping configured on a registered *table*."""
+    return GenomicColumns(
+        table.chrom_col,
+        table.start_col,
+        table.end_col,
+        table.strand_col or DEFAULT_STRAND_COL,
+    )
 
 
 def extract_stranded(stranded_expr: exp.Expression | None) -> bool:

--- a/tests/expanders/test_genomic_columns.py
+++ b/tests/expanders/test_genomic_columns.py
@@ -1,0 +1,623 @@
+"""Genomic-column resolution for CLUSTER/MERGE over a derived-table FROM (#164).
+
+CLUSTER and MERGE derive their partition/order/aggregation columns from the
+enclosing FROM relation through the shared CLUSTER/MERGE resolution toolkit.
+These tests drive the public ``transpile`` API and pin the resolution the #164
+fix newly performs: tracing the genomic columns *through* a derived table or CTE
+to the underlying registered mapping, honoring an explicit projection that
+re-exposes the canonical columns, and raising a clear ``ValueError`` when the
+source is opaque or combines multiple relations through a join — rather than
+silently defaulting
+to the canonical ``chrom`` / ``start`` / ``end`` names and emitting SQL that
+references columns that do not exist.
+
+The behavior is operator-neutral (both expanders call the same resolver), so the
+resolver branches are exercised through CLUSTER, with dedicated MERGE tests
+pinning that the shared resolver reaches MERGE and composes with its GROUP BY /
+aggregation layer.
+"""
+
+import pytest
+
+from giql.table import Table
+from giql.transpile import transpile
+
+
+def _query(op, source):
+    """Build a CLUSTER or MERGE query over *source* for operator-parametrized tests."""
+    if op == "CLUSTER":
+        return f"SELECT *, CLUSTER(interval) AS cid FROM {source}"
+    return f"SELECT MERGE(interval) FROM {source}"
+
+
+@pytest.fixture
+def custom():
+    """A ``regions`` table declaring non-canonical genomic column names."""
+    return Table("regions", chrom_col="ch", start_col="s", end_col="e")
+
+
+class TestGenomicColumnResolution:
+    """Resolution of genomic columns for CLUSTER/MERGE over a derived FROM (#164)."""
+
+    def test_transpile_should_emit_custom_window_when_cluster_over_derived_table(
+        self, custom
+    ):
+        """Test a CLUSTER over a ``SELECT *`` derived table uses the custom columns.
+
+        Given:
+            A CLUSTER whose FROM is a ``SELECT *`` subquery over a table declaring
+            custom column names.
+        When:
+            Transpiling the query.
+        Then:
+            The window should partition/order/LAG on the underlying custom columns,
+            not the canonical defaults — resolution traces through the subquery
+            instead of silently defaulting (the #164 fix).
+        """
+        # Arrange
+        query = "SELECT *, CLUSTER(interval) AS cid FROM (SELECT * FROM regions) AS sub"
+
+        # Act
+        sql = transpile(query, tables=[custom])
+
+        # Assert
+        assert 'PARTITION BY "ch" ORDER BY "s" NULLS LAST' in sql
+        assert 'LAG("e")' in sql
+        assert '"chrom"' not in sql and '"start"' not in sql and '"end"' not in sql
+
+    def test_transpile_should_emit_custom_aggregation_when_merge_over_derived_table(
+        self, custom
+    ):
+        """Test a MERGE over a ``SELECT *`` derived table uses the custom columns.
+
+        Given:
+            A MERGE whose FROM is a ``SELECT *`` subquery over a table declaring
+            custom column names.
+        When:
+            Transpiling the query.
+        Then:
+            The clustered aggregation should group and MIN/MAX on the underlying
+            custom columns — proving the shared resolver reaches MERGE and composes
+            with its GROUP BY / aggregation layer.
+        """
+        # Arrange
+        query = "SELECT MERGE(interval) FROM (SELECT * FROM regions) AS sub"
+
+        # Act
+        sql = transpile(query, tables=[custom])
+
+        # Assert
+        assert 'MIN("s") AS s' in sql and 'MAX("e") AS e' in sql
+        assert 'GROUP BY "ch"' in sql
+        assert '"chrom"' not in sql and '"start"' not in sql and '"end"' not in sql
+
+    def test_transpile_should_resolve_custom_columns_when_from_is_qualified_star(
+        self, custom
+    ):
+        """Test resolution through a derived table projecting a qualified star.
+
+        Given:
+            A CLUSTER over a derived table whose projection is ``alias.*`` rather
+            than a bare ``*``.
+        When:
+            Transpiling the query.
+        Then:
+            The qualified star should pass its columns through, resolving to the
+            underlying custom mapping.
+        """
+        # Arrange
+        query = (
+            "SELECT *, CLUSTER(interval) AS cid "
+            "FROM (SELECT sub.* FROM regions sub) AS d"
+        )
+
+        # Act
+        sql = transpile(query, tables=[custom])
+
+        # Assert
+        assert 'PARTITION BY "ch" ORDER BY "s" NULLS LAST' in sql
+        assert '"chrom"' not in sql
+
+    def test_transpile_should_resolve_custom_columns_when_star_mixed_with_projection(
+        self, custom
+    ):
+        """Test a star mixed with an extra projection still passes columns through.
+
+        Given:
+            A CLUSTER over a derived table projecting ``alias.*`` alongside an extra
+            computed column.
+        When:
+            Transpiling the query.
+        Then:
+            The presence of the star makes the source a passthrough, so it resolves
+            to the underlying custom mapping.
+        """
+        # Arrange
+        query = (
+            "SELECT *, CLUSTER(interval) AS cid "
+            "FROM (SELECT r.*, 1 AS extra FROM regions r) AS sub"
+        )
+
+        # Act
+        sql = transpile(query, tables=[custom])
+
+        # Assert
+        assert 'PARTITION BY "ch" ORDER BY "s" NULLS LAST' in sql
+        assert '"chrom"' not in sql
+
+    def test_transpile_should_resolve_custom_columns_when_from_is_cte(self, custom):
+        """Test resolution through a pass-through CTE to the underlying table.
+
+        Given:
+            A CLUSTER whose FROM references a ``SELECT *`` CTE over a custom-mapped
+            table.
+        When:
+            Transpiling the query.
+        Then:
+            It should resolve through the CTE to the custom columns. (The rewrite
+            drops the enclosing WITH clause — a pre-existing transplant limitation
+            tracked by #174, orthogonal to this column resolution — so only the
+            resolved columns are asserted, not executability.)
+        """
+        # Arrange
+        query = (
+            "WITH sub AS (SELECT * FROM regions) "
+            "SELECT *, CLUSTER(interval) AS cid FROM sub"
+        )
+
+        # Act
+        sql = transpile(query, tables=[custom])
+
+        # Assert
+        assert 'PARTITION BY "ch" ORDER BY "s" NULLS LAST' in sql
+        assert '"chrom"' not in sql
+
+    def test_transpile_should_resolve_custom_columns_when_from_is_nested_derived_table(
+        self, custom
+    ):
+        """Test resolution recurses through nested derived tables.
+
+        Given:
+            A CLUSTER whose FROM is a ``SELECT *`` derived table wrapping another
+            ``SELECT *`` derived table over a custom-mapped source.
+        When:
+            Transpiling the query.
+        Then:
+            Resolution should recurse through both levels to the custom columns.
+        """
+        # Arrange
+        query = (
+            "SELECT *, CLUSTER(interval) AS cid "
+            "FROM (SELECT * FROM (SELECT * FROM regions) a) b"
+        )
+
+        # Act
+        sql = transpile(query, tables=[custom])
+
+        # Assert
+        assert 'PARTITION BY "ch" ORDER BY "s" NULLS LAST' in sql
+        assert '"chrom"' not in sql
+
+    @pytest.mark.parametrize("setop", ["UNION ALL", "INTERSECT", "EXCEPT"])
+    def test_transpile_should_resolve_left_arm_when_from_is_set_operation_derived_table(
+        self, setop, custom
+    ):
+        """Test a set-operation-bodied derived table resolves via its left arm.
+
+        Given:
+            A CLUSTER over a derived table whose body combines a custom-mapped
+            ``regions`` (left arm) with a differently-mapped ``regions2`` (right arm)
+            through UNION ALL / INTERSECT / EXCEPT.
+        When:
+            Transpiling the query.
+        Then:
+            It should not raise and should resolve to the LEFT arm's mapping — the
+            left table's physical columns appear in the emitted SQL and the right
+            arm's do not, proving the left arm alone determines the resolution across
+            every set-operation keyword (INTERSECT / EXCEPT no longer over-raise).
+        """
+        # Arrange
+        regions2 = Table("regions2", chrom_col="seqid", start_col="lo", end_col="hi")
+        query = (
+            "SELECT *, CLUSTER(interval) AS cid "
+            f"FROM (SELECT * FROM regions {setop} SELECT * FROM regions2) AS sub"
+        )
+
+        # Act
+        sql = transpile(query, tables=[custom, regions2])
+
+        # Assert
+        assert 'PARTITION BY "ch" ORDER BY "s" NULLS LAST' in sql
+        assert '"seqid"' not in sql and '"lo"' not in sql and '"hi"' not in sql
+
+    def test_transpile_should_resolve_custom_columns_when_cte_defined_on_ancestor(
+        self, custom
+    ):
+        """Test a CTE defined on an ancestor SELECT is found by the resolver.
+
+        Given:
+            A MERGE nested in a subquery whose FROM references a CTE defined on the
+            enclosing root SELECT.
+        When:
+            Transpiling the query.
+        Then:
+            The resolver should walk up to the ancestor's WITH clause and resolve
+            the custom columns.
+        """
+        # Arrange
+        query = (
+            "WITH c AS (SELECT * FROM regions) "
+            "SELECT * FROM (SELECT MERGE(interval) FROM c) z"
+        )
+
+        # Act
+        sql = transpile(query, tables=[custom])
+
+        # Assert
+        assert 'GROUP BY "ch"' in sql
+        assert '"chrom"' not in sql
+
+    def test_transpile_should_prefer_cte_body_over_registered_table_of_same_name(self):
+        """Test a CTE shadowing a registered table resolves through the CTE body.
+
+        Given:
+            A CLUSTER over a CTE named identically to a registered table, whose body
+            selects from a *different* registered table with its own mapping.
+        When:
+            Transpiling the query.
+        Then:
+            The CTE body should win (resolution checks CTEs before registered
+            tables), so the columns come from the CTE's underlying source, not the
+            shadowed same-named table.
+        """
+        # Arrange
+        regions = Table("regions", chrom_col="ch", start_col="s", end_col="e")
+        realsrc = Table("realsrc", chrom_col="rc", start_col="rs", end_col="re_")
+        query = (
+            "WITH regions AS (SELECT * FROM realsrc) "
+            "SELECT *, CLUSTER(interval) AS cid FROM regions"
+        )
+
+        # Act
+        sql = transpile(query, tables=[regions, realsrc])
+
+        # Assert
+        assert 'PARTITION BY "rc" ORDER BY "rs" NULLS LAST' in sql
+        assert 'LAG("re_")' in sql
+        assert '"ch"' not in sql
+
+    def test_transpile_should_resolve_partial_custom_mapping_through_derived_table(self):
+        """Test a partial custom mapping resolves field-by-field through a subquery.
+
+        Given:
+            A CLUSTER over a ``SELECT *`` derived table whose source customizes only
+            the chromosome column and leaves start/end at their defaults.
+        When:
+            Transpiling the query.
+        Then:
+            The window should mix the custom chromosome with the default start/end,
+            exactly as the mapping declares.
+        """
+        # Arrange
+        regions = Table("regions", chrom_col="ch")
+        query = "SELECT *, CLUSTER(interval) AS cid FROM (SELECT * FROM regions) AS sub"
+
+        # Act
+        sql = transpile(query, tables=[regions])
+
+        # Assert
+        assert 'PARTITION BY "ch" ORDER BY "start" NULLS LAST' in sql
+        assert 'LAG("end")' in sql
+
+    def test_transpile_should_partition_by_custom_strand_when_stranded_over_derived(
+        self,
+    ):
+        """Test a stranded CLUSTER resolves the custom strand column through a subquery.
+
+        Given:
+            A stranded CLUSTER over a ``SELECT *`` derived table whose source
+            declares a custom strand column.
+        When:
+            Transpiling the query.
+        Then:
+            The window partition should include the custom strand column.
+        """
+        # Arrange
+        regions = Table(
+            "regions", chrom_col="ch", start_col="s", end_col="e", strand_col="st"
+        )
+        query = (
+            "SELECT *, CLUSTER(interval, stranded := true) AS cid "
+            "FROM (SELECT * FROM regions) AS sub"
+        )
+
+        # Act
+        sql = transpile(query, tables=[regions])
+
+        # Assert
+        assert 'PARTITION BY "ch", "st" ORDER BY "s" NULLS LAST' in sql
+
+    def test_transpile_should_use_default_strand_when_table_declares_none_over_derived(
+        self,
+    ):
+        """Test a stranded CLUSTER falls back to the default strand column.
+
+        Given:
+            A stranded CLUSTER over a ``SELECT *`` derived table whose source
+            declares no strand column.
+        When:
+            Transpiling the query.
+        Then:
+            The window partition should fall back to the canonical ``strand``
+            column alongside the custom chromosome.
+        """
+        # Arrange
+        regions = Table(
+            "regions", chrom_col="ch", start_col="s", end_col="e", strand_col=None
+        )
+        query = (
+            "SELECT *, CLUSTER(interval, stranded := true) AS cid "
+            "FROM (SELECT * FROM regions) AS sub"
+        )
+
+        # Act
+        sql = transpile(query, tables=[regions])
+
+        # Assert
+        assert 'PARTITION BY "ch", "strand" ORDER BY "s" NULLS LAST' in sql
+
+    @pytest.mark.parametrize("op", ["CLUSTER", "MERGE"])
+    def test_transpile_should_resolve_canonical_when_derived_reexposes_canonical_names(
+        self, op, custom
+    ):
+        """Test a derived table re-aliasing to canonical names resolves to canonical.
+
+        Given:
+            A CLUSTER/MERGE over a derived table whose explicit projection aliases
+            the custom columns back to the canonical ``chrom`` / ``start`` / ``end``
+            names.
+        When:
+            Transpiling the query.
+        Then:
+            It should not raise and should resolve to the canonical columns the
+            subquery re-exposes — emitting the full canonical window/group shape
+            while the underlying custom columns never leak.
+        """
+        # Arrange
+        source = "(SELECT ch AS chrom, s AS start, e AS end FROM regions) AS sub"
+        query = _query(op, source)
+
+        # Act
+        sql = transpile(query, tables=[custom])
+
+        # Assert
+        if op == "CLUSTER":
+            assert 'PARTITION BY "chrom" ORDER BY "start"' in sql
+        else:
+            assert 'GROUP BY "chrom"' in sql
+        assert '"ch"' not in sql
+
+    def test_transpile_should_fall_back_to_canonical_when_derived_table_unregistered(
+        self,
+    ):
+        """Test a derived table over an unregistered source defaults to canonical.
+
+        Given:
+            A CLUSTER over a ``SELECT *`` derived table whose source table is not
+            registered.
+        When:
+            Transpiling the query.
+        Then:
+            It should not raise and should fall back to the canonical columns, as an
+            unregistered relation is assumed canonical.
+        """
+        # Arrange
+        query = "SELECT *, CLUSTER(interval) AS cid FROM (SELECT * FROM unknown) AS sub"
+
+        # Act
+        sql = transpile(query, tables=[])
+
+        # Assert
+        assert 'PARTITION BY "chrom" ORDER BY "start" NULLS LAST' in sql
+
+    def test_transpile_should_fall_back_to_canonical_when_no_from_clause(self):
+        """Test a CLUSTER with no FROM clause defaults to the canonical columns.
+
+        Given:
+            A CLUSTER whose enclosing SELECT has no FROM clause.
+        When:
+            Transpiling the query.
+        Then:
+            It should not raise and should fall back to the canonical columns, as
+            there is no source relation to resolve.
+        """
+        # Arrange
+        query = "SELECT CLUSTER(interval) AS cid"
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+
+        # Assert
+        assert 'PARTITION BY "chrom" ORDER BY "start" NULLS LAST' in sql
+
+
+class TestGenomicColumnResolutionErrors:
+    """CLUSTER/MERGE raise when a derived FROM cannot be resolved (#164)."""
+
+    @pytest.mark.parametrize("op", ["CLUSTER", "MERGE"])
+    def test_transpile_should_raise_when_derived_table_hides_genomic_columns(
+        self, op, custom
+    ):
+        """Test an opaque derived-table projection raises instead of defaulting.
+
+        Given:
+            A CLUSTER/MERGE over a derived table whose explicit projection exposes
+            only non-canonical column names.
+        When:
+            Transpiling the query.
+        Then:
+            It should raise a ValueError explaining the source neither exposes the
+            canonical columns nor resolves to a registered table — rather than
+            silently emitting SQL that references non-existent columns.
+        """
+        # Arrange
+        source = "(SELECT ch, s, e FROM regions) AS sub"
+        query = _query(op, source)
+
+        # Act & assert
+        with pytest.raises(ValueError, match="neither exposes the canonical"):
+            transpile(query, tables=[custom])
+
+    def test_transpile_should_raise_when_from_is_a_values_relation(self):
+        """Test a VALUES-relation FROM raises as an untraceable source.
+
+        Given:
+            A CLUSTER whose FROM is a derived table wrapping a VALUES clause.
+        When:
+            Transpiling the query.
+        Then:
+            It should raise a ValueError, as a VALUES body exposes no traceable
+            genomic columns.
+        """
+        # Arrange
+        query = (
+            "SELECT *, CLUSTER(interval) AS cid FROM (VALUES (1, 2, 3)) AS v(a, b, c)"
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match="neither exposes the canonical"):
+            transpile(query, tables=[])
+
+    def test_transpile_should_raise_when_from_is_a_table_valued_function(self):
+        """Test a table-valued-function FROM raises as an untraceable source.
+
+        Given:
+            A CLUSTER whose FROM is a table-valued function (``UNNEST``).
+        When:
+            Transpiling the query.
+        Then:
+            It should raise a ValueError, as a function source has no genomic column
+            mapping.
+        """
+        # Arrange
+        query = "SELECT *, CLUSTER(interval) AS cid FROM UNNEST([1, 2, 3])"
+
+        # Act & assert
+        with pytest.raises(ValueError, match="neither exposes the canonical"):
+            transpile(query, tables=[])
+
+    def test_transpile_should_raise_when_cte_is_recursive(self, custom):
+        """Test a mutually-recursive CTE raises instead of looping forever.
+
+        Given:
+            A CLUSTER over a CTE whose body transitively selects from itself.
+        When:
+            Transpiling the query.
+        Then:
+            The cycle guard should terminate resolution and raise a ValueError
+            rather than recursing without bound.
+        """
+        # Arrange
+        query = (
+            "WITH a AS (SELECT * FROM b), b AS (SELECT * FROM a) "
+            "SELECT *, CLUSTER(interval) AS cid FROM a"
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match="neither exposes the canonical"):
+            transpile(query, tables=[custom])
+
+    def test_transpile_should_raise_when_from_clause_joins_two_relations(self, custom):
+        """Test a join of two identically-mapped relations is rejected.
+
+        Given:
+            A CLUSTER whose FROM joins two tables that declare the same genomic
+            column mapping.
+        When:
+            Transpiling the query.
+        Then:
+            It should raise a ValueError rejecting the join outright — the
+            whole-query rewrite cannot preserve a join, so even agreeing mappings
+            are not resolved.
+        """
+        # Arrange
+        regions2 = Table("regions2", chrom_col="ch", start_col="s", end_col="e")
+        query = (
+            "SELECT *, CLUSTER(interval) AS cid FROM regions a JOIN regions2 b ON TRUE"
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match="over a join is not supported"):
+            transpile(query, tables=[custom, regions2])
+
+    def test_transpile_should_raise_when_join_mixes_concrete_and_opaque_sources(
+        self, custom
+    ):
+        """Test a join of a concrete table and an opaque subquery is rejected.
+
+        Given:
+            A CLUSTER whose FROM joins a registered custom-mapped table with an
+            opaque derived sibling.
+        When:
+            Transpiling the query.
+        Then:
+            It should raise the join rejection rather than silently preferring the
+            concrete mapping and dropping the join partner.
+        """
+        # Arrange
+        query = (
+            "SELECT *, CLUSTER(interval) AS cid "
+            "FROM regions JOIN (SELECT foo FROM regions) q ON TRUE"
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match="over a join is not supported"):
+            transpile(query, tables=[custom])
+
+    @pytest.mark.parametrize("op", ["CLUSTER", "MERGE"])
+    def test_transpile_should_raise_when_from_clause_joins_conflicting_relations(
+        self, op, custom
+    ):
+        """Test a join of two conflicting-mapped relations is rejected as a join.
+
+        Given:
+            A CLUSTER/MERGE whose FROM joins two tables declaring different genomic
+            column mappings.
+        When:
+            Transpiling the query.
+        Then:
+            It should raise the join rejection — the join is refused before any
+            conflicting-mapping comparison is even reached.
+        """
+        # Arrange
+        other = Table("other", chrom_col="seqid", start_col="lo", end_col="hi")
+        source = "regions JOIN other ON TRUE"
+        query = _query(op, source)
+
+        # Act & assert
+        with pytest.raises(ValueError, match="over a join is not supported"):
+            transpile(query, tables=[custom, other])
+
+    def test_transpile_should_raise_when_qualified_star_projects_over_a_join(
+        self, custom
+    ):
+        """Test a qualified ``alias.*`` projection does not sneak past a join.
+
+        Given:
+            A CLUSTER selecting a qualified ``a.*`` over a FROM that joins two
+            relations.
+        When:
+            Transpiling the query.
+        Then:
+            It should still raise the join rejection — qualifying the star to one
+            side does not exempt the FROM from being a join.
+        """
+        # Arrange
+        regions2 = Table("regions2", chrom_col="ch", start_col="s", end_col="e")
+        query = (
+            "SELECT a.*, CLUSTER(interval) AS cid FROM regions a JOIN regions2 b ON TRUE"
+        )
+
+        # Act & assert
+        with pytest.raises(ValueError, match="over a join is not supported"):
+            transpile(query, tables=[custom, regions2])


### PR DESCRIPTION
## Summary

Fix `genomic_columns` so CLUSTER and MERGE resolve the correct physical genomic columns when their FROM clause is a derived table (or, for column resolution, a CTE), instead of silently defaulting to the canonical `chrom` / `start` / `end` names. For a CTE FROM this PR fixes column *resolution* only; end-to-end *executability* is not — the whole-query rewrite still drops the enclosing `WITH` clause, so a CTE FROM currently emits non-executable SQL. That is a pre-existing limitation tracked separately in #174.

Previously the column mapping was read only when the enclosing FROM was a bare `exp.Table`; a derived-table or CTE FROM yielded no table name, so the operators fell back to the canonical columns. When the underlying source used a custom mapping, the emitted SQL then partitioned/ordered/aggregated on columns that do not exist. This was pre-existing behavior carried over from the legacy `ClusterTransformer` and was untested (surfaced as advisory A14 in the #162 / #144 round-2 review).

The fix replaces the bare-table lookup with a recursive resolver that traces the genomic columns through a star-passthrough derived table or CTE to the underlying registered mapping. Any projection containing a star (`SELECT *`, `SELECT alias.*`, or a star alongside extra columns) passes its sources' columns through; an explicit projection is treated as transparent only when it re-exposes the canonical columns; an unregistered table or an empty FROM keeps the canonical default. When the source genuinely cannot be resolved — an opaque derived table whose columns are neither canonical nor traceable — it raises a clear `ValueError` rather than emitting SQL that references non-existent columns. The resolver is reached through the single `genomic_columns` entry point shared by both expanders, so CLUSTER and MERGE are fixed together.

Trade-offs and scope notes:
- CLUSTER/MERGE over a JOIN is unsupported and rejected with a clear `ValueError`. The whole-query rewrite cannot preserve a join (only the driving relation survives `transplant`) and bare genomic-column window/grouping references over a join are inherently ambiguous, so the shape fails loud rather than silently dropping the join. The guard fires only on the query being rewritten; a join nested inside a traced-through derived-table or CTE body is preserved and resolves from that body's driving relation.
- CTE name resolution folds identifier case (the target engines treat identifiers case-insensitively), so a mixed-case or quoted CTE reference resolves rather than silently defaulting to canonical columns.
- Resolving a CTE FROM produces the correct columns, but the whole-query rewrite still drops the enclosing `WITH` clause (a pre-existing limitation in `transplant`, orthogonal to column resolution and reproducible with a canonical table). That is deliberately left out of scope and tracked separately in #174; the CTE tests here assert only column resolution, not executability.

Closes #164

## Proposed changes

### Recursive FROM-source resolution in `giql.expanders._genomic`

Rewrite `genomic_columns` to delegate to a small resolver:
- `genomic_columns` rejects a top-level JOIN FROM with a clear `ValueError` (only the rewritten query's join would be dropped by `transplant`), then delegates to the resolver, raises a `ValueError` for an opaque/unresolvable derived source, and otherwise falls back to the canonical columns.
- `_resolve_from_columns` resolves the driving `from_` relation to a single `(mapping, opaque)` result. Joins on the rewrite target are rejected upstream; a join inside a traced-through body is ignored, so its column list is taken from the driving relation.
- `_resolve_source` classifies a source: a CTE (looked up before registered tables and matched case-insensitively, so a CTE shadows a same-named table), a registered table, an unregistered table (assumed canonical), a derived subquery, or an untraceable source (LATERAL / VALUES / table-valued function).
- `_resolve_query` decides whether a derived-table/CTE body passes its columns through: any projection containing a star resolves from the inner sources; an explicit projection is transparent only when it re-exposes the canonical `chrom` / `start` / `end` names, otherwise the source is opaque. A set-operation body (`UNION` / `INTERSECT` / `EXCEPT`, via `exp.SetOperation`) resolves from its left arm.
- `_find_cte` walks the enclosing `WITH` clauses up the ancestor chain with a case-insensitive name match; a `seen` set guards against a self- or mutually-recursive CTE.
- `_mapping_for` reproduces the existing per-table mapping with the default-strand fallback.

## Test cases

New suite `tests/expanders/test_genomic_columns.py`, driving the public `transpile` API only.

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestGenomicColumnResolution` | A CLUSTER over a `SELECT *` derived table on a custom-mapped table | Transpiling | Window partitions/orders/LAGs on the custom columns, no canonical names | Star-passthrough resolution (the fix) |
| 2 | `TestGenomicColumnResolution` | A MERGE over a `SELECT *` derived table on a custom-mapped table | Transpiling | Aggregation groups and MIN/MAX on the custom columns | MERGE shares the resolver |
| 3 | `TestGenomicColumnResolution` | A derived table projecting `alias.*` | Transpiling | Resolves through to the custom mapping | Qualified-star passthrough |
| 4 | `TestGenomicColumnResolution` | A derived table projecting a star alongside an extra column | Transpiling | Star presence still makes it a passthrough | Mixed-projection passthrough |
| 5 | `TestGenomicColumnResolution` | A pass-through CTE over a custom-mapped table | Transpiling | Resolves through the CTE to the custom columns | CTE column resolution |
| 6 | `TestGenomicColumnResolution` | A derived table wrapping another derived table | Transpiling | Recurses through both levels | Nested resolution |
| 7 | `TestGenomicColumnResolution` | A set-operation-bodied derived table (`UNION ALL` / `INTERSECT` / `EXCEPT`) with a differently-mapped right arm | Transpiling | Left arm determines the columns, no raise | Set-operation resolution |
| 8 | `TestGenomicColumnResolution` | A MERGE whose FROM references a CTE defined on the ancestor SELECT | Transpiling | Resolver walks up to the ancestor `WITH` | Ancestor-CTE lookup |
| 9 | `TestGenomicColumnResolution` | A CTE named identically to a registered table, over a different source | Transpiling | CTE body wins over the shadowed table | CTE-before-table precedence |
| 10 | `TestGenomicColumnResolution` | A source customizing only the chromosome column | Transpiling | Custom chromosome mixes with default start/end | Partial mapping |
| 11 | `TestGenomicColumnResolution` | A stranded CLUSTER over a derived table with a custom strand column | Transpiling | Partition includes the custom strand column | Custom strand |
| 12 | `TestGenomicColumnResolution` | A stranded CLUSTER over a derived table with no strand column | Transpiling | Partition falls back to the default strand column | Strand fallback |
| 13 | `TestGenomicColumnResolution` | A derived table re-aliasing custom columns to canonical names (CLUSTER and MERGE) | Transpiling | Resolves to canonical columns and the custom names are absent | Canonical re-expose |
| 14 | `TestGenomicColumnResolution` | A derived table over an unregistered source | Transpiling | Falls back to canonical columns, no raise | Unregistered default |
| 15 | `TestGenomicColumnResolution` | A CLUSTER with no FROM clause | Transpiling | Falls back to canonical columns | Empty-FROM default |
| 16 | `TestGenomicColumnResolutionErrors` | A derived table whose projection hides the genomic columns (CLUSTER and MERGE) | Transpiling | Raises ValueError explaining the source is unresolvable | Opaque-source error |
| 17 | `TestGenomicColumnResolutionErrors` | A VALUES-relation FROM | Transpiling | Raises ValueError | Untraceable source |
| 18 | `TestGenomicColumnResolutionErrors` | A table-valued-function (`UNNEST`) FROM | Transpiling | Raises ValueError | Untraceable source |
| 19 | `TestGenomicColumnResolutionErrors` | A mutually-recursive CTE | Transpiling | Cycle guard raises rather than looping | Recursion guard |
| 20 | `TestGenomicColumnResolutionErrors` | A top-level JOIN of two relations | Transpiling | Raises ValueError that a join is unsupported | Join rejection |
| 21 | `TestGenomicColumnResolutionErrors` | A top-level JOIN mixing a concrete-mapped and an opaque source | Transpiling | Raises ValueError that a join is unsupported | Join rejection |
| 22 | `TestGenomicColumnResolutionErrors` | A top-level JOIN of tables with conflicting mappings (CLUSTER and MERGE) | Transpiling | Raises ValueError that a join is unsupported | Join rejection |
| 23 | `TestGenomicColumnResolutionErrors` | A qualified `alias.*` projected over a top-level JOIN | Transpiling | Raises ValueError that a join is unsupported | Join rejection |

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM
