### PR TITLE
Use the reserved __giql_ prefix for CLUSTER/MERGE synthesized identifiers — Closes #161

### DIFF
--- a/docs/transpilation/index.rst
+++ b/docs/transpilation/index.rst
@@ -207,7 +207,7 @@ conventions yield the same numeric distance.
          FROM (
              SELECT
                  *,
-                 SUM(is_new_cluster) OVER (
+                 SUM(__giql_is_new_cluster) OVER (
                      PARTITION BY "chrom"
                      ORDER BY "start" NULLS LAST
                  ) AS __giql_cluster_id
@@ -220,9 +220,9 @@ conventions yield the same numeric distance.
                              ORDER BY "start" NULLS LAST
                          ) >= "start" THEN 0
                          ELSE 1
-                     END AS is_new_cluster
+                     END AS __giql_is_new_cluster
                  FROM features
-             ) AS lag_calc
-         ) AS clustered
-         GROUP BY chrom, __giql_cluster_id
+             ) AS __giql_lag_calc
+         ) AS __giql_clustered
+         GROUP BY "chrom", __giql_cluster_id
          ORDER BY "chrom" NULLS LAST, "start" NULLS LAST

--- a/src/giql/constants.py
+++ b/src/giql/constants.py
@@ -21,3 +21,17 @@ DEFAULT_BIN_SIZE = 10_000
 #: resolver's reserved-prefix guard and the DISJOIN expander's CTE names and
 #: guard cannot drift apart.
 DJ_PREFIX = "__giql_dj_"
+
+#: The reserved column name for CLUSTER's synthesized per-row "new cluster" flag
+#: (``CASE ... END AS __giql_is_new_cluster``), consumed by the outer
+#: ``SUM(...) OVER (...)`` window that assigns cluster ids. The reserved ``__giql_``
+#: prefix keeps it clear of user columns: a user column named ``is_new_cluster``
+#: coexisting with ``SELECT *`` otherwise mis-binds the SUM (#161). A single source
+#: of truth so the alias and its ``SUM`` consumer cannot drift apart.
+CLUSTER_FLAG_COL = "__giql_is_new_cluster"
+
+#: The reserved column name for the cluster id MERGE synthesizes
+#: (``CLUSTER(...) AS __giql_cluster_id``) and then groups by. Reserved-prefixed for
+#: the same reason as :data:`CLUSTER_FLAG_COL`; a single source of truth so the alias
+#: and its ``GROUP BY`` consumer cannot drift apart.
+CLUSTER_ID_COL = "__giql_cluster_id"

--- a/src/giql/expanders/cluster.py
+++ b/src/giql/expanders/cluster.py
@@ -10,12 +10,15 @@ expansion restructures the enclosing query into a two-level form::
 
 becomes::
 
-    SELECT *, SUM(is_new_cluster) OVER (PARTITION BY chrom ORDER BY start) AS cluster_id
+    SELECT *,
+           SUM(__giql_is_new_cluster) OVER (PARTITION BY chrom ORDER BY start)
+               AS cluster_id
     FROM (
         SELECT *,
-               CASE WHEN LAG(end) OVER (...) >= start THEN 0 ELSE 1 END AS is_new_cluster
+               CASE WHEN LAG(end) OVER (...) >= start THEN 0 ELSE 1 END
+                    AS __giql_is_new_cluster
         FROM features
-    ) AS lag_calc
+    ) AS __giql_lag_calc
 
 (The ``becomes::`` form is simplified for readability; the emitted SQL quotes
 identifiers and appends ``NULLS LAST`` to the window ORDER BY.)
@@ -50,6 +53,7 @@ from __future__ import annotations
 
 from sqlglot import exp
 
+from giql.constants import CLUSTER_FLAG_COL
 from giql.expander import ExpansionContext
 from giql.expander import expand_operators
 from giql.expander import register
@@ -72,7 +76,7 @@ def expand_cluster(node: GIQLCluster, ctx: ExpansionContext) -> exp.Expression:
     to it through the registry's generic chain (CLUSTER emits identical SQL across
     targets). Locates the enclosing :class:`~sqlglot.expressions.Select`, derives
     the genomic columns from the FROM table, and rewrites that SELECT in place into
-    the two-level ``lag_calc`` form. Returns the original CLUSTER node (now
+    the two-level ``__giql_lag_calc`` form. Returns the original CLUSTER node (now
     unreachable from the rewritten root SELECT) so the pass's ``node.replace`` is a
     no-op.
 
@@ -115,7 +119,7 @@ def expand_cluster(node: GIQLCluster, ctx: ExpansionContext) -> exp.Expression:
         return node
     transplant(select, transformed)
     # copy()+transplant duplicated the enclosing WHERE / HAVING into the new
-    # lag_calc subquery; the originals the pass collected are now unreachable, so
+    # __giql_lag_calc subquery; the originals the pass collected are now unreachable, so
     # re-run the pass over the restructured SELECT to expand any sibling pass-3
     # operators (spatial predicates, DISTANCE) carried into it. Safe from
     # recursion: the CLUSTER node is already replaced by its SUM window. (#144 B1)
@@ -142,7 +146,7 @@ def expand_cluster_query(
     """Restructure *query* for every CLUSTER in its projection; ``None`` if none.
 
     Finds CLUSTER expressions in *query*'s SELECT list and rewrites the query into
-    the two-level ``lag_calc`` form once per CLUSTER (chaining, as the legacy
+    the two-level ``__giql_lag_calc`` form once per CLUSTER (chaining, as the legacy
     transformer did). Operates on *query* directly and returns the rewritten
     query. Returns ``None`` when *query* projects no CLUSTER, so callers can treat
     that as a no-op.
@@ -154,9 +158,10 @@ def expand_cluster_query(
     if not cluster_exprs:
         return None
     if len(cluster_exprs) > 1:
-        # Chaining the rewrite per CLUSTER yields a duplicate ``lag_calc`` alias
-        # and an ``is_new_cluster`` binder error — non-executable SQL. Fail loudly,
-        # mirroring the multiple-MERGE guard, rather than emitting it (#144 A15).
+        # Chaining the rewrite per CLUSTER yields a duplicate ``__giql_lag_calc``
+        # alias and an ``__giql_is_new_cluster`` binder error — non-executable SQL.
+        # Fail loudly, mirroring the multiple-MERGE guard, rather than emitting the
+        # broken SQL (#144 A15).
         raise ValueError("Multiple CLUSTER expressions not yet supported")
     for cluster_expr in cluster_exprs:
         query = _transform_for_cluster(query, cluster_expr, columns)
@@ -166,14 +171,14 @@ def expand_cluster_query(
 def _transform_for_cluster(
     query: exp.Select, cluster_expr: GIQLCluster, columns: GenomicColumns
 ) -> exp.Select:
-    """Rewrite *query* into the two-level ``lag_calc`` form for one CLUSTER.
+    """Rewrite *query* into the two-level ``__giql_lag_calc`` form for one CLUSTER.
 
     A byte-for-byte port of the legacy
     ``ClusterTransformer._transform_for_cluster``, with the genomic columns passed
     in (the legacy method re-derived them from the FROM table) rather than read off
-    ``self``. Builds an inner ``lag_calc`` subquery that materializes an
-    ``is_new_cluster`` flag from a ``LAG`` window, then an outer query whose
-    ``SUM(is_new_cluster) OVER (...)`` window replaces the CLUSTER projection.
+    ``self``. Builds an inner ``__giql_lag_calc`` subquery that materializes an
+    ``__giql_is_new_cluster`` flag from a ``LAG`` window, then an outer query whose
+    ``SUM(__giql_is_new_cluster) OVER (...)`` window replaces the CLUSTER projection.
     """
     chrom_col, start_col, end_col, strand_col = columns
 
@@ -243,7 +248,7 @@ def _transform_for_cluster(
     else:
         keep_together = adjacency
 
-    # Create CASE expression for is_new_cluster
+    # Create CASE expression for __giql_is_new_cluster
     case_expr = exp.Case(
         ifs=[
             exp.If(
@@ -254,7 +259,8 @@ def _transform_for_cluster(
         default=exp.Literal.number(1),
     )
 
-    # Build CTE SELECT expressions (all original except CLUSTER, plus is_new_cluster)
+    # Build CTE SELECT expressions (all original except CLUSTER, plus
+    # __giql_is_new_cluster)
     cte_expressions = []
     for expression in query.expressions:
         # Skip CLUSTER expressions
@@ -272,7 +278,7 @@ def _transform_for_cluster(
     if stranded:
         required_cols.add(strand_col)
 
-    # The predicate is evaluated inside the lag_calc CTE, so every column
+    # The predicate is evaluated inside the __giql_lag_calc CTE, so every column
     # it references (current-row columns and PREV() arguments alike) must
     # be projected into that CTE. Folding them into required_cols makes the
     # scope dependency explicit and keeps the columns available even when a
@@ -300,9 +306,9 @@ def _transform_for_cluster(
     for col in sorted(required_cols - selected_cols):
         cte_expressions.append(exp.column(col, quoted=True))
 
-    # Add is_new_cluster calculation
-    # NOTE: synthesized name; the missing __giql_ reserved prefix is left to #161.
-    cte_expressions.append(exp.alias_(case_expr, "is_new_cluster", quoted=False))
+    # Add __giql_is_new_cluster calculation. The reserved __giql_ prefix keeps the
+    # synthesized flag from colliding with a user column of the same name (#161).
+    cte_expressions.append(exp.alias_(case_expr, CLUSTER_FLAG_COL, quoted=False))
 
     # Build CTE query
     cte_select = exp.Select()
@@ -320,9 +326,9 @@ def _transform_for_cluster(
     if query.args.get("having"):
         cte_select.set("having", query.args["having"].copy())
 
-    # Create outer query with SUM over is_new_cluster
+    # Create outer query with SUM over __giql_is_new_cluster
     sum_window = exp.Window(
-        this=exp.Sum(this=exp.column("is_new_cluster")),
+        this=exp.Sum(this=exp.column(CLUSTER_FLAG_COL)),
         partition_by=partition_cols,
         order=exp.Order(expressions=order_by),
     )
@@ -346,11 +352,13 @@ def _transform_for_cluster(
     new_query = exp.Select()
     new_query.select(*new_expressions, copy=False)
 
-    # Wrap CTE in subquery and set as FROM clause
-    # NOTE: synthesized name; the missing __giql_ reserved prefix is left to #161.
+    # Wrap CTE in subquery and set as FROM clause. The alias carries the reserved
+    # __giql_ prefix for namespace consistency with the other synthesized names
+    # (#161); a derived-table alias never actually collides with a user relation
+    # (it lives in the enclosing query's scope), so this is hygiene, not a fix.
     subquery = exp.Subquery(
         this=cte_select,
-        alias=exp.TableAlias(this=exp.Identifier(this="lag_calc")),
+        alias=exp.TableAlias(this=exp.Identifier(this="__giql_lag_calc")),
     )
     new_query.from_(subquery, copy=False)
 

--- a/src/giql/expanders/merge.py
+++ b/src/giql/expanders/merge.py
@@ -9,13 +9,14 @@ a cluster id, then aggregate ``MIN(start)`` / ``MAX(end)`` per cluster::
 becomes::
 
     SELECT chrom, MIN(start) AS start, MAX(end) AS end
-    FROM (SELECT *, CLUSTER(interval) AS __giql_cluster_id FROM features) AS clustered
+    FROM (SELECT *, CLUSTER(interval) AS __giql_cluster_id FROM features)
+        AS __giql_clustered
     GROUP BY chrom, __giql_cluster_id
     ORDER BY chrom, start
 
 (The ``becomes::`` form is simplified for readability; the emitted SQL quotes
 identifiers, appends ``NULLS LAST``, and the inner ``CLUSTER(...)`` is itself
-expanded into the two-level ``lag_calc`` form.)
+expanded into the two-level ``__giql_lag_calc`` form.)
 
 This module is the AST-expansion replacement for the legacy
 :class:`giql.transformer.MergeTransformer`; it produces the same SQL (the existing
@@ -33,6 +34,7 @@ from __future__ import annotations
 
 from sqlglot import exp
 
+from giql.constants import CLUSTER_ID_COL
 from giql.expander import ExpansionContext
 from giql.expander import expand_operators
 from giql.expander import register
@@ -97,7 +99,7 @@ def expand_merge(node: GIQLMerge, ctx: ExpansionContext) -> exp.Expression:
         # in-projection-expression case; this guards the out-of-projection case.
         return node
     transplant(select, transformed)
-    # copy()+transplant duplicated the enclosing WHERE into the new clustered
+    # copy()+transplant duplicated the enclosing WHERE into the new __giql_clustered
     # subquery; the originals the pass collected are now unreachable, so re-run the
     # pass over the restructured SELECT to expand any sibling pass-3 operators
     # carried into it. Safe from recursion: the MERGE is already gone. (#144 B1)
@@ -143,8 +145,8 @@ def _transform_for_merge(
     with the genomic columns passed in and the intermediate clustered query
     restructured through CLUSTER's shared
     :func:`giql.expanders.cluster.expand_cluster_query` (the legacy method called
-    ``ClusterTransformer.transform``). Builds an inner ``clustered`` subquery that
-    appends ``__giql_cluster_id``, then an outer query that aggregates
+    ``ClusterTransformer.transform``). Builds an inner ``__giql_clustered`` subquery
+    that appends ``__giql_cluster_id``, then an outer query that aggregates
     ``MIN(start)`` / ``MAX(end)`` per cluster.
     """
     chrom_col, start_col, end_col, strand_col = columns
@@ -169,10 +171,10 @@ def _transform_for_merge(
     # Start with original query's FROM/WHERE/etc
     cluster_query = exp.Select()
     cluster_query.select(exp.Star(), copy=False)
-    # NOTE: __giql_cluster_id carries the reserved prefix; the un-prefixed
-    # `clustered` / `lag_calc` / `is_new_cluster` siblings are left to #161.
+    # __giql_cluster_id and its ``__giql_clustered`` / ``__giql_lag_calc`` /
+    # ``__giql_is_new_cluster`` siblings all carry the reserved prefix (#161).
     cluster_query.select(
-        exp.alias_(cluster_expr, "__giql_cluster_id", quoted=False),
+        exp.alias_(cluster_expr, CLUSTER_ID_COL, quoted=False),
         append=True,
         copy=False,
     )
@@ -200,7 +202,7 @@ def _transform_for_merge(
     if stranded:
         group_by_cols.append(exp.column(strand_col, quoted=True))
 
-    group_by_cols.append(exp.column("__giql_cluster_id"))
+    group_by_cols.append(exp.column(CLUSTER_ID_COL))
 
     # Build SELECT expressions for merged intervals
     select_exprs = []
@@ -237,10 +239,13 @@ def _transform_for_merge(
     final_query = exp.Select()
     final_query.select(*select_exprs, copy=False)
 
-    # FROM the clustered subquery
+    # FROM the clustered subquery. The alias carries the reserved __giql_ prefix for
+    # namespace consistency with the other synthesized names (#161); a derived-table
+    # alias never actually collides with a user relation (it lives in the enclosing
+    # query's scope), so this is hygiene, not a fix.
     subquery = exp.Subquery(
         this=cluster_query,
-        alias=exp.TableAlias(this=exp.Identifier(this="clustered")),
+        alias=exp.TableAlias(this=exp.Identifier(this="__giql_clustered")),
     )
     final_query.from_(subquery, copy=False)
 

--- a/tests/expanders/test_cluster.py
+++ b/tests/expanders/test_cluster.py
@@ -43,8 +43,8 @@ class TestClusterExpander:
 
         # Assert
         assert "G_I_Q_L" not in sql
-        assert "AS lag_calc" in sql
-        assert "is_new_cluster" in sql
+        assert "AS __giql_lag_calc" in sql
+        assert "__giql_is_new_cluster" in sql
 
     def test_transpile_should_raise_when_multiple_cluster_in_one_select(self):
         """Test that two CLUSTER expressions in one SELECT are rejected.
@@ -56,7 +56,7 @@ class TestClusterExpander:
         Then:
             It should raise ValueError naming the unsupported multiple-CLUSTER
             case, rather than chaining the rewrite into non-executable SQL (a
-            duplicate lag_calc alias / is_new_cluster binder error).
+            duplicate __giql_lag_calc alias / __giql_is_new_cluster binder error).
         """
         # Arrange
         query = (
@@ -134,7 +134,7 @@ class TestClusterExpander:
         # Assert
         window = 'OVER (PARTITION BY "chrom" ORDER BY "start" NULLS LAST)'
         assert f'LAG("end") {window} >= "start"' in sql
-        assert f'{window} + ' not in sql
+        assert f"{window} + " not in sql
 
     def test_transpile_should_split_clauses_between_lag_calc_and_outer_query(self):
         """Test that CLUSTER places clauses at the correct query level.
@@ -158,9 +158,10 @@ class TestClusterExpander:
 
         # Assert
         assert (
-            "WHERE chrom = 'chr1' GROUP BY chrom HAVING COUNT(*) > 1) AS lag_calc" in sql
+            "WHERE chrom = 'chr1' GROUP BY chrom HAVING COUNT(*) > 1) AS __giql_lag_calc"
+            in sql
         )
-        assert ") AS lag_calc ORDER BY chrom" in sql
+        assert ") AS __giql_lag_calc ORDER BY chrom" in sql
 
     def test_transpile_should_expand_bare_cluster_without_alias(self):
         """Test that an un-aliased CLUSTER expands to a bare SUM window.
@@ -181,7 +182,7 @@ class TestClusterExpander:
 
         # Assert
         assert "G_I_Q_L" not in sql
-        assert "SUM(is_new_cluster) OVER" in sql
+        assert "SUM(__giql_is_new_cluster) OVER" in sql
 
     def test_transpile_should_keep_explicit_projection_columns_in_lag_calc(self):
         """Test that explicit (non-star) projection columns flow into lag_calc.
@@ -202,7 +203,7 @@ class TestClusterExpander:
 
         # Assert
         assert "SELECT chrom, start," in sql
-        assert "AS lag_calc" in sql
+        assert "AS __giql_lag_calc" in sql
         assert "G_I_Q_L" not in sql
 
     # Note: CLUSTER combined with an INTERSECTS *join* in the same SELECT is not
@@ -259,7 +260,7 @@ class TestClusterExpander:
 
         # Assert
         assert "G_I_Q_L" not in sql
-        assert sql.count("AS lag_calc") == 2
+        assert sql.count("AS __giql_lag_calc") == 2
 
     @pytest.mark.parametrize("predicate_op", ["INTERSECTS", "CONTAINS", "WITHIN"])
     @pytest.mark.parametrize(
@@ -294,7 +295,7 @@ class TestClusterExpander:
 
         # Assert
         assert "G_I_Q_L" not in sql
-        assert "AS lag_calc" in sql
+        assert "AS __giql_lag_calc" in sql
 
     @pytest.mark.parametrize(
         "query",
@@ -342,7 +343,7 @@ class TestClusterExpander:
         code = (
             "from giql.transpile import transpile; "
             "print(transpile("
-            "\"SELECT chrom, CLUSTER(interval, stranded := true, "
+            '"SELECT chrom, CLUSTER(interval, stranded := true, '
             "predicate := name = PREV(score)) AS c FROM peaks\", tables=['peaks']))"
         )
         base_env = {
@@ -368,3 +369,75 @@ class TestClusterExpander:
         # Assert
         assert out_a == out_b
         assert "G_I_Q_L" not in out_a
+
+    def test_transpile_should_namespace_synthesized_cluster_identifiers(self):
+        """Test that CLUSTER's synthesized identifiers carry the reserved prefix.
+
+        Given:
+            A plain CLUSTER query.
+        When:
+            Transpiling the query.
+        Then:
+            The emitted SQL should alias the synthesized helpers as the reserved
+            __giql_lag_calc and __giql_is_new_cluster identifiers and never emit the
+            bare forms, guarding #161 against a partial revert that would re-collide
+            with a user column named is_new_cluster.
+        """
+        # Arrange
+        query = "SELECT *, CLUSTER(interval) AS cid FROM peaks"
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+
+        # Assert
+        assert "AS __giql_lag_calc" in sql
+        assert "AS __giql_is_new_cluster" in sql
+        assert "AS lag_calc" not in sql
+        assert "AS is_new_cluster" not in sql
+
+    def test_transpile_should_disambiguate_cluster_when_source_has_is_new_cluster_column(
+        self,
+    ):
+        """Test that CLUSTER runs correctly beside a user is_new_cluster column.
+
+        Given:
+            A table carrying a user column literally named is_new_cluster, seeded
+            with a poison value that would corrupt the cumulative SUM if the outer
+            window bound to it instead of CLUSTER's synthesized flag (the pre-#161
+            collision, which executed silently and returned wrong ids).
+        When:
+            Transpiling a star-projected CLUSTER and executing it on DuckDB.
+        Then:
+            The query should execute and return the correct per-partition cluster
+            ids, proving the synthesized flag now lives in the reserved __giql_
+            namespace and no longer collides with the user column, which itself
+            survives unchanged in the output.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE intervals ("
+            'chrom VARCHAR, "start" INTEGER, "end" INTEGER, is_new_cluster INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO intervals VALUES (?, ?, ?, ?)",
+            [
+                ("chr1", 100, 200, 7),  # i1
+                ("chr1", 150, 250, 7),  # overlaps i1 -> same cluster
+                ("chr1", 400, 500, 7),  # separate -> new cluster
+            ],
+        )
+
+        # Act
+        sql = transpile(
+            "SELECT *, CLUSTER(interval) AS cluster_id FROM intervals",
+            tables=["intervals"],
+        )
+        cursor = conn.execute(sql)
+        columns = [desc[0] for desc in cursor.description]
+        rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+        # Assert
+        assert [r["cluster_id"] for r in rows] == [1, 1, 2]
+        assert [r["is_new_cluster"] for r in rows] == [7, 7, 7]

--- a/tests/expanders/test_merge.py
+++ b/tests/expanders/test_merge.py
@@ -136,7 +136,7 @@ class TestMergeExpander:
 
         # Assert
         assert "G_I_Q_L" not in sql
-        assert "AS clustered" in sql
+        assert "AS __giql_clustered" in sql
         assert "__giql_cluster_id" in sql
 
     def test_transpile_should_carry_where_into_clustered_subquery(self):
@@ -158,7 +158,7 @@ class TestMergeExpander:
 
         # Assert
         assert "WHERE chrom = 'chr1'" in sql
-        assert "AS clustered" in sql
+        assert "AS __giql_clustered" in sql
 
     @pytest.mark.parametrize(
         "predicate, message",
@@ -206,7 +206,7 @@ class TestMergeExpander:
 
         # Assert
         assert "G_I_Q_L" not in sql
-        assert "AS clustered" in sql
+        assert "AS __giql_clustered" in sql
         assert "__giql_cluster_id" in sql
 
     @pytest.mark.parametrize("predicate_op", ["INTERSECTS", "CONTAINS", "WITHIN"])
@@ -242,7 +242,7 @@ class TestMergeExpander:
 
         # Assert
         assert "G_I_Q_L" not in sql
-        assert "AS clustered" in sql
+        assert "AS __giql_clustered" in sql
 
     @pytest.mark.parametrize(
         "query",
@@ -290,3 +290,72 @@ class TestMergeExpander:
         # Assert
         assert 'GROUP BY "order"' in sql
         assert "GROUP BY order" not in sql
+
+    def test_transpile_should_namespace_synthesized_merge_identifiers(self):
+        """Test that MERGE's synthesized identifiers carry the reserved prefix.
+
+        Given:
+            A plain MERGE query.
+        When:
+            Transpiling the query.
+        Then:
+            The emitted SQL should alias the synthesized helpers as the reserved
+            __giql_clustered, __giql_lag_calc, and __giql_is_new_cluster identifiers
+            (the latter two composed from CLUSTER) and never emit the bare forms,
+            guarding #161 against a partial revert that would re-collide with user
+            columns named clustered / lag_calc / is_new_cluster.
+        """
+        # Arrange
+        query = "SELECT MERGE(interval) FROM peaks"
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+
+        # Assert
+        assert "AS __giql_clustered" in sql
+        assert "AS __giql_lag_calc" in sql
+        assert "AS __giql_is_new_cluster" in sql
+        assert "AS clustered" not in sql
+        assert "AS lag_calc" not in sql
+        assert "AS is_new_cluster" not in sql
+
+    def test_transpile_should_disambiguate_merge_when_source_has_is_new_cluster_column(
+        self,
+    ):
+        """Test that MERGE merges correctly beside a user is_new_cluster column.
+
+        Given:
+            A table carrying a user column literally named is_new_cluster, seeded
+            with a poison value. MERGE always composes CLUSTER over ``SELECT *``, so
+            pre-#161 the outer SUM bound to the user column and produced wrong
+            cluster ids, silently splitting rows that should merge.
+        When:
+            Transpiling the MERGE and executing it on DuckDB.
+        Then:
+            Overlapping intervals should collapse into one merged row and the
+            separate interval into another, proving the synthesized flag now lives
+            in the reserved __giql_ namespace and no longer collides.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE intervals ("
+            'chrom VARCHAR, "start" INTEGER, "end" INTEGER, is_new_cluster INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO intervals VALUES (?, ?, ?, ?)",
+            [
+                ("chr1", 1, 5, 7),  # overlaps the next -> one cluster
+                ("chr1", 3, 8, 7),
+                ("chr1", 20, 25, 7),  # separate -> its own cluster
+            ],
+        )
+
+        # Act
+        sql = transpile("SELECT MERGE(interval) FROM intervals", tables=["intervals"])
+        cursor = conn.execute(sql)
+        rows = cursor.fetchall()
+
+        # Assert
+        assert rows == [("chr1", 1, 8), ("chr1", 20, 25)]

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -1546,6 +1546,7 @@ class TestStatementFinalizer:
             It should raise TypeError rather than silently returning the
             non-Expression, mirroring the node-local expander return guard.
         """
+
         # Arrange
         def expander(node, ctx):
             ctx.add_statement_finalizer(lambda root: None)
@@ -1691,9 +1692,9 @@ class TestClusterMergeExpansion:
             Running the ExpandOperators pass.
         Then:
             It should consume the CLUSTER node in place (returning the same root
-            object), wrap the source in a ``lag_calc`` derived table with a LAG
-            window and an ``is_new_cluster`` CASE, project an outer SUM window, and
-            mint no expander alias.
+            object), wrap the source in a ``__giql_lag_calc`` derived table with a
+            LAG window and an ``__giql_is_new_cluster`` CASE, project an outer SUM
+            window, and mint no expander alias.
         """
         # Arrange
         ast, tables = _prepare_operator(GIQLCluster)
@@ -1705,7 +1706,7 @@ class TestClusterMergeExpansion:
         assert result is ast  # whole-query rewrite mutates the root in place
         assert not list(result.find_all(GIQLCluster))
         aliases = {sub.alias for sub in result.find_all(exp.Subquery) if sub.alias}
-        assert "lag_calc" in aliases
+        assert "__giql_lag_calc" in aliases
         windows = list(result.find_all(exp.Window))
         assert any(isinstance(w.this, exp.Sum) for w in windows)  # outer cluster id
         assert any(
@@ -1713,7 +1714,7 @@ class TestClusterMergeExpansion:
             for w in windows
         )  # inner adjacency LAG
         assert any(
-            isinstance(a, exp.Alias) and a.alias == "is_new_cluster"
+            isinstance(a, exp.Alias) and a.alias == "__giql_is_new_cluster"
             for a in result.find_all(exp.Alias)
         )
         assert EXPAND_ALIAS_PREFIX not in result.sql(dialect=GIQLDialect)
@@ -1728,9 +1729,10 @@ class TestClusterMergeExpansion:
             Running the ExpandOperators pass.
         Then:
             It should consume the MERGE node in place (returning the same root
-            object), wrap a ``clustered`` subquery (itself wrapping a ``lag_calc``)
-            under a GROUP BY that includes the synthesized ``__giql_cluster_id``,
-            project MIN/MAX bounds, and mint no expander alias.
+            object), wrap a ``__giql_clustered`` subquery (itself wrapping a
+            ``__giql_lag_calc``) under a GROUP BY that includes the synthesized
+            ``__giql_cluster_id``, project MIN/MAX bounds, and mint no expander
+            alias.
         """
         # Arrange
         ast, tables = _prepare_operator(GIQLMerge)
@@ -1742,8 +1744,8 @@ class TestClusterMergeExpansion:
         assert result is ast  # whole-query rewrite mutates the root in place
         assert not list(result.find_all(GIQLMerge))
         aliases = {sub.alias for sub in result.find_all(exp.Subquery) if sub.alias}
-        assert "clustered" in aliases  # MERGE wraps the clustered subquery
-        assert "lag_calc" in aliases  # built on CLUSTER
+        assert "__giql_clustered" in aliases  # MERGE wraps the clustered subquery
+        assert "__giql_lag_calc" in aliases  # built on CLUSTER
         group = result.find(exp.Group)
         assert group is not None
         assert any(
@@ -1758,9 +1760,7 @@ class TestClusterMergeExpansion:
 class TestMigratedOperatorsRegistered:
     """Every operator resolves a built-in expander in the process REGISTRY."""
 
-    @pytest.mark.parametrize(
-        "operator", _OPERATOR_CLASSES, ids=lambda c: c.__name__
-    )
+    @pytest.mark.parametrize("operator", _OPERATOR_CLASSES, ids=lambda c: c.__name__)
     def test_migrated_operator_resolves_in_process_registry(self, operator):
         """Test that each operator resolves an expander in REGISTRY.
 


### PR DESCRIPTION
## Summary

Move the three CLUSTER/MERGE synthesized SQL identifiers into the reserved `__giql_` namespace so they cannot collide with user-supplied names. The per-row flag `is_new_cluster`, the CLUSTER derived-table alias `lag_calc`, and the MERGE derived-table alias `clustered` previously lived outside the namespace epic #137 reserves for synthesized names (`giql/expander.py`, `EXPAND_ALIAS_PREFIX`), unlike the already-prefixed `__giql_cluster_id`.

The genuine bug is the `is_new_cluster` flag — a projected column that coexists with `SELECT *`. A user table projecting a real column named `is_new_cluster` collided with the synthesized flag: the inner subquery exposed two `is_new_cluster` columns and the outer `SUM(is_new_cluster) OVER (...)` bound to the wrong one, executing silently and returning corrupted cluster ids for an integer column (or a `BinderException` for a non-integer one). The `lag_calc` / `clustered` renames are namespace hygiene: those are derived-table aliases in a fresh SQL scope, so they never actually shadowed a same-named user column or relation at runtime, but the reserved prefix makes the intent explicit and guards against future reuse.

This intentionally changes the emitted SQL for CLUSTER and MERGE (the synthesized alias names only), so the transpilation-string assertions and the transpilation docs' emitted-SQL example are updated in lockstep.

Closes #161

## Proposed changes

### Reserved-prefix rename in the CLUSTER and MERGE expanders

Rename the synthesized identifiers to `__giql_is_new_cluster` / `__giql_lag_calc` (`src/giql/expanders/cluster.py`) and `__giql_clustered` (`src/giql/expanders/merge.py`), along with their docstring and comment references. Each name is emitted from a single unconditional code path in its expander, so the prefix holds across every parameter variant (stranded, max-gap, predicate, nested).

### Shared constants for the two producer→consumer names

Extract the two names that are aliased in one place and consumed in another — `__giql_is_new_cluster` (aliased in the inner CTE, consumed by the outer `SUM` window) and `__giql_cluster_id` (aliased by MERGE's CLUSTER, consumed by the `GROUP BY`) — to `CLUSTER_FLAG_COL` and `CLUSTER_ID_COL` in `src/giql/constants.py`, and consume them from `cluster.py` / `merge.py`. This mirrors how `disjoin.py` imports `DJ_PREFIX` from the same module, giving each producer→consumer pair a single source of truth so a one-sided typo cannot silently reintroduce the binder error. The single-use derived-table aliases (`__giql_lag_calc`, `__giql_clustered`) stay inline.

### Transpilation-docs oracle fix

`docs/transpilation/index.rst` showed a half-migrated MERGE emitted-SQL example — `__giql_cluster_id` already prefixed alongside bare `is_new_cluster` / `lag_calc` / `clustered`. Update those lines to match the actual transpiler output, and quote the `GROUP BY "chrom"` term the transpiler actually emits.

## Test cases

Update the existing transpilation-string assertions across `tests/expanders/test_cluster.py`, `tests/expanders/test_merge.py`, and `tests/test_expander.py` from the old bare names to the `__giql_` forms, and add the coverage below.

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestClusterExpander` | A DuckDB table with a user column named `is_new_cluster` and a star-projected CLUSTER | The transpiled SQL is executed | It returns the correct per-partition cluster ids and preserves the user column | CLUSTER collision disambiguation (executable) |
| 2 | `TestMergeExpander` | A DuckDB table with a user column named `is_new_cluster` and a MERGE | The transpiled SQL is executed | Overlapping intervals collapse into one merged row and the separate interval into another | MERGE collision disambiguation (executable) |
| 3 | `TestClusterExpander` | A plain CLUSTER query | Transpiling | It aliases the synthesized helpers as `__giql_lag_calc` / `__giql_is_new_cluster` and emits no bare forms | CLUSTER reserved-namespace guard |
| 4 | `TestMergeExpander` | A plain MERGE query | Transpiling | It aliases the synthesized helpers as `__giql_clustered` / `__giql_lag_calc` / `__giql_is_new_cluster` and emits no bare forms | MERGE reserved-namespace guard |

## Review

Round-1 review (`.sdlc/reviews/issue-#161/review-1.md`) returned zero blocking findings across nine reviewers; all findings were advisory. Remediated here: extracting the two producer→consumer names to shared constants (A1), softening the `lag_calc` / `clustered` comments to describe reserved-namespace hygiene rather than a runtime shadowing bug that cannot occur (A2), fixing twin comment/docstring drift (A3), quoting `GROUP BY "chrom"` in the docs oracle (A4), reflowing orphaned comment/docstring fragments (A5), and tightening the AAA phase boundary in the two executable tests (A8). The undocumented `__giql_` namespace contract and a repo-wide reserved-identifier constant convention are deferred to follow-up #178.

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM