### PR TITLE
CLUSTER/MERGE over a CTE FROM drops the WITH clause, emitting non-executable SQL — Closes #174

### DIFF
--- a/src/giql/expanders/_genomic.py
+++ b/src/giql/expanders/_genomic.py
@@ -316,7 +316,8 @@ def reject_cluster_merge_mix(select: exp.Select) -> None:
 
 
 def transplant(select: exp.Select, new: exp.Select) -> None:
-    """Replace *select*'s contents with *new*'s, preserving *select*'s identity.
+    """Replace *select*'s contents with *new*'s (preserving *select*'s enclosing
+    ``WITH``, see below), keeping *select*'s identity.
 
     Part of the shared CLUSTER/MERGE expansion toolkit. Clears every argument of
     *select* and re-installs *new*'s, so *select* keeps its position in the
@@ -328,8 +329,30 @@ def transplant(select: exp.Select, new: exp.Select) -> None:
     ``exp.Select``, as the ``_transform_for_*`` helpers return. Its children are
     re-parented onto *select*, so passing a node still attached elsewhere would
     corrupt that other tree.
+
+    The enclosing ``WITH`` clause is preserved: the ``_transform_for_*`` helpers
+    build *new* from the original's FROM / WHERE / GROUP / HAVING / ORDER but never
+    its top-level ``WITH``, so a CLUSTER/MERGE over a CTE FROM would otherwise drop
+    the enclosing ``WITH`` and dangle the now-undefined CTE reference. That
+    reference is named by the rewritten ``__giql_lag_calc`` subquery (nested, for
+    MERGE, inside its ``__giql_clustered`` aggregation wrapper). Re-attaching
+    *select*'s original ``WITH`` keeps the emitted SQL executable — a CTE is in
+    scope for the entire query, including that nested subquery (#174).
     """
     assert new.parent is None, "transplant() requires a detached `new` subtree"
+    preserved_with = select.args.get("with_")
     select.args.clear()
     for key, value in list(new.args.items()):
         select.set(key, value)
+    # The _transform_for_* helpers populate `new` with only
+    # select/from/where/group/having/order and never a top-level WITH, so
+    # re-attaching the preserved WITH can never clobber one `new` supplies. Assert
+    # that invariant rather than silently dropping the user's CTEs if a future
+    # rewrite ever violates it — the correct behavior there would be to *merge* the
+    # two WITH clauses, not pick one and drop the other.
+    assert new.args.get("with_") is None, (
+        "transplant() cannot reconcile a WITH from `new` with the preserved outer "
+        "WITH; a rewrite that emits its own WITH must merge them explicitly."
+    )
+    if preserved_with is not None:
+        select.set("with_", preserved_with)

--- a/tests/expanders/test_cluster.py
+++ b/tests/expanders/test_cluster.py
@@ -441,3 +441,135 @@ class TestClusterExpander:
         # Assert
         assert [r["cluster_id"] for r in rows] == [1, 1, 2]
         assert [r["is_new_cluster"] for r in rows] == [7, 7, 7]
+
+    @pytest.mark.parametrize(
+        "query, expected_with",
+        [
+            (
+                "WITH sub AS (SELECT * FROM peaks) "
+                "SELECT *, CLUSTER(interval) AS cid FROM sub",
+                "WITH sub AS (SELECT * FROM peaks)",
+            ),
+            (
+                "WITH a AS (SELECT * FROM peaks), sub AS (SELECT * FROM a) "
+                "SELECT *, CLUSTER(interval) AS cid FROM sub",
+                "WITH a AS (SELECT * FROM peaks), sub AS (SELECT * FROM a)",
+            ),
+        ],
+        ids=["single_cte", "chained_ctes"],
+    )
+    def test_transpile_should_preserve_with_clause_when_cluster_over_cte(
+        self, query, expected_with
+    ):
+        """Test that CLUSTER over a CTE FROM keeps the enclosing WITH clause.
+
+        Given:
+            A CLUSTER whose FROM references a CTE — a single CTE, and a chain of
+            two CTEs where the driving relation is defined in terms of the first.
+        When:
+            Transpiling the query.
+        Then:
+            The emitted SQL should retain the enclosing WITH clause verbatim so the
+            rewritten __giql_lag_calc subquery's ``FROM sub`` reference still
+            resolves, rather than dropping the WITH and dangling an undefined CTE
+            reference — the pre-#174 transplant defect.
+        """
+        # Act
+        sql = transpile(query, tables=["peaks"])
+
+        # Assert
+        assert sql.startswith(expected_with)
+        assert "AS __giql_lag_calc" in sql
+        assert "FROM sub) AS __giql_lag_calc" in sql
+
+    def test_transpile_should_execute_when_cluster_over_cte(self):
+        """Test that CLUSTER over a CTE FROM emits executable SQL.
+
+        Given:
+            A CLUSTER whose FROM references a pass-through CTE over a seeded table.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            The query should execute (the preserved WITH keeps the CTE reference
+            resolvable) and return the correct per-partition cluster ids, proving
+            the #174 fix emits runnable SQL rather than referencing a dropped CTE.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [
+                ("chr1", 100, 200),  # i1
+                ("chr1", 150, 250),  # overlaps i1 -> same cluster
+                ("chr1", 400, 500),  # separate -> new cluster
+            ],
+        )
+        query = (
+            "WITH sub AS (SELECT * FROM peaks) "
+            "SELECT *, CLUSTER(interval) AS cid FROM sub"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        cursor = conn.execute(sql)
+        columns = [desc[0] for desc in cursor.description]
+        rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+        # Assert
+        # Sorted: the emitted CLUSTER query carries no outer ORDER BY, so assert the
+        # cluster-id multiset rather than an insertion-order-dependent sequence.
+        assert sorted(r["cid"] for r in rows) == [1, 1, 2]
+
+    def test_transpile_should_not_hoist_outer_with_when_cluster_nested_in_cte_body(
+        self,
+    ):
+        """Test that a CLUSTER inside a CTE body keeps the outer WITH at the root.
+
+        Given:
+            A CLUSTER nested inside the body of one CTE whose driving relation is a
+            sibling CTE, under a root SELECT that carries the enclosing WITH.
+        When:
+            Transpiling the query.
+        Then:
+            The enclosing WITH should stay at the root and the rewritten
+            __giql_lag_calc subquery should still reference the sibling CTE ``a`` —
+            the inner transplant reads only its own SELECT's (absent) WITH, so it
+            neither hoists the ancestor WITH nor drops the sibling CTE reference.
+        """
+        # Arrange
+        query = (
+            "WITH a AS (SELECT * FROM peaks), "
+            "sub AS (SELECT *, CLUSTER(interval) AS cid FROM a) "
+            "SELECT * FROM sub"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+
+        # Assert
+        assert sql.startswith("WITH a AS (SELECT * FROM peaks), sub AS (")
+        assert "FROM a) AS __giql_lag_calc" in sql
+        assert sql.rstrip().endswith("SELECT * FROM sub")
+
+    def test_transpile_should_not_emit_with_when_cluster_over_bare_table(self):
+        """Test that a CLUSTER over a bare table grows no spurious WITH.
+
+        Given:
+            A CLUSTER over a bare registered table with no enclosing WITH.
+        When:
+            Transpiling the query.
+        Then:
+            The emitted SQL should not begin with a WITH clause — the transplant
+            WITH-preservation branch is a no-op on the common, CTE-free path (#174).
+        """
+        # Act
+        sql = transpile(
+            "SELECT *, CLUSTER(interval) AS cid FROM peaks", tables=["peaks"]
+        )
+
+        # Assert
+        assert not sql.lstrip().upper().startswith("WITH")

--- a/tests/expanders/test_genomic_columns.py
+++ b/tests/expanders/test_genomic_columns.py
@@ -154,10 +154,11 @@ class TestGenomicColumnResolution:
         When:
             Transpiling the query.
         Then:
-            It should resolve through the CTE to the custom columns. (The rewrite
-            drops the enclosing WITH clause — a pre-existing transplant limitation
-            tracked by #174, orthogonal to this column resolution — so only the
-            resolved columns are asserted, not executability.)
+            It should resolve through the CTE to the custom columns, and the
+            enclosing WITH clause is preserved so the rewritten SQL stays
+            executable (#174 — WITH preservation is pinned in the CLUSTER/MERGE
+            expander suites; asserted here to confirm resolution and preservation
+            compose).
         """
         # Arrange
         query = (
@@ -171,6 +172,7 @@ class TestGenomicColumnResolution:
         # Assert
         assert 'PARTITION BY "ch" ORDER BY "s" NULLS LAST' in sql
         assert '"chrom"' not in sql
+        assert sql.startswith("WITH sub AS (SELECT * FROM regions)")
 
     def test_transpile_should_resolve_custom_columns_when_from_is_nested_derived_table(
         self, custom

--- a/tests/expanders/test_merge.py
+++ b/tests/expanders/test_merge.py
@@ -359,3 +359,131 @@ class TestMergeExpander:
 
         # Assert
         assert rows == [("chr1", 1, 8), ("chr1", 20, 25)]
+
+    @pytest.mark.parametrize(
+        "query, expected_with",
+        [
+            (
+                "WITH sub AS (SELECT * FROM peaks) SELECT MERGE(interval) FROM sub",
+                "WITH sub AS (SELECT * FROM peaks)",
+            ),
+            (
+                "WITH a AS (SELECT * FROM peaks), sub AS (SELECT * FROM a) "
+                "SELECT MERGE(interval) FROM sub",
+                "WITH a AS (SELECT * FROM peaks), sub AS (SELECT * FROM a)",
+            ),
+        ],
+        ids=["single_cte", "chained_ctes"],
+    )
+    def test_transpile_should_preserve_with_clause_when_merge_over_cte(
+        self, query, expected_with
+    ):
+        """Test that MERGE over a CTE FROM keeps the enclosing WITH clause.
+
+        Given:
+            A MERGE whose FROM references a CTE — a single CTE, and a chain of two
+            CTEs where the driving relation is defined in terms of the first.
+        When:
+            Transpiling the query.
+        Then:
+            The emitted SQL should retain the enclosing WITH clause verbatim so the
+            rewritten __giql_clustered subquery's ``FROM sub`` reference still
+            resolves, rather than dropping the WITH and dangling an undefined CTE
+            reference — the pre-#174 transplant defect.
+        """
+        # Act
+        sql = transpile(query, tables=["peaks"])
+
+        # Assert
+        assert sql.startswith(expected_with)
+        assert "AS __giql_clustered" in sql
+        assert "FROM sub) AS __giql_lag_calc" in sql
+
+    def test_transpile_should_execute_when_merge_over_cte(self):
+        """Test that MERGE over a CTE FROM emits executable SQL.
+
+        Given:
+            A MERGE whose FROM references a pass-through CTE over a seeded table.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            The query should execute (the preserved WITH keeps the CTE reference
+            resolvable) and collapse overlapping intervals into merged rows,
+            proving the #174 fix emits runnable SQL rather than referencing a
+            dropped CTE.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [
+                ("chr1", 1, 5),  # overlaps the next -> one merged row
+                ("chr1", 3, 8),
+                ("chr1", 20, 25),  # separate -> its own row
+            ],
+        )
+        query = "WITH sub AS (SELECT * FROM peaks) SELECT MERGE(interval) FROM sub"
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [("chr1", 1, 8), ("chr1", 20, 25)]
+
+    def test_transpile_should_not_hoist_outer_with_when_merge_nested_in_cte_body(self):
+        """Test that a MERGE inside a CTE body keeps the outer WITH at the root.
+
+        Given:
+            A MERGE nested inside a CTE body, under a root SELECT that carries the
+            enclosing WITH.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            The enclosing WITH should stay at the root, the MERGE should expand into
+            the __giql_clustered form inside the CTE body, and the query should
+            execute — the inner transplant reads only its own SELECT's (absent) WITH,
+            so it does not hoist the ancestor WITH.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 1, 5), ("chr1", 3, 8), ("chr1", 20, 25)],
+        )
+        query = "WITH sub AS (SELECT MERGE(interval) FROM peaks) SELECT * FROM sub"
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert sql.startswith("WITH sub AS (")
+        assert "AS __giql_clustered" in sql
+        assert sql.rstrip().endswith("SELECT * FROM sub")
+        assert rows == [("chr1", 1, 8), ("chr1", 20, 25)]
+
+    def test_transpile_should_not_emit_with_when_merge_over_bare_table(self):
+        """Test that a MERGE over a bare table grows no spurious WITH.
+
+        Given:
+            A MERGE over a bare registered table with no enclosing WITH.
+        When:
+            Transpiling the query.
+        Then:
+            The emitted SQL should not begin with a WITH clause — the transplant
+            WITH-preservation branch is a no-op on the common, CTE-free path (#174).
+        """
+        # Act
+        sql = transpile("SELECT MERGE(interval) FROM peaks", tables=["peaks"])
+
+        # Assert
+        assert not sql.lstrip().upper().startswith("WITH")

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -975,6 +975,35 @@ class TestCrossTargetOracleCluster:
             expected=[],
         )
 
+    def test_cluster_over_cte_from_agrees_across_targets(self, cross_target_oracle):
+        """Test CLUSTER over a CTE FROM agrees across targets (#174).
+
+        Given:
+            Two overlapping intervals and one isolated interval on chr1, wrapped in
+            a pass-through CTE that the CLUSTER runs over.
+        When:
+            A CLUSTER projection over the CTE runs on every target.
+        Then:
+            Every target should preserve the enclosing WITH — keeping the emitted
+            SQL executable — and assign identical cluster ids, in agreement, proving
+            the CTE-scoping fix holds on DataFusion as well as DuckDB.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "WITH sub AS (SELECT * FROM peaks) "
+            'SELECT chrom, start, "end", CLUSTER(interval) AS cid FROM sub',
+            peaks=[
+                ("chr1", 100, 200),
+                ("chr1", 150, 300),
+                ("chr1", 5000, 6000),
+            ],
+            expected=[
+                ("chr1", 100, 200, 1),
+                ("chr1", 150, 300, 1),
+                ("chr1", 5000, 6000, 2),
+            ],
+        )
+
 
 class TestCrossTargetOracleMerge:
     """MERGE identity across all targets (T2)."""
@@ -1019,6 +1048,32 @@ class TestCrossTargetOracleMerge:
             tables=[Table("peaks")],
             peaks=[],
             expected=[],
+        )
+
+    def test_merge_over_cte_from_agrees_across_targets(self, cross_target_oracle):
+        """Test MERGE over a CTE FROM agrees across targets (#174).
+
+        Given:
+            Two overlapping intervals and one isolated interval on chr1, wrapped in
+            a pass-through CTE that the MERGE runs over.
+        When:
+            A MERGE query over the CTE runs on every target.
+        Then:
+            Every target should preserve the enclosing WITH — keeping the emitted
+            SQL executable — and return the merged span and the isolated interval,
+            in agreement, proving the CTE-scoping fix holds on DataFusion as well as
+            DuckDB.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "WITH sub AS (SELECT * FROM peaks) SELECT MERGE(interval) FROM sub",
+            tables=[Table("peaks")],
+            peaks=[
+                ("chr1", 100, 200),
+                ("chr1", 150, 300),
+                ("chr1", 5000, 6000),
+            ],
+            expected=[("chr1", 100, 300), ("chr1", 5000, 6000)],
         )
 
 


### PR DESCRIPTION
## Summary

CLUSTER and MERGE are whole-query rewrites: each builds a fresh SELECT from the original query's FROM/WHERE/GROUP/HAVING/ORDER and transplants it onto the root SELECT through the shared `giql.expanders._genomic.transplant` helper, which clears the root's args and re-installs the rewrite's. Because the rewrite never carries the original's top-level `WITH`, a CLUSTER/MERGE over a CTE FROM dropped the enclosing `WITH` clause and left the rewritten `__giql_lag_calc` / `__giql_clustered` subquery referencing a now-undefined CTE — emitting non-executable SQL.

The fix is a single change at the shared locus: `transplant` captures the root SELECT's `WITH` before clearing its args and re-attaches it. A CTE is in scope for the entire query, including the nested subquery, so the reference resolves and the emitted SQL is executable. Fixing `transplant` — rather than each `_transform_for_*` builder — covers both CLUSTER and MERGE in one place.

Closes #174

## Proposed changes

### `src/giql/expanders/_genomic.py`

- `transplant` now reads `select`'s `with_` argument before `select.args.clear()`, and re-attaches it after copying `new`'s args. Because the `_transform_for_*` helpers provably never build a top-level `WITH` on `new`, an `assert new.args.get("with_") is None` documents that invariant loudly (a future rewrite that emits its own WITH must merge the two, not silently drop the user's CTEs) rather than branching on an always-true condition. The summary line notes the WITH exception and the detail paragraph explains that the surviving CTE reference is named by the `__giql_lag_calc` subquery (nested, for MERGE, inside its `__giql_clustered` wrapper).

### Tests

- `tests/expanders/test_cluster.py` / `test_merge.py`: WITH-preservation regressions (single and chained CTEs) asserting the emitted SQL retains the `WITH` prefix and still names the CTE in the rewritten subquery; DuckDB executability regressions proving the SQL now runs and returns correct cluster ids / merged rows; nested-operator-in-CTE-body regressions pinning that an operator *inside* a CTE body does not hoist the outer WITH; and negative tests that a bare-table CLUSTER/MERGE grows no spurious `WITH`.
- `tests/integration/datafusion/test_cross_target_oracle.py`: CTE-over-CLUSTER and CTE-over-MERGE cases proving all three targets (generic, DuckDB, DataFusion) agree — the CTE-scoping fix is load-bearing on every engine, and a DuckDB-only test cannot catch a DataFusion regression.
- `tests/expanders/test_genomic_columns.py`: flip the stale `#174` caveat in the CTE column-resolution test — it now asserts the `WITH` is preserved, confirming column resolution and `WITH` preservation compose.

## Review

Reviewed by 9 independent reviewers through a principal-SWE + Python/SQL lens (`.sdlc/reviews/issue-#174/review-1.md`): **zero blocking**, A1–A10 advisory. Five reviewers ran dual-engine (DuckDB + DataFusion) probes across single/chained/set-operation/stranded/nested-CTE/`WITH RECURSIVE` and the #172 correlated-NEAREST-fallback composition — all executable and cross-target-agreeing; the adversarial reviewer could not break the fix. Round-1 remediation applied: A1 (assert-hardened guard), A5/A6 (docstring precision), A2/A4/A7/A8 (nested-CTE, cross-target oracle, negative, and order-independent tests). The general root-only-clause loss (LIMIT/OFFSET/DISTINCT/QUALIFY, still silently dropped — out of #174's WITH scope) is filed as #181.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestClusterExpander` | A CLUSTER whose FROM references a single CTE and a chain of two CTEs | Transpiling the query | The emitted SQL retains the enclosing `WITH` verbatim and the rewritten `__giql_lag_calc` subquery still names the CTE | WITH preservation for CLUSTER |
| 2 | `TestClusterExpander` | A CLUSTER over a pass-through CTE on a seeded table | Transpiling and executing on DuckDB | The query runs and returns the correct cluster-id multiset | CLUSTER executability over a CTE |
| 3 | `TestClusterExpander` | A CLUSTER nested inside a CTE body whose driver is a sibling CTE | Transpiling the query | The outer `WITH` stays at the root and the rewrite still references the sibling CTE — the outer WITH is not hoisted | Nested-CTE-body WITH scoping |
| 4 | `TestClusterExpander` | A CLUSTER over a bare table with no WITH | Transpiling the query | The emitted SQL does not begin with `WITH` | No spurious WITH on the common path |
| 5 | `TestMergeExpander` | A MERGE whose FROM references a single CTE and a chain of two CTEs | Transpiling the query | The emitted SQL retains the enclosing `WITH` verbatim and the rewritten `__giql_clustered` subquery still names the CTE | WITH preservation for MERGE |
| 6 | `TestMergeExpander` | A MERGE over a pass-through CTE on a seeded table | Transpiling and executing on DuckDB | The query runs and collapses overlapping intervals into the correct merged rows | MERGE executability over a CTE |
| 7 | `TestMergeExpander` | A MERGE nested inside a CTE body | Transpiling and executing on DuckDB | The outer `WITH` stays at the root, the MERGE expands inside the CTE body, and the query executes | Nested-CTE-body WITH scoping |
| 8 | `TestMergeExpander` | A MERGE over a bare table with no WITH | Transpiling the query | The emitted SQL does not begin with `WITH` | No spurious WITH on the common path |
| 9 | `TestCrossTargetOracleCluster` | A CLUSTER over a pass-through CTE | Running on generic, DuckDB, and DataFusion | All three targets preserve the WITH and agree on the cluster ids | Cross-target CTE executability (CLUSTER) |
| 10 | `TestCrossTargetOracleMerge` | A MERGE over a pass-through CTE | Running on generic, DuckDB, and DataFusion | All three targets preserve the WITH and agree on the merged rows | Cross-target CTE executability (MERGE) |
| 11 | `TestGenomicColumnResolution` | A CLUSTER whose FROM references a `SELECT *` CTE over a custom-mapped table | Transpiling the query | It resolves through the CTE to the custom columns and preserves the enclosing `WITH` | Column resolution and WITH preservation compose |

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM