### PR TITLE
CLUSTER/MERGE whole-query rewrites silently drop outer LIMIT / OFFSET / DISTINCT / QUALIFY — Closes #181

### DIFF
--- a/src/giql/expanders/_genomic.py
+++ b/src/giql/expanders/_genomic.py
@@ -315,9 +315,30 @@ def reject_cluster_merge_mix(select: exp.Select) -> None:
         )
 
 
+# Top-level ``exp.Select`` args the ``_transform_for_*`` helpers rebuild onto their
+# freshly-built ``new`` query (the SELECT list, the FROM/WHERE/GROUP/HAVING that
+# move into the inner subquery, and the ORDER that stays outer). ``joins`` is
+# rejected upstream in :func:`genomic_columns` before any transplant runs. See
+# :func:`transplant` for how everything outside this set and
+# :data:`_PRESERVED_ROOT_ARGS` is handled.
+_REBUILT_ROOT_ARGS = frozenset(
+    {"expressions", "from_", "where", "group", "having", "order", "joins"}
+)
+
+# Outer clauses the ``_transform_for_*`` helpers do NOT rebuild onto ``new`` but
+# that belong on the outer/final query the rewrite produces, so :func:`transplant`
+# re-attaches each (see it for why dropping any corrupts the result). These are
+# sqlglot ``exp.Select`` arg names — only ``with_`` carries a trailing underscore.
+# (A named ``WINDOW`` clause is deliberately NOT here: CLUSTER duplicates the
+# window-referencing projection into the inner subquery too, so an outer-only
+# re-attach would still dangle; :func:`transplant` rejects it loudly instead.)
+_PRESERVED_ROOT_ARGS = ("with_", "limit", "offset", "distinct", "qualify")
+
+
 def transplant(select: exp.Select, new: exp.Select) -> None:
-    """Replace *select*'s contents with *new*'s (preserving *select*'s enclosing
-    ``WITH``, see below), keeping *select*'s identity.
+    """Rewrite *select* into *new*, preserving *select*'s outer clauses
+    (:data:`_PRESERVED_ROOT_ARGS`) and failing loud on any it cannot carry, while
+    keeping *select*'s identity.
 
     Part of the shared CLUSTER/MERGE expansion toolkit. Clears every argument of
     *select* and re-installs *new*'s, so *select* keeps its position in the
@@ -330,29 +351,59 @@ def transplant(select: exp.Select, new: exp.Select) -> None:
     re-parented onto *select*, so passing a node still attached elsewhere would
     corrupt that other tree.
 
-    The enclosing ``WITH`` clause is preserved: the ``_transform_for_*`` helpers
-    build *new* from the original's FROM / WHERE / GROUP / HAVING / ORDER but never
-    its top-level ``WITH``, so a CLUSTER/MERGE over a CTE FROM would otherwise drop
-    the enclosing ``WITH`` and dangle the now-undefined CTE reference. That
-    reference is named by the rewritten ``__giql_lag_calc`` subquery (nested, for
-    MERGE, inside its ``__giql_clustered`` aggregation wrapper). Re-attaching
-    *select*'s original ``WITH`` keeps the emitted SQL executable — a CTE is in
-    scope for the entire query, including that nested subquery (#174).
+    The ``_transform_for_*`` helpers build *new* from :data:`_REBUILT_ROOT_ARGS`
+    (the SELECT list plus FROM / WHERE / GROUP / HAVING / ORDER) but never *select*'s
+    other top-level clauses. The clauses in :data:`_PRESERVED_ROOT_ARGS` belong on
+    the outer query the rewrite produces, so dropping them corrupts the result: a
+    CLUSTER/MERGE over a CTE FROM would dangle the ``WITH``'s CTE reference the
+    rewritten ``__giql_lag_calc`` subquery still names (nested, for MERGE, inside
+    its ``__giql_clustered`` wrapper) — non-executable SQL (#174) — while a dropped
+    ``LIMIT`` / ``OFFSET`` / ``DISTINCT`` / ``QUALIFY`` would silently return the
+    wrong rows (#181). ``transplant`` re-attaches each onto the outer query.
+
+    Any *other* top-level clause (e.g. a named ``WINDOW``, ``SELECT … INTO``,
+    ``FOR UPDATE``, ``SORT``/``CLUSTER``/``DISTRIBUTE BY``) is neither rebuilt nor
+    preserved, so rather than silently drop it — the very failure mode #174/#181 were
+    about — this raises :class:`ValueError`. Silent-drop is the worst outcome for a
+    query compiler; a loud error is diagnosable and future-proofs the rewrite against
+    new sqlglot args. (A named ``WINDOW`` referenced by a surviving projection is a
+    genuine gap rather than a nonsensical clause, but preserving it correctly means
+    threading the definition into the inner subquery too — deferred; for now it
+    fails loud rather than emitting a dangling ``OVER w``.)
+
+    :raises ValueError: When *select* carries a top-level clause that is neither
+        rebuilt (:data:`_REBUILT_ROOT_ARGS`) nor preserved
+        (:data:`_PRESERVED_ROOT_ARGS`).
     """
     assert new.parent is None, "transplant() requires a detached `new` subtree"
-    preserved_with = select.args.get("with_")
+    unhandled = sorted(
+        key
+        for key, value in select.args.items()
+        if value is not None
+        and key not in _REBUILT_ROOT_ARGS
+        and key not in _PRESERVED_ROOT_ARGS
+    )
+    if unhandled:
+        raise ValueError(
+            "CLUSTER/MERGE cannot carry these top-level clause(s) through the "
+            f"whole-query rewrite: {unhandled}. They are neither rebuilt nor in the "
+            "preserved set (e.g. SELECT INTO, FOR UPDATE, SORT/CLUSTER/DISTRIBUTE "
+            "BY). Run the operator over a subquery that applies the clause instead."
+        )
+    preserved = {key: select.args.get(key) for key in _PRESERVED_ROOT_ARGS}
     select.args.clear()
     for key, value in list(new.args.items()):
         select.set(key, value)
-    # The _transform_for_* helpers populate `new` with only
-    # select/from/where/group/having/order and never a top-level WITH, so
-    # re-attaching the preserved WITH can never clobber one `new` supplies. Assert
-    # that invariant rather than silently dropping the user's CTEs if a future
-    # rewrite ever violates it — the correct behavior there would be to *merge* the
-    # two WITH clauses, not pick one and drop the other.
-    assert new.args.get("with_") is None, (
-        "transplant() cannot reconcile a WITH from `new` with the preserved outer "
-        "WITH; a rewrite that emits its own WITH must merge them explicitly."
-    )
-    if preserved_with is not None:
-        select.set("with_", preserved_with)
+    for key, value in preserved.items():
+        if value is None:
+            continue
+        # The _transform_for_* helpers never set these clauses on `new`, so
+        # re-attaching a preserved clause can never clobber one `new` supplies.
+        # Assert that invariant rather than silently choosing one — a future
+        # rewrite that emits its own copy must reconcile the two explicitly (for
+        # WITH, by merging the CTE lists rather than dropping either).
+        assert new.args.get(key) is None, (
+            f"transplant() cannot reconcile a {key!r} clause from `new` with the "
+            "preserved outer one; a rewrite that emits its own must merge them."
+        )
+        select.set(key, value)

--- a/src/giql/expanders/merge.py
+++ b/src/giql/expanders/merge.py
@@ -256,12 +256,22 @@ def _transform_for_merge(
     # Add GROUP BY
     final_query.group_by(*group_by_cols, copy=False)
 
-    # Add ORDER BY (chromosome, start)
-    final_query.order_by(
-        exp.Ordered(this=exp.column(chrom_col, quoted=True)), copy=False
-    )
-    final_query.order_by(
-        exp.Ordered(this=exp.column(start_col, quoted=True)), append=True, copy=False
-    )
+    # ORDER BY: honor the user's ORDER BY over the merged output when present,
+    # otherwise default to (chromosome, start) for deterministic output. MERGE
+    # aggregates rows away, so the user's ORDER BY resolves against the merged
+    # columns (e.g. ``ORDER BY "end" DESC`` over ``MAX("end") AS end``). Overriding
+    # it with the fixed default silently returned the wrong rows once an outer LIMIT
+    # was preserved (#181), so the user's ordering takes precedence.
+    if query.args.get("order"):
+        final_query.set("order", query.args["order"].copy())
+    else:
+        final_query.order_by(
+            exp.Ordered(this=exp.column(chrom_col, quoted=True)), copy=False
+        )
+        final_query.order_by(
+            exp.Ordered(this=exp.column(start_col, quoted=True)),
+            append=True,
+            copy=False,
+        )
 
     return final_query

--- a/tests/expanders/test_cluster.py
+++ b/tests/expanders/test_cluster.py
@@ -573,3 +573,217 @@ class TestClusterExpander:
 
         # Assert
         assert not sql.lstrip().upper().startswith("WITH")
+
+    @pytest.mark.parametrize(
+        "clause",
+        ["LIMIT 2", "LIMIT 2 OFFSET 1", "QUALIFY cid > 1"],
+        ids=["limit", "offset", "qualify"],
+    )
+    def test_transpile_should_preserve_result_clause_when_cluster(self, clause):
+        """Test that CLUSTER preserves an outer result-shaping clause.
+
+        Given:
+            A CLUSTER query carrying an outer LIMIT / OFFSET / QUALIFY clause.
+        When:
+            Transpiling the query.
+        Then:
+            The full clause should survive verbatim on the rewritten outer query
+            rather than being silently dropped by the whole-query transplant (#181),
+            so the emitted SQL returns the rows the original query asked for.
+        """
+        # Act
+        sql = transpile(
+            f"SELECT *, CLUSTER(interval) AS cid FROM peaks {clause}", tables=["peaks"]
+        )
+
+        # Assert
+        assert clause in sql
+
+    def test_transpile_should_preserve_distinct_when_cluster(self):
+        """Test that CLUSTER preserves an outer DISTINCT.
+
+        Given:
+            A CLUSTER query with a DISTINCT projection.
+        When:
+            Transpiling the query.
+        Then:
+            The rewritten outer query should keep SELECT DISTINCT rather than
+            dropping it in the transplant (#181).
+        """
+        # Act
+        sql = transpile(
+            "SELECT DISTINCT chrom, CLUSTER(interval) AS cid FROM peaks",
+            tables=["peaks"],
+        )
+
+        # Assert
+        assert "SELECT DISTINCT" in sql
+
+    def test_transpile_should_dedup_when_cluster_with_distinct(self):
+        """Test that a preserved DISTINCT dedups the CLUSTER output rows.
+
+        Given:
+            A CLUSTER over rows that collapse to one distinct (chrom, cluster-id)
+            pair, projected with DISTINCT on an explicit column list.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            The preserved DISTINCT should land on the outer query and dedup the final
+            rows to the single distinct pair — proving DISTINCT is re-attached to the
+            outer query, not an inner subquery (#181). An explicit projection is used
+            so the dedup is not confounded by the pre-existing star-column leak (#184).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 12, 22), ("chr1", 14, 24)],
+        )
+        query = "SELECT DISTINCT chrom, CLUSTER(interval) AS cid FROM peaks"
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [("chr1", 1)]
+
+    def test_transpile_should_execute_when_cluster_with_limit_and_offset(self):
+        """Test that CLUSTER with LIMIT/OFFSET returns the correct row window.
+
+        Given:
+            A CLUSTER query with an outer ORDER BY, LIMIT, and OFFSET over a seeded
+            table.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            The preserved LIMIT/OFFSET should return exactly the requested ordered
+            window — proving the fix emits the right rows rather than the silently
+            unbounded result the dropped clauses produced (#181).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 15, 30), ("chr1", 100, 110), ("chr1", 105, 120)],
+        )
+        query = (
+            'SELECT chrom, start, "end", CLUSTER(interval) AS cid '
+            "FROM peaks ORDER BY start LIMIT 2 OFFSET 1"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [("chr1", 15, 30, 1), ("chr1", 100, 110, 2)]
+
+    def test_transpile_should_execute_when_cluster_with_qualify(self):
+        """Test that CLUSTER with QUALIFY filters on the cluster id.
+
+        Given:
+            A CLUSTER query with a QUALIFY predicate over the cluster-id alias.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            The preserved QUALIFY should filter the rewritten outer query on the SUM
+            window result, returning only the rows in clusters past the first (#181).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 15, 30), ("chr1", 100, 110), ("chr1", 105, 120)],
+        )
+        query = (
+            'SELECT chrom, start, "end", CLUSTER(interval) AS cid '
+            "FROM peaks QUALIFY cid > 1"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        rows = sorted(conn.execute(sql).fetchall())
+
+        # Assert
+        assert rows == [("chr1", 100, 110, 2), ("chr1", 105, 120, 2)]
+
+    def test_transpile_should_preserve_with_and_limit_when_cluster_over_cte(self):
+        """Test that CLUSTER over a CTE preserves both the WITH and an outer LIMIT.
+
+        Given:
+            A CLUSTER over a CTE FROM that also carries an outer LIMIT — the #174
+            (WITH) and #181 (LIMIT) preservation cases composed in one query.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            Both the enclosing WITH and the LIMIT should survive the transplant, so
+            the query executes and returns exactly the requested ordered window.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 15, 30), ("chr1", 100, 110)],
+        )
+        query = (
+            "WITH sub AS (SELECT * FROM peaks) "
+            'SELECT chrom, start, "end", CLUSTER(interval) AS cid '
+            "FROM sub ORDER BY start LIMIT 2"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert sql.startswith("WITH sub AS (SELECT * FROM peaks)")
+        assert rows == [("chr1", 10, 20, 1), ("chr1", 15, 30, 1)]
+
+    @pytest.mark.parametrize(
+        "clause",
+        [
+            "INTO newtbl FROM peaks",
+            "FROM peaks FOR UPDATE",
+            "FROM peaks SORT BY start",
+            "FROM peaks WINDOW w AS (PARTITION BY chrom)",
+        ],
+        ids=["into", "for_update", "sort_by", "named_window"],
+    )
+    def test_transpile_should_raise_when_cluster_carries_unsupported_root_clause(
+        self, clause
+    ):
+        """Test that an unhandled outer clause fails loud rather than dropping.
+
+        Given:
+            A CLUSTER query carrying a top-level clause the whole-query rewrite
+            neither rebuilds nor preserves — SELECT INTO, FOR UPDATE, SORT BY, or a
+            named WINDOW.
+        When:
+            Transpiling the query.
+        Then:
+            It should raise ValueError naming the unsupported clause rather than
+            silently dropping it (the #174/#181 failure mode) — a loud, diagnosable
+            error for a clause the transplant cannot carry.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="cannot carry these top-level clause"):
+            transpile(
+                f"SELECT chrom, CLUSTER(interval) AS cid {clause}", tables=["peaks"]
+            )

--- a/tests/expanders/test_merge.py
+++ b/tests/expanders/test_merge.py
@@ -487,3 +487,133 @@ class TestMergeExpander:
 
         # Assert
         assert not sql.lstrip().upper().startswith("WITH")
+
+    @pytest.mark.parametrize(
+        "clause, expected",
+        [
+            ("LIMIT 1", "LIMIT 1"),
+            ("LIMIT 5 OFFSET 1", "OFFSET 1"),
+        ],
+        ids=["limit", "offset"],
+    )
+    def test_transpile_should_preserve_result_clause_when_merge(self, clause, expected):
+        """Test that MERGE preserves an outer result-shaping clause.
+
+        Given:
+            A MERGE query carrying an outer LIMIT / OFFSET clause.
+        When:
+            Transpiling the query.
+        Then:
+            The clause should survive on the rewritten outer aggregation query rather
+            than being silently dropped by the whole-query transplant (#181).
+        """
+        # Act
+        sql = transpile(f"SELECT MERGE(interval) FROM peaks {clause}", tables=["peaks"])
+
+        # Assert
+        assert expected in sql
+
+    def test_transpile_should_execute_when_merge_with_limit_and_offset(self):
+        """Test that MERGE with LIMIT/OFFSET returns the correct merged-row window.
+
+        Given:
+            A MERGE query with an outer LIMIT and OFFSET over a seeded table. MERGE
+            already emits an ORDER BY chrom, start, so the window is deterministic.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            The preserved LIMIT/OFFSET should return exactly the requested slice of
+            the ordered merged rows rather than the silently unbounded result the
+            dropped clauses produced (#181).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 15, 30), ("chr1", 100, 110), ("chr1", 105, 120)],
+        )
+        query = "SELECT MERGE(interval) FROM peaks LIMIT 5 OFFSET 1"
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [("chr1", 100, 120)]
+
+    def test_transpile_should_default_order_by_chrom_start_when_merge_unordered(self):
+        """Test that MERGE keeps its chrom, start default ORDER BY without a user one.
+
+        Given:
+            A MERGE query with no user ORDER BY.
+        When:
+            Transpiling the query.
+        Then:
+            The emitted SQL should carry MERGE's default ORDER BY on chromosome then
+            start, so unordered MERGE output stays deterministic.
+        """
+        # Act
+        sql = transpile("SELECT MERGE(interval) FROM peaks", tables=["peaks"])
+
+        # Assert
+        assert 'ORDER BY "chrom" NULLS LAST, "start" NULLS LAST' in sql
+
+    def test_transpile_should_honor_user_order_by_when_merge_with_limit(self):
+        """Test that MERGE honors the user's ORDER BY under an outer LIMIT.
+
+        Given:
+            A MERGE query with a user ORDER BY on the merged end descending and an
+            outer LIMIT of one row, over a seeded table.
+        When:
+            Transpiling the query and executing it on DuckDB.
+        Then:
+            MERGE should order the merged rows by the user's ORDER BY (not its fixed
+            chrom, start default) so the preserved LIMIT returns the largest-end
+            merged row — otherwise the preserved LIMIT would silently return the
+            wrong row over MERGE's forced ordering (#181).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 100, 110), ("chr1", 5000, 6000)],
+        )
+        query = 'SELECT MERGE(interval) FROM peaks ORDER BY "end" DESC LIMIT 1'
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [("chr1", 5000, 6000)]
+
+    # DISTINCT/QUALIFY over MERGE: transplant re-attaches every preserved clause
+    # operator-agnostically, so CLUSTER's DISTINCT/QUALIFY tests already exercise the
+    # shared re-attach path. MERGE's outer query is a GROUP BY aggregation, so a
+    # DISTINCT there is redundant-but-valid (asserted below); a non-windowed QUALIFY
+    # is ill-formed over an aggregation and is faithfully passed through to fail at the
+    # engine rather than silently drop — hence no MERGE+QUALIFY executability test.
+    def test_transpile_should_preserve_distinct_when_merge(self):
+        """Test that MERGE preserves an outer DISTINCT.
+
+        Given:
+            A MERGE query with a DISTINCT projection.
+        When:
+            Transpiling the query.
+        Then:
+            The rewritten outer aggregation query should keep SELECT DISTINCT rather
+            than dropping it in the transplant (#181).
+        """
+        # Act
+        sql = transpile("SELECT DISTINCT MERGE(interval) FROM peaks", tables=["peaks"])
+
+        # Assert
+        assert "SELECT DISTINCT" in sql

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -1004,6 +1004,35 @@ class TestCrossTargetOracleCluster:
             ],
         )
 
+    def test_cluster_with_limit_agrees_across_targets(self, cross_target_oracle):
+        """Test CLUSTER with an outer LIMIT agrees across targets (#181).
+
+        Given:
+            Four intervals forming two clusters on chr1, ordered by start with an
+            outer LIMIT of two rows.
+        When:
+            A CLUSTER projection with ORDER BY / LIMIT runs on every target.
+        Then:
+            Every target should preserve the LIMIT — returning the same two ordered
+            rows rather than the whole table — and agree, proving the result-clause
+            preservation holds on DataFusion as well as DuckDB.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT chrom, start, "end", CLUSTER(interval) AS cid '
+            "FROM peaks ORDER BY start LIMIT 2",
+            peaks=[
+                ("chr1", 10, 20),
+                ("chr1", 15, 30),
+                ("chr1", 100, 110),
+                ("chr1", 105, 120),
+            ],
+            expected=[
+                ("chr1", 10, 20, 1),
+                ("chr1", 15, 30, 1),
+            ],
+        )
+
 
 class TestCrossTargetOracleMerge:
     """MERGE identity across all targets (T2)."""
@@ -1074,6 +1103,59 @@ class TestCrossTargetOracleMerge:
                 ("chr1", 5000, 6000),
             ],
             expected=[("chr1", 100, 300), ("chr1", 5000, 6000)],
+        )
+
+    def test_merge_with_limit_agrees_across_targets(self, cross_target_oracle):
+        """Test MERGE with an outer LIMIT agrees across targets (#181).
+
+        Given:
+            Two merged runs on chr1 with an outer LIMIT of one row (MERGE already
+            emits ORDER BY chrom, start, so the window is deterministic).
+        When:
+            A MERGE query with a LIMIT runs on every target.
+        Then:
+            Every target should preserve the LIMIT — returning only the first merged
+            span rather than both — and agree, proving the result-clause preservation
+            holds on DataFusion as well as DuckDB.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT MERGE(interval) FROM peaks LIMIT 1",
+            tables=[Table("peaks")],
+            peaks=[
+                ("chr1", 100, 200),
+                ("chr1", 150, 300),
+                ("chr1", 5000, 6000),
+            ],
+            expected=[("chr1", 100, 300)],
+        )
+
+    def test_merge_with_user_order_by_limit_agrees_across_targets(
+        self, cross_target_oracle
+    ):
+        """Test MERGE honors a user ORDER BY under LIMIT across targets (#181).
+
+        Given:
+            Two merged runs on chr1 with a user ORDER BY on the merged end descending
+            and an outer LIMIT of one row.
+        When:
+            A MERGE query with ORDER BY / LIMIT runs on every target.
+        Then:
+            Every target should order by the user's ORDER BY (not MERGE's fixed
+            chrom, start default) and return the largest-end merged span, in
+            agreement — proving MERGE honors the user ordering so the preserved LIMIT
+            slices the rows the user asked for.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            'SELECT MERGE(interval) FROM peaks ORDER BY "end" DESC LIMIT 1',
+            tables=[Table("peaks")],
+            peaks=[
+                ("chr1", 100, 200),
+                ("chr1", 150, 300),
+                ("chr1", 5000, 6000),
+            ],
+            expected=[("chr1", 5000, 6000)],
         )
 
 


### PR DESCRIPTION
## Summary

The CLUSTER and MERGE whole-query rewrites rebuild the outer SELECT from only the original query's SELECT list plus FROM/WHERE/GROUP/HAVING/ORDER, and the shared `giql.expanders._genomic.transplant` helper clears the root SELECT's args and re-installs the rewrite's. Every *other* top-level clause was therefore silently dropped. #174 fixed the `WITH` facet (which failed loudly as non-executable SQL); the result-shaping `LIMIT` / `OFFSET` / `DISTINCT` / `QUALIFY` were still discarded — producing **executable but wrong** SQL with no error.

This generalizes #174's single-clause WITH preservation into a `_PRESERVED_ROOT_ARGS` whitelist. `transplant` captures each root-only clause before clearing the args and re-attaches it onto the rewritten outer query. Three companion corrections keep the generalization sound:

- **MERGE honors the user's ORDER BY.** MERGE's builder forced its own `ORDER BY chrom, start` and dropped the user's, so a preserved LIMIT would have returned a silently-wrong top-N. `_transform_for_merge` now uses the user's ORDER BY when present, falling back to `chrom, start` only when absent (consistent with CLUSTER).
- **A fail-loud completeness guard.** Any top-level clause `transplant` neither rebuilds (`_REBUILT_ROOT_ARGS`) nor preserves (`_PRESERVED_ROOT_ARGS`) now raises `ValueError` instead of being silently dropped — closing the same failure class for `WINDOW`, `SELECT INTO`, `FOR UPDATE`, `SORT`/`CLUSTER`/`DISTRIBUTE BY`, and any future sqlglot arg.
- The per-clause invariant assert from #174 (the `_transform_for_*` helpers never emit these on `new`) is retained.

Closes #181

## Proposed changes

### `src/giql/expanders/_genomic.py`

- Add `_PRESERVED_ROOT_ARGS = ("with_", "limit", "offset", "distinct", "qualify")` and `_REBUILT_ROOT_ARGS` (the clauses the builders rebuild).
- `transplant` captures the preserved clauses before `select.args.clear()`, re-attaches each after copying `new`'s args (per-clause invariant assert retained), and **raises `ValueError`** for any unhandled top-level clause. The docstring is generalized and its "Replace" contract corrected to "Rewrite … preserving outer clauses and failing loud".

### `src/giql/expanders/merge.py`

- `_transform_for_merge` honors the user's ORDER BY over the merged output when present, defaulting to `chrom, start` only when absent.

### Tests

- `tests/expanders/test_cluster.py`: string-level preservation of LIMIT/OFFSET/QUALIFY (full-clause assertions) and DISTINCT; DuckDB executability of CLUSTER with LIMIT+OFFSET, QUALIFY, and DISTINCT (explicit-projection dedup); a WITH+LIMIT composition; and a parametrized completeness-guard rejection test (INTO / FOR UPDATE / SORT BY / named WINDOW).
- `tests/expanders/test_merge.py`: LIMIT/OFFSET preservation and executability; MERGE default-order regression; MERGE honoring the user's ORDER BY under LIMIT (B1); and MERGE+DISTINCT preservation with a rationale comment on the MERGE aggregation boundary.
- `tests/integration/datafusion/test_cross_target_oracle.py`: CLUSTER-LIMIT, MERGE-LIMIT, and MERGE user-ORDER-BY+LIMIT cases proving all three targets agree.

## Review

Reviewed by 9 independent reviewers through a principal-SWE + Python/SQL lens (`.sdlc/reviews/issue-#181/review-1.md`): one blocking (B1, MERGE ORDER BY) plus A1–A8 advisory. Five reviewers ran dual-engine (DuckDB + DataFusion) probes. Round-1 remediation applied: B1 (MERGE honors user ORDER BY), A1 (completeness guard; WINDOW deferred to #183 as it needs inner-subquery threading), A2 (MERGE+QUALIFY passthrough → loud engine error, documented), A4–A7 (docstring precision, tightened assertions, new tests), A8 (accept stale `supports_qualify`). The CLUSTER `SELECT *` star-leak surfaced via DISTINCT is pre-existing (#161 family) and filed as #184.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestClusterExpander` | A CLUSTER with an outer LIMIT / OFFSET / QUALIFY | Transpiling | The full clause survives verbatim on the outer query | Clause preservation (string) |
| 2 | `TestClusterExpander` | A CLUSTER with a DISTINCT projection | Transpiling | The outer query keeps SELECT DISTINCT | DISTINCT preservation |
| 3 | `TestClusterExpander` | A CLUSTER with ORDER BY / LIMIT / OFFSET | Executing on DuckDB | Returns exactly the requested ordered window | LIMIT/OFFSET executability |
| 4 | `TestClusterExpander` | A CLUSTER with QUALIFY over the cluster-id alias | Executing on DuckDB | Filters on the SUM window result | QUALIFY executability |
| 5 | `TestClusterExpander` | A CLUSTER with DISTINCT on an explicit projection | Executing on DuckDB | Dedups the final rows to the distinct pair | DISTINCT dedup on the outer query |
| 6 | `TestClusterExpander` | A CLUSTER over a CTE with an outer LIMIT | Executing on DuckDB | Both WITH and LIMIT survive | #174 + #181 composition |
| 7 | `TestClusterExpander` | A CLUSTER carrying INTO / FOR UPDATE / SORT BY / WINDOW | Transpiling | Raises ValueError naming the unsupported clause | Fail-loud completeness guard |
| 8 | `TestMergeExpander` | A MERGE with an outer LIMIT / OFFSET | Transpiling / executing on DuckDB | The clause survives and returns the requested slice | LIMIT/OFFSET preservation |
| 9 | `TestMergeExpander` | A MERGE with no user ORDER BY | Transpiling | Keeps the chrom, start default ORDER BY | Default-order regression |
| 10 | `TestMergeExpander` | A MERGE with a user ORDER BY end DESC and LIMIT 1 | Executing on DuckDB | Returns the largest-end merged row | MERGE honors user ORDER BY (B1) |
| 11 | `TestMergeExpander` | A MERGE with a DISTINCT projection | Transpiling | The outer aggregation keeps SELECT DISTINCT | DISTINCT preservation |
| 12 | `TestCrossTargetOracleCluster` / `Merge` | CLUSTER-LIMIT, MERGE-LIMIT, MERGE user-ORDER-BY+LIMIT | Running on generic, DuckDB, DataFusion | All three targets preserve the clause / ordering and agree | Cross-target preservation |

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM