### PR TITLE
CLUSTER SELECT * leaks the synthesized __giql_is_new_cluster column into query output — Closes #184

### DIFF
--- a/docs/dialect/aggregation-operators.rst
+++ b/docs/dialect/aggregation-operators.rst
@@ -191,6 +191,10 @@ Find regions with multiple overlapping features:
    INNER JOIN cluster_sizes s ON c.cluster_id = s.cluster_id
    WHERE s.size >= 3
 
+.. note::
+
+   **Synthesized flag hidden under** ``SELECT *``. A ``SELECT *, CLUSTER(...)`` query materializes an internal ``__giql_is_new_cluster`` flag in a subquery, so the outer star is emitted as ``SELECT * EXCEPT (__giql_is_new_cluster)`` to keep that helper column out of the result (#184). ``* EXCEPT`` is a DataFusion-family extension: the generic and ``datafusion`` dialects emit it, while ``duckdb`` spells the exclusion ``EXCLUDE``. Transpile with ``dialect="duckdb"`` to execute on DuckDB — the portable generic ``* EXCEPT`` form is not DuckDB-runnable. An explicitly-projected ``CLUSTER`` (no star) surfaces no helper column and needs no exclusion.
+
 Performance Notes
 ~~~~~~~~~~~~~~~~~
 

--- a/src/giql/expanders/cluster.py
+++ b/src/giql/expanders/cluster.py
@@ -21,7 +21,9 @@ becomes::
     ) AS __giql_lag_calc
 
 (The ``becomes::`` form is simplified for readability; the emitted SQL quotes
-identifiers and appends ``NULLS LAST`` to the window ORDER BY.)
+identifiers, appends ``NULLS LAST`` to the window ORDER BY, and — for a star
+projection — emits the outer star as ``* EXCEPT (__giql_is_new_cluster)`` to hide the
+synthesized flag from the output (#184).)
 
 This module is the AST-expansion replacement for the legacy
 :class:`giql.transformer.ClusterTransformer`, which ran as a pre-pass transformer
@@ -109,6 +111,11 @@ def expand_cluster(node: GIQLCluster, ctx: ExpansionContext) -> exp.Expression:
     # preserve its identity (and so a root SELECT is rewritten without a parent to
     # replace it through).
     source = select.copy()
+    # Hiding the synthesized __giql_is_new_cluster flag from a surfacing star is the
+    # safe default (#184; MERGE opts out — see expand_cluster_query). This runs for
+    # every CLUSTER the pass expands, root or nested: harmless when the flag would
+    # not surface, and it also stops a nested CLUSTER's flag leaking through an
+    # enclosing star.
     transformed = expand_cluster_query(source, columns)
     if transformed is None:
         # No-op for a CLUSTER that parses outside the SELECT projection (e.g. in
@@ -143,7 +150,7 @@ def expand_cluster(node: GIQLCluster, ctx: ExpansionContext) -> exp.Expression:
 
 
 def expand_cluster_query(
-    query: exp.Select, columns: GenomicColumns
+    query: exp.Select, columns: GenomicColumns, hide_reserved: bool = True
 ) -> exp.Select | None:
     """Restructure *query* for every CLUSTER in its projection; ``None`` if none.
 
@@ -153,8 +160,13 @@ def expand_cluster_query(
     query. Returns ``None`` when *query* projects no CLUSTER, so callers can treat
     that as a no-op.
 
-    Reused by :mod:`giql.expanders.merge`, whose intermediate clustered query is
-    restructured through this same helper.
+    *hide_reserved* (default ``True``) rewrites a star in the outer projection to hide
+    the synthesized ``__giql_is_new_cluster`` flag the star would otherwise surface
+    (#184). Hiding is the default so a caller cannot silently reintroduce the leak by
+    omitting it. MERGE — which reuses this helper to build its intermediate clustered
+    query — is the one caller that opts out (``hide_reserved=False``): its explicit
+    outer projection never surfaces the flag, so hiding it would only add a needless
+    ``* EXCEPT`` to the intermediate ``__giql_clustered`` subquery.
     """
     cluster_exprs = find_projected(query, GIQLCluster)
     if not cluster_exprs:
@@ -166,12 +178,15 @@ def expand_cluster_query(
         # broken SQL (#144 A15).
         raise ValueError("Multiple CLUSTER expressions not yet supported")
     for cluster_expr in cluster_exprs:
-        query = _transform_for_cluster(query, cluster_expr, columns)
+        query = _transform_for_cluster(query, cluster_expr, columns, hide_reserved)
     return query
 
 
 def _transform_for_cluster(
-    query: exp.Select, cluster_expr: GIQLCluster, columns: GenomicColumns
+    query: exp.Select,
+    cluster_expr: GIQLCluster,
+    columns: GenomicColumns,
+    hide_reserved: bool = True,
 ) -> exp.Select:
     """Rewrite *query* into the two-level ``__giql_lag_calc`` form for one CLUSTER.
 
@@ -348,7 +363,17 @@ def _transform_for_cluster(
                 exp.alias_(sum_window, expression.alias, quoted=False)
             )
         else:
-            new_expressions.append(expression)
+            # A star projection expands over the inner __giql_lag_calc subquery,
+            # which carries the synthesized __giql_is_new_cluster flag. When
+            # hide_reserved is set (the default; MERGE opts out — see
+            # expand_cluster_query), rewrite the star to EXCEPT the flag so it never
+            # surfaces; non-star items pass through unchanged (#184).
+            hidden = (
+                _star_excepting_reserved(expression, CLUSTER_FLAG_COL)
+                if hide_reserved
+                else None
+            )
+            new_expressions.append(expression if hidden is None else hidden)
 
     # Build new query
     new_query = exp.Select()
@@ -369,6 +394,44 @@ def _transform_for_cluster(
         new_query.order_by(*query.args["order"].expressions, copy=False)
 
     return new_query
+
+
+def _star_excepting_reserved(
+    expression: exp.Expression, reserved: str
+) -> exp.Star | None:
+    """Return a bare ``* EXCEPT (reserved)`` star, or ``None`` for a non-bare-star.
+
+    The CLUSTER rewrite's outer query selects from the single ``__giql_lag_calc``
+    subquery, whose ``*`` carries the synthesized ``reserved`` flag
+    (``__giql_is_new_cluster``), so a bare ``*`` outer projection would surface it — and,
+    under a preserved DISTINCT, dedup over it. Replacing the outer star with
+    ``* EXCEPT (reserved)`` hides the flag from the output (#184). Any ``EXCEPT`` the
+    user's own star carried is
+    already applied *inside* ``__giql_lag_calc`` (the inner subquery keeps the original
+    projection node), so the outer star only needs to drop the flag, never the user's
+    columns.
+
+    The hiding is applied *eagerly*, at the same projection level as the outer star —
+    NOT via an outer-wrapping statement finalizer like NEAREST's
+    (:func:`giql.expanders.nearest._make_reserved_column_finalizer`). It must be:
+    ``transplant`` re-attaches the user's ``DISTINCT`` onto this outer query, so a
+    finalizer that wrapped it in ``SELECT * EXCEPT (...) FROM (<this>)`` would dedup
+    over the flag *before* stripping it (splitting rows that should collapse). NEAREST
+    can wrap because its reserved columns surface through an arbitrary enclosing SELECT
+    it does not own; CLUSTER owns its outer star at build time and must excise the flag
+    in place. A future consolidation (#187) must preserve this level constraint.
+
+    Only a bare ``*`` (an :class:`~sqlglot.expressions.Star`) is handled; a qualified
+    ``rel.*`` returns ``None`` and passes through unchanged — a separate, pre-existing
+    non-executable shape the rewrite does not resolve (the outer FROM is the renamed
+    ``__giql_lag_calc``, so ``rel.*`` already dangles independent of this hiding; #185).
+    ``* EXCEPT`` is the portable exclusion form GIQL already relies on (the coordinate
+    canonicalizer and the NEAREST fallback finalizer emit it too), so sqlglot renders
+    the target spelling (``EXCLUDE`` for DuckDB) without a capability branch here.
+    """
+    if isinstance(expression, exp.Star):
+        return exp.Star(except_=[exp.column(reserved, quoted=True)])
+    return None
 
 
 def _rewrite_predecessor_refs(

--- a/src/giql/expanders/merge.py
+++ b/src/giql/expanders/merge.py
@@ -190,8 +190,11 @@ def _transform_for_merge(
     if query.args.get("where"):
         cluster_query.set("where", query.args["where"].copy())
 
-    # Apply CLUSTER transformation to get the CTE-based query
-    clustered = expand_cluster_query(cluster_query, columns)
+    # Apply CLUSTER transformation to get the CTE-based query. hide_reserved=False:
+    # MERGE opts out of CLUSTER's flag-hiding (#184) because its explicit outer
+    # projection (chrom, MIN/MAX) never surfaces __giql_is_new_cluster, so hiding it
+    # would only add a needless ``* EXCEPT`` to this intermediate clustered subquery.
+    clustered = expand_cluster_query(cluster_query, columns, hide_reserved=False)
     assert clustered is not None, "intermediate MERGE cluster query has no CLUSTER"
     cluster_query = clustered
 

--- a/src/giql/targets.py
+++ b/src/giql/targets.py
@@ -92,11 +92,15 @@ class GenericTarget(Target):
     every coordinate-canonicalization site over a **non-canonical** target falls
     back to a ``SELECT * EXCEPT (...)`` projection (re-appending the recomputed
     interval columns) — the canonicalizer wrapper CTE and the DISJOIN / NEAREST
-    passthroughs alike. ``* EXCEPT`` is **not** SQL-92 and is **not
-    DuckDB-runnable** — it is a DataFusion-family extension — so the generic
-    target's non-canonical output runs only on an ``* EXCEPT``-capable engine.
-    A canonical (0-based half-open) target passes the row through as a plain,
-    fully portable ``SELECT *``.
+    passthroughs alike. A star-projected CLUSTER is a further ``* EXCEPT`` site
+    (independent of canonicalization): it hides its synthesized
+    ``__giql_is_new_cluster`` flag with ``* EXCEPT`` (#184). ``* EXCEPT`` is **not**
+    SQL-92 and is **not DuckDB-runnable** — it is a DataFusion-family extension — so
+    the generic target's output from any of these sites runs only on an
+    ``* EXCEPT``-capable engine (transpile with ``dialect="duckdb"`` to execute on
+    DuckDB, where it spells the exclusion ``EXCLUDE``). A canonical (0-based
+    half-open) target with no star-projected CLUSTER passes the row through as a
+    plain, fully portable ``SELECT *``.
     """
 
     name: str = "generic"

--- a/tests/expanders/test_cluster.py
+++ b/tests/expanders/test_cluster.py
@@ -430,9 +430,12 @@ class TestClusterExpander:
         )
 
         # Act
+        # dialect="duckdb" so the flag-hiding star emits DuckDB's EXCLUDE spelling
+        # (#184); the generic EXCEPT form is not DuckDB-executable.
         sql = transpile(
             "SELECT *, CLUSTER(interval) AS cluster_id FROM intervals",
             tables=["intervals"],
+            dialect="duckdb",
         )
         cursor = conn.execute(sql)
         columns = [desc[0] for desc in cursor.description]
@@ -441,6 +444,8 @@ class TestClusterExpander:
         # Assert
         assert [r["cluster_id"] for r in rows] == [1, 1, 2]
         assert [r["is_new_cluster"] for r in rows] == [7, 7, 7]
+        # The synthesized flag is hidden; only the user's is_new_cluster surfaces.
+        assert "__giql_is_new_cluster" not in columns
 
     @pytest.mark.parametrize(
         "query, expected_with",
@@ -514,7 +519,9 @@ class TestClusterExpander:
         )
 
         # Act
-        sql = transpile(query, tables=["peaks"])
+        # dialect="duckdb" so the flag-hiding star emits DuckDB's EXCLUDE spelling
+        # (#184); the generic EXCEPT form is not DuckDB-executable.
+        sql = transpile(query, tables=["peaks"], dialect="duckdb")
         cursor = conn.execute(sql)
         columns = [desc[0] for desc in cursor.description]
         rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
@@ -651,6 +658,168 @@ class TestClusterExpander:
 
         # Assert
         assert rows == [("chr1", 1)]
+
+    def test_transpile_should_hide_flag_when_cluster_projects_star(self):
+        """Test that a star-projected CLUSTER EXCEPTs the synthesized flag.
+
+        Given:
+            A top-level CLUSTER with a SELECT * projection.
+        When:
+            Transpiling the query.
+        Then:
+            The outer star should EXCEPT the synthesized __giql_is_new_cluster flag so
+            it never surfaces in the query output (#184), and the bare flag name
+            should not appear as a projected column.
+        """
+        # Act
+        sql = transpile(
+            "SELECT *, CLUSTER(interval) AS cid FROM peaks", tables=["peaks"]
+        )
+
+        # Assert
+        assert 'EXCEPT ("__giql_is_new_cluster")' in sql
+
+    def test_transpile_should_execute_star_without_flag_when_cluster_projects_star(
+        self,
+    ):
+        """Test that a star-projected CLUSTER omits the flag from its output columns.
+
+        Given:
+            A star-projected CLUSTER over a seeded table.
+        When:
+            Transpiling for DuckDB and executing it.
+        Then:
+            The output columns should be exactly the user columns plus the cluster id,
+            with the synthesized __giql_is_new_cluster flag hidden (#184), and the
+            cluster ids should be correct.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 15, 30), ("chr1", 100, 110)],
+        )
+
+        # Act
+        sql = transpile(
+            "SELECT *, CLUSTER(interval) AS cid FROM peaks",
+            tables=["peaks"],
+            dialect="duckdb",
+        )
+        cursor = conn.execute(sql)
+        columns = [desc[0] for desc in cursor.description]
+        rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+
+        # Assert
+        assert columns == ["chrom", "start", "end", "cid"]
+        assert sorted(r["cid"] for r in rows) == [1, 1, 2]
+
+    def test_transpile_should_apply_user_except_inside_and_hide_flag_outside(self):
+        """Test that a user's own EXCEPT survives while the flag is still hidden.
+
+        Given:
+            A star-projected CLUSTER whose projection carries a user EXCEPT on a column.
+        When:
+            Transpiling for DuckDB and executing it.
+        Then:
+            The user-excepted column should be dropped (applied inside the lag_calc
+            subquery) and the synthesized flag should also be absent, leaving the
+            remaining user columns plus the cluster id (#184).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE peaks "
+            '(chrom VARCHAR, "start" INTEGER, "end" INTEGER, score INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?, ?)",
+            [("chr1", 10, 20, 5), ("chr1", 15, 30, 5), ("chr1", 100, 110, 9)],
+        )
+
+        # Act
+        sql = transpile(
+            "SELECT * EXCEPT (score), CLUSTER(interval) AS cid FROM peaks",
+            tables=["peaks"],
+            dialect="duckdb",
+        )
+        columns = [desc[0] for desc in conn.execute(sql).description]
+
+        # Assert
+        assert columns == ["chrom", "start", "end", "cid"]
+
+    def test_transpile_should_dedup_star_without_flag_when_cluster_distinct(self):
+        """Test that DISTINCT over a star-projected CLUSTER dedups without the flag.
+
+        Given:
+            A CLUSTER over rows that collapse to one distinct interval, projected with
+            DISTINCT over a bare star.
+        When:
+            Transpiling for DuckDB and executing it.
+        Then:
+            The output should dedup to the single distinct row rather than splitting on
+            the now-hidden __giql_is_new_cluster flag — the star-leak fix (#184) also
+            resolves the DISTINCT-star dedup confound noted in #181.
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 10, 20), ("chr1", 10, 20)],
+        )
+
+        # Act
+        sql = transpile(
+            "SELECT DISTINCT *, CLUSTER(interval) AS cid FROM peaks",
+            tables=["peaks"],
+            dialect="duckdb",
+        )
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [("chr1", 10, 20, 1)]
+
+    def test_transpile_should_hide_flag_when_cluster_nested_below_root(self):
+        """Test that a nested CLUSTER's flag does not leak through an enclosing star.
+
+        Given:
+            A star-projected CLUSTER nested inside a FROM-subquery, with the outer
+            query projecting a bare star over it.
+        When:
+            Transpiling for DuckDB and executing it.
+        Then:
+            The nested CLUSTER should EXCEPT its synthesized flag so the enclosing
+            star does not re-surface it — hiding runs for every CLUSTER expansion,
+            not only a root one (#184).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 15, 30), ("chr1", 100, 110)],
+        )
+        query = "SELECT * FROM (SELECT *, CLUSTER(interval) AS cid FROM peaks) x"
+
+        # Act
+        sql = transpile(query, tables=["peaks"], dialect="duckdb")
+        columns = [desc[0] for desc in conn.execute(sql).description]
+
+        # Assert
+        assert "__giql_is_new_cluster" not in columns
+        assert columns == ["chrom", "start", "end", "cid"]
 
     def test_transpile_should_execute_when_cluster_with_limit_and_offset(self):
         """Test that CLUSTER with LIMIT/OFFSET returns the correct row window.

--- a/tests/expanders/test_merge.py
+++ b/tests/expanders/test_merge.py
@@ -617,3 +617,22 @@ class TestMergeExpander:
 
         # Assert
         assert "SELECT DISTINCT" in sql
+
+    def test_transpile_should_not_hide_flag_when_merge(self):
+        """Test that MERGE's composed CLUSTER does not add a flag-hiding star.
+
+        Given:
+            A plain MERGE query.
+        When:
+            Transpiling the query.
+        Then:
+            The emitted SQL should not carry a flag-hiding ``* EXCEPT`` / ``EXCLUDE``
+            wrapper: MERGE composes CLUSTER with hide_reserved disabled because its
+            explicit outer projection never surfaces the __giql_is_new_cluster flag,
+            so no needless exclusion is added to the intermediate subquery (#184).
+        """
+        # Act
+        sql = transpile("SELECT MERGE(interval) FROM peaks", tables=["peaks"])
+
+        # Assert
+        assert 'EXCEPT ("__giql_is_new_cluster")' not in sql

--- a/tests/integration/bedtools/conftest.py
+++ b/tests/integration/bedtools/conftest.py
@@ -51,7 +51,11 @@ def giql_query(duckdb_connection):
                 name,
                 [i.to_tuple() for i in intervals],
             )
-        sql = transpile(query, tables=tables)
+        # Transpile for DuckDB: this helper always executes on the DuckDB
+        # connection, and some operators (e.g. a star-projected CLUSTER, #184) emit
+        # DuckDB-specific spellings such as ``* EXCLUDE`` that the portable generic
+        # ``* EXCEPT`` form does not share.
+        sql = transpile(query, tables=tables, dialect="duckdb")
         return duckdb_connection.execute(sql).fetchall()
 
     return _run

--- a/tests/integration/bedtools/test_cluster.py
+++ b/tests/integration/bedtools/test_cluster.py
@@ -40,6 +40,9 @@ def test_cluster_basic(duckdb_connection):
         FROM intervals
         """,
         tables=["intervals"],
+        # dialect="duckdb": a star-projected CLUSTER emits DuckDB's EXCLUDE
+        # flag-hiding spelling (#184); the generic EXCEPT form is not DuckDB-runnable.
+        dialect="duckdb",
     )
     giql_result = duckdb_connection.execute(sql).fetchall()
 
@@ -89,6 +92,9 @@ def test_cluster_separated(duckdb_connection):
         FROM intervals
         """,
         tables=["intervals"],
+        # dialect="duckdb": a star-projected CLUSTER emits DuckDB's EXCLUDE
+        # flag-hiding spelling (#184); the generic EXCEPT form is not DuckDB-runnable.
+        dialect="duckdb",
     )
     giql_result = duckdb_connection.execute(sql).fetchall()
 
@@ -123,6 +129,9 @@ def test_cluster_multiple_chromosomes(duckdb_connection):
         FROM intervals
         """,
         tables=["intervals"],
+        # dialect="duckdb": a star-projected CLUSTER emits DuckDB's EXCLUDE
+        # flag-hiding spelling (#184); the generic EXCEPT form is not DuckDB-runnable.
+        dialect="duckdb",
     )
     giql_result = duckdb_connection.execute(sql).fetchall()
 
@@ -163,6 +172,9 @@ def test_cluster_stranded(duckdb_connection):
         FROM intervals
         """,
         tables=["intervals"],
+        # dialect="duckdb": a star-projected CLUSTER emits DuckDB's EXCLUDE
+        # flag-hiding spelling (#184); the generic EXCEPT form is not DuckDB-runnable.
+        dialect="duckdb",
     )
     giql_result = duckdb_connection.execute(sql).fetchall()
 

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -688,29 +688,34 @@ class TestCrossTargetOracleNearest:
             copy+transplant relocates the fallback join, and the finalizer must
             re-locate it by its reserved marker to wrap away the reserved columns.
         Then:
-            Every target should return each nearest gene (``genes.* + distance``),
-            CLUSTER's own ``__giql_is_new_cluster`` helper, and the cluster id, and
-            agree. No reserved ``__giql_x_*`` NEAREST column leaks through the
-            enclosing ``SELECT *`` (formerly a #172 residual) — a leak would surface
-            four extra columns and break the cross-target column-count agreement.
+            Every target should return each nearest gene (``genes.* + distance``) and
+            the cluster id, and agree. CLUSTER's own ``__giql_is_new_cluster`` flag is
+            hidden from the ``SELECT *`` output (#184), and no reserved ``__giql_x_*``
+            NEAREST column leaks either (formerly a #172 residual) — a leak of either
+            would surface extra columns and break the cross-target column agreement.
         """
         # Arrange / Act / Assert
-        # The 5th column is CLUSTER's own ``__giql_is_new_cluster`` flag, which a
-        # ``SELECT *, CLUSTER(...)`` surfaces on every target — a separate known
-        # leak family (#161-related), orthogonal to #172. The #172 point is that no
-        # ``__giql_x_*`` reserved NEAREST column joins it and the targets agree.
+        # A top-level ``SELECT *, CLUSTER(...)`` now hides its synthesized
+        # ``__giql_is_new_cluster`` flag with ``* EXCEPT`` / ``EXCLUDE`` (#184), so the
+        # output is (genes.*, distance, cid). Only datafusion + duckdb are exercised:
+        # the generic target's portable SQL for this composition combines a real
+        # correlated LATERAL (which DataFusion cannot plan) with the flag-hiding
+        # ``* EXCEPT`` (which DuckDB does not accept — it spells exclusion
+        # ``EXCLUDE``), so neither available engine can run the generic arm. datafusion
+        # (decorrelated fallback) and duckdb (real LATERAL) still agree, which is the
+        # #172 point.
         cross_target_oracle(
             "SELECT *, CLUSTER(interval) AS cid FROM ("
             "SELECT b.* FROM peaks a "
             "CROSS JOIN LATERAL NEAREST(genes, reference := a.interval, k := 1) b"
             ") sub",
+            targets=["datafusion", "duckdb"],
             peaks=[("chr1", 200, 300), ("chr1", 1000, 1100)],
             genes=[("chr1", 280, 290), ("chr1", 1050, 1060)],
             expected=[
-                ("chr1", 280, 290, 0, 1, 1),
-                ("chr1", 1050, 1060, 0, 1, 2),
+                ("chr1", 280, 290, 0, 1),
+                ("chr1", 1050, 1060, 0, 2),
             ],
-            engines={"generic": "duckdb"},
         )
 
     def test_two_correlated_nearest_star_agrees_across_targets(
@@ -1031,6 +1036,62 @@ class TestCrossTargetOracleCluster:
                 ("chr1", 10, 20, 1),
                 ("chr1", 15, 30, 1),
             ],
+        )
+
+    def test_cluster_star_hides_flag_agrees_across_targets(self, cross_target_oracle):
+        """Test a star-projected CLUSTER hides its flag identically per target (#184).
+
+        Given:
+            Two overlapping intervals and one isolated interval on chr1, projected
+            with a bare SELECT * alongside CLUSTER.
+        When:
+            The star-projected CLUSTER runs on every target.
+        Then:
+            Every target should hide the synthesized __giql_is_new_cluster flag —
+            emitting DuckDB's EXCLUDE and DataFusion's / generic's EXCEPT spelling —
+            so the output is exactly the interval columns plus the cluster id, and all
+            targets agree.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT *, CLUSTER(interval) AS cid FROM peaks",
+            peaks=[
+                ("chr1", 100, 200),
+                ("chr1", 150, 300),
+                ("chr1", 5000, 6000),
+            ],
+            expected=[
+                ("chr1", 100, 200, 1),
+                ("chr1", 150, 300, 1),
+                ("chr1", 5000, 6000, 2),
+            ],
+        )
+
+    def test_cluster_distinct_star_dedups_agrees_across_targets(
+        self, cross_target_oracle
+    ):
+        """Test DISTINCT over a star CLUSTER dedups identically per target (#184/#181).
+
+        Given:
+            Three byte-identical intervals projected with DISTINCT over a bare star
+            alongside CLUSTER.
+        When:
+            The DISTINCT star-projected CLUSTER runs on every target.
+        Then:
+            Every target should hide the flag and dedup to the single distinct row —
+            rather than splitting on the now-hidden __giql_is_new_cluster flag — and
+            agree, proving the star-leak fix resolves the #181 DISTINCT confound on
+            DataFusion as well as DuckDB.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT DISTINCT *, CLUSTER(interval) AS cid FROM peaks",
+            peaks=[
+                ("chr1", 10, 20),
+                ("chr1", 10, 20),
+                ("chr1", 10, 20),
+            ],
+            expected=[("chr1", 10, 20, 1)],
         )
 
 

--- a/tests/test_nearest_transpilation.py
+++ b/tests/test_nearest_transpilation.py
@@ -867,7 +867,9 @@ class TestNearestFallbackReservedColumnProjection:
             The finalizer should re-locate the transplanted join by its reserved
             ``meta`` tag and wrap the enclosing SELECT in ``SELECT * EXCEPT (...)``,
             so no reserved column reaches the output — the former #172 residual is
-            fixed.
+            fixed. The top-level ``SELECT *, CLUSTER(...)`` adds a *second*
+            ``SELECT * EXCEPT (__giql_is_new_cluster)`` to hide its own cluster flag
+            (#184), so the reserved wrapper is the one excepting the NEAREST set.
         """
         # Arrange
         sql = (
@@ -885,13 +887,18 @@ class TestNearestFallbackReservedColumnProjection:
         # Assert
         emitted = _reserved_columns_defined(output)
         assert emitted  # the fallback did synthesize reserved columns
-        # The single reserved wrapper excepts exactly the emitted reserved set.
-        assert output.count("SELECT * EXCEPT (") == 1
-        wrap_start = output.index("SELECT * EXCEPT (")
-        excepted = _wrapper_except_names(output[wrap_start:])
-        assert excepted == emitted
-        # No reserved column survives to the top-level CLUSTER projection.
-        assert not _RESERVED_COLUMN_RE.search(output[:wrap_start])
+        # Locate the wrapper that excepts exactly the reserved NEAREST set (not the
+        # CLUSTER flag wrapper, which excepts __giql_is_new_cluster — #184). Exactly
+        # one wrapper should except that set (uniqueness, as the old count guard held).
+        reserved_wraps = [
+            match.start()
+            for match in re.finditer(re.escape("SELECT * EXCEPT ("), output)
+            if _wrapper_except_names(output[match.start() :]) == emitted
+        ]
+        assert len(reserved_wraps) == 1
+        # No reserved column survives above the NEAREST wrapper into the CLUSTER
+        # projection.
+        assert not _RESERVED_COLUMN_RE.search(output[: reserved_wraps[0]])
 
     def test_expand_two_correlated_nearest_should_wrap_each_reserved_set_on_datafusion(
         self, tables_with_peaks_and_genes


### PR DESCRIPTION
## Summary

A top-level CLUSTER over a star projection (`SELECT *, CLUSTER(interval) AS cid FROM peaks`) surfaced the synthesized `__giql_is_new_cluster` flag as an extra output column: the outer star expands over the inner `__giql_lag_calc` subquery that carries the flag. Under a preserved `DISTINCT` (#181) the query then deduped over that hidden column, returning too many rows.

The fix rewrites the outer star to `* EXCEPT ("__giql_is_new_cluster")` (sqlglot renders DuckDB's `EXCLUDE` and DataFusion's / generic's `EXCEPT`), hiding the flag. Hiding is the **safe default** for every CLUSTER expansion (root or nested); MERGE — which composes the same helper but never surfaces the flag through its explicit outer projection — opts out explicitly, so its intermediate subquery keeps a plain star.

The hiding is applied **eagerly**, at the same projection level as the outer star, rather than via a NEAREST-style outer-wrapping finalizer. This is required for correctness: `transplant` re-attaches the user's `DISTINCT` onto the outer query, so a finalizer wrap would dedup over the flag *before* stripping it.

Closes #184

## Proposed changes

### `src/giql/expanders/cluster.py`

- Add `_star_excepting_reserved`, which returns a bare `* EXCEPT (reserved)` star for a bare `*` projection (and `None` otherwise, so a qualified `rel.*` — a separate pre-existing shape, filed as #185 — passes through untouched). Any `EXCEPT` the user's own star carried is already applied inside `__giql_lag_calc`, so the outer star only drops the flag. The excluded name is quoted, consistent with NEAREST.
- `expand_cluster_query` / `_transform_for_cluster` take `hide_reserved` defaulting to `True` (safe default); `expand_cluster` relies on it, and MERGE (`merge.py`) opts out with `hide_reserved=False`.

### Docs

- `src/giql/targets.py` and `docs/dialect/aggregation-operators.rst`: document that a star-projected CLUSTER is a new generic-target `* EXCEPT` site — transpile with `dialect="duckdb"` to execute on DuckDB, where it spells the exclusion `EXCLUDE`.

## Behavior notes / ripples

- **Dialect spelling:** generic/DataFusion emit `* EXCEPT`, DuckDB emits `* EXCLUDE`. Generic CLUSTER-star output is only executable on an `* EXCEPT`-capable engine. Every test that executes CLUSTER star output on DuckDB now transpiles with `dialect="duckdb"` — the two unit tests, and the **bedtools integration suite** (`giql_query` fixture + the direct CLUSTER transpile calls), which is skipped locally but runs in CI.
- **#172 oracle case:** now asserts the flag is hidden (its expected drops the column) and exercises only datafusion + duckdb — that composition's generic SQL combines a real LATERAL (unplannable on DataFusion) with `* EXCEPT` (unparseable on DuckDB), so no engine can run the generic arm.
- **#181 A3:** hiding the flag also resolves the DISTINCT-star dedup confound.

## Review

Reviewed by 9 independent reviewers through a principal-SWE + Python/SQL lens (`.sdlc/reviews/issue-#184/review-1.md`): one blocking (B1, the bedtools CI regression, independently found by two reviewers) plus A1–A13 advisory. The adversarial reviewer could not break the fix (and found it *repairs* a pre-existing `* EXCEPT (strand)` bug); five reviewers verified identical output on DuckDB + DataFusion. Round-1 remediation applied: B1 (bedtools `dialect="duckdb"`), A2 (safe default), A7 (documented the eager-vs-finalizer DISTINCT-level invariant), A3 (portability docs), and A1/A4/A5/A6/A8–A11 (wording, naming, quoting, test fixes incl. a nested-CLUSTER test, uniqueness guard, cross-target DISTINCT case). Deferred: qualified `rel.*` (#185) and synthesized-column-hygiene consolidation (#187).

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestClusterExpander` | A star-projected CLUSTER | Transpiling | The outer star EXCEPTs the quoted `__giql_is_new_cluster` | Flag hidden (string) |
| 2 | `TestClusterExpander` | A star-projected CLUSTER | Executing on DuckDB | Output columns are user columns plus `cid`, no flag; ids correct | Flag hidden (execution) |
| 3 | `TestClusterExpander` | A star CLUSTER with a user `EXCEPT` | Executing on DuckDB | User-excepted column and flag both absent | User EXCEPT preserved inside |
| 4 | `TestClusterExpander` | `SELECT DISTINCT *` over a CLUSTER on collapsing rows | Executing on DuckDB | Dedups to the single row, not split on the flag | #181 A3 confound resolved |
| 5 | `TestClusterExpander` | A star CLUSTER nested in a FROM-subquery under an outer star | Executing on DuckDB | The nested flag does not re-surface through the enclosing star | Nested-CLUSTER hiding |
| 6 | `TestMergeExpander` | A plain MERGE | Transpiling | No flag-hiding `* EXCEPT` wrapper is added | MERGE opt-out |
| 7 | `TestCrossTargetOracleCluster` | A star-projected CLUSTER | generic / DuckDB / DataFusion | All targets hide the flag and agree | Cross-target hiding |
| 8 | `TestCrossTargetOracleCluster` | `SELECT DISTINCT *` over a CLUSTER | generic / DuckDB / DataFusion | All targets dedup without the flag and agree | Cross-target DISTINCT |
| 9 | `TestCrossTargetOracleNearest` | `SELECT *` CLUSTER over a correlated NEAREST | datafusion + duckdb | Both the flag and the reserved NEAREST columns are hidden and agree | #172 + #184 composition |

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM