### PR TITLE
Make CLUSTER over a qualified rel.* projection executable — Closes #185

### DIFF
--- a/docs/dialect/aggregation-operators.rst
+++ b/docs/dialect/aggregation-operators.rst
@@ -193,7 +193,7 @@ Find regions with multiple overlapping features:
 
 .. note::
 
-   **Synthesized flag hidden under** ``SELECT *``. A ``SELECT *, CLUSTER(...)`` query materializes an internal ``__giql_is_new_cluster`` flag in a subquery, so the outer star is emitted as ``SELECT * EXCEPT (__giql_is_new_cluster)`` to keep that helper column out of the result (#184). ``* EXCEPT`` is a DataFusion-family extension: the generic and ``datafusion`` dialects emit it, while ``duckdb`` spells the exclusion ``EXCLUDE``. Transpile with ``dialect="duckdb"`` to execute on DuckDB — the portable generic ``* EXCEPT`` form is not DuckDB-runnable. An explicitly-projected ``CLUSTER`` (no star) surfaces no helper column and needs no exclusion.
+   **Synthesized flag hidden under** ``SELECT *``. A ``SELECT *, CLUSTER(...)`` query materializes an internal ``__giql_is_new_cluster`` flag in a subquery, so the outer star is emitted as ``SELECT * EXCEPT (__giql_is_new_cluster)`` to keep that helper column out of the result (#184). ``* EXCEPT`` is a DataFusion-family extension: the generic and ``datafusion`` dialects emit it, while ``duckdb`` spells the exclusion ``EXCLUDE``. Transpile with ``dialect="duckdb"`` to execute on DuckDB — the portable generic ``* EXCEPT`` form is not DuckDB-runnable. A qualified ``SELECT t.*, CLUSTER(...)`` receives the same treatment: because ``CLUSTER`` runs over a single relation, the qualifier is dropped and the outer star is emitted as the same bare ``* EXCEPT (__giql_is_new_cluster)`` (#185). An explicitly-projected ``CLUSTER`` (no star) surfaces no helper column and needs no exclusion.
 
 Performance Notes
 ~~~~~~~~~~~~~~~~~

--- a/src/giql/expanders/_genomic.py
+++ b/src/giql/expanders/_genomic.py
@@ -164,6 +164,23 @@ def _resolve_source(
     return None, True
 
 
+def is_star_projection(expression: exp.Expression) -> bool:
+    """Return ``True`` for a bare ``*`` or a qualified ``rel.*`` projection.
+
+    A bare star parses as an :class:`~sqlglot.expressions.Star`; a qualified ``rel.*``
+    parses as an :class:`~sqlglot.expressions.Column` wrapping a ``Star``, not a bare
+    ``Star``. Both project every column of their source, so any caller that special-cases
+    "this projection surfaces all of the relation's columns" must recognize both shapes
+    identically. Defining the predicate once keeps the CLUSTER required-column dedup, the
+    CLUSTER outer-star rewrite, and this module's derived-table passthrough check from
+    drifting apart — a drift whose failure modes are exactly a dangling ``rel.*`` alias
+    and duplicated required columns (#185).
+    """
+    return isinstance(expression, exp.Star) or (
+        isinstance(expression, exp.Column) and isinstance(expression.this, exp.Star)
+    )
+
+
 def _resolve_query(
     query: exp.Expression, tables: Tables, seen: frozenset[str]
 ) -> tuple[GenomicColumns | None, bool]:
@@ -188,11 +205,7 @@ def _resolve_query(
         return None, True
 
     projections = query.expressions
-    passes_through = any(
-        isinstance(projection, exp.Star)
-        or (isinstance(projection, exp.Column) and isinstance(projection.this, exp.Star))
-        for projection in projections
-    )
+    passes_through = any(is_star_projection(projection) for projection in projections)
     if passes_through:
         return _resolve_from_columns(query, tables, seen)
 

--- a/src/giql/expanders/cluster.py
+++ b/src/giql/expanders/cluster.py
@@ -21,9 +21,9 @@ becomes::
     ) AS __giql_lag_calc
 
 (The ``becomes::`` form is simplified for readability; the emitted SQL quotes
-identifiers, appends ``NULLS LAST`` to the window ORDER BY, and — for a star
-projection — emits the outer star as ``* EXCEPT (__giql_is_new_cluster)`` to hide the
-synthesized flag from the output (#184).)
+identifiers, appends ``NULLS LAST`` to the window ORDER BY, and — for a bare or
+qualified star projection — emits the outer star as ``* EXCEPT (__giql_is_new_cluster)``
+to hide the synthesized flag from the output (#184, #185).)
 
 This module is the AST-expansion replacement for the legacy
 :class:`giql.transformer.ClusterTransformer`, which ran as a pre-pass transformer
@@ -63,6 +63,7 @@ from giql.expanders._genomic import GenomicColumns
 from giql.expanders._genomic import extract_stranded
 from giql.expanders._genomic import find_projected
 from giql.expanders._genomic import genomic_columns
+from giql.expanders._genomic import is_star_projection
 from giql.expanders._genomic import reject_cluster_merge_mix
 from giql.expanders._genomic import require_top_level_projection
 from giql.expanders._genomic import transplant
@@ -306,15 +307,20 @@ def _transform_for_cluster(
     # Check if required columns are already in the select list
     selected_cols = set()
     for expr in cte_expressions:
-        if isinstance(expr, exp.Column):
+        if is_star_projection(expr):
+            # A bare ``*`` or a qualified ``rel.*`` covers every column. A qualified
+            # ``rel.*`` parses as a Column wrapping a Star, so it must be caught here,
+            # before the plain-Column branch below — whose ``.name`` for a star is the
+            # literal ``'*'`` (never a required-column name), so it would leave chrom/
+            # start/end seen as missing and re-inject them as chrom_1/start_1/end_1
+            # duplicates (#185).
+            selected_cols = required_cols  # Assume all are covered
+            break
+        elif isinstance(expr, exp.Column):
             selected_cols.add(expr.name)
         elif isinstance(expr, exp.Alias):
             # Don't count aliases as the source column
             pass
-        elif isinstance(expr, exp.Star):
-            # SELECT * includes all columns
-            selected_cols = required_cols  # Assume all are covered
-            break
 
     # Add missing required columns
     # Sort the residual so the injected-column order is deterministic across runs
@@ -363,17 +369,17 @@ def _transform_for_cluster(
                 exp.alias_(sum_window, expression.alias, quoted=False)
             )
         else:
-            # A star projection expands over the inner __giql_lag_calc subquery,
-            # which carries the synthesized __giql_is_new_cluster flag. When
+            # A star projection (bare ``*`` or qualified ``rel.*``) expands over the
+            # inner __giql_lag_calc subquery. It is always rewritten to a *bare* outer
+            # star (dropping any dangling ``rel.`` qualifier — an executability fix), and
+            # the synthesized __giql_is_new_cluster flag is EXCEPTed from it only when
             # hide_reserved is set (the default; MERGE opts out — see
-            # expand_cluster_query), rewrite the star to EXCEPT the flag so it never
-            # surfaces; non-star items pass through unchanged (#184).
-            hidden = (
-                _star_excepting_reserved(expression, CLUSTER_FLAG_COL)
-                if hide_reserved
-                else None
+            # expand_cluster_query). Non-star items pass through unchanged. See
+            # _outer_star_over_lag_calc for why the two concerns are gated separately.
+            rewritten = _outer_star_over_lag_calc(
+                expression, CLUSTER_FLAG_COL, hide_reserved
             )
-            new_expressions.append(expression if hidden is None else hidden)
+            new_expressions.append(expression if rewritten is None else rewritten)
 
     # Build new query
     new_query = exp.Select()
@@ -396,20 +402,35 @@ def _transform_for_cluster(
     return new_query
 
 
-def _star_excepting_reserved(
-    expression: exp.Expression, reserved: str
+def _outer_star_over_lag_calc(
+    expression: exp.Expression, reserved: str, hide_reserved: bool
 ) -> exp.Star | None:
-    """Return a bare ``* EXCEPT (reserved)`` star, or ``None`` for a non-bare-star.
+    """Rewrite a star projection for the outer query over ``__giql_lag_calc``.
 
-    The CLUSTER rewrite's outer query selects from the single ``__giql_lag_calc``
-    subquery, whose ``*`` carries the synthesized ``reserved`` flag
-    (``__giql_is_new_cluster``), so a bare ``*`` outer projection would surface it — and,
-    under a preserved DISTINCT, dedup over it. Replacing the outer star with
-    ``* EXCEPT (reserved)`` hides the flag from the output (#184). Any ``EXCEPT`` the
-    user's own star carried is
-    already applied *inside* ``__giql_lag_calc`` (the inner subquery keeps the original
-    projection node), so the outer star only needs to drop the flag, never the user's
-    columns.
+    Returns a *bare* :class:`~sqlglot.expressions.Star` for a bare ``*`` or a qualified
+    ``rel.*`` outer projection, or ``None`` for any non-star item (which passes through
+    unchanged). Two independent concerns are handled here, deliberately on separate
+    gates:
+
+    **Normalization to a bare star — always.** The CLUSTER rewrite's outer query selects
+    from the single renamed ``__giql_lag_calc`` subquery, so the user's ``rel.``
+    qualifier no longer resolves there — an un-rewritten ``rel.*`` would dangle
+    (``Binder Error: Referenced table "rel" not found``). CLUSTER runs over a single
+    relation (joins are rejected upstream by
+    :func:`giql.expanders._genomic.genomic_columns`), so every column ``rel.*`` would
+    have named is exactly the subquery's projection, making ``rel.*`` equivalent to
+    ``*``. The qualifier is therefore *always* dropped to a bare star. This is an
+    **executability** fix (without it the query does not bind), so it must NOT be gated
+    on the cosmetic *hide_reserved* flag (#185). Any ``EXCEPT`` the user's own star
+    carried is already applied *inside* ``__giql_lag_calc`` (the inner subquery keeps
+    the original projection node), so the outer bare star never needs to carry it.
+
+    **Flag-hiding — only when *hide_reserved*.** The subquery's ``*`` also carries the
+    synthesized ``reserved`` flag (``__giql_is_new_cluster``), so a bare outer ``*``
+    would surface it — and, under a preserved DISTINCT, dedup over it. When
+    *hide_reserved* is set (the default; MERGE opts out — its explicit projection never
+    surfaces the flag), the bare star is emitted as ``* EXCEPT (reserved)`` to hide it
+    (#184).
 
     The hiding is applied *eagerly*, at the same projection level as the outer star —
     NOT via an outer-wrapping statement finalizer like NEAREST's
@@ -421,17 +442,15 @@ def _star_excepting_reserved(
     it does not own; CLUSTER owns its outer star at build time and must excise the flag
     in place. A future consolidation (#187) must preserve this level constraint.
 
-    Only a bare ``*`` (an :class:`~sqlglot.expressions.Star`) is handled; a qualified
-    ``rel.*`` returns ``None`` and passes through unchanged — a separate, pre-existing
-    non-executable shape the rewrite does not resolve (the outer FROM is the renamed
-    ``__giql_lag_calc``, so ``rel.*`` already dangles independent of this hiding; #185).
     ``* EXCEPT`` is the portable exclusion form GIQL already relies on (the coordinate
     canonicalizer and the NEAREST fallback finalizer emit it too), so sqlglot renders
     the target spelling (``EXCLUDE`` for DuckDB) without a capability branch here.
     """
-    if isinstance(expression, exp.Star):
+    if not is_star_projection(expression):
+        return None
+    if hide_reserved:
         return exp.Star(except_=[exp.column(reserved, quoted=True)])
-    return None
+    return exp.Star()
 
 
 def _rewrite_predecessor_refs(

--- a/tests/expanders/test_cluster.py
+++ b/tests/expanders/test_cluster.py
@@ -821,6 +821,181 @@ class TestClusterExpander:
         assert "__giql_is_new_cluster" not in columns
         assert columns == ["chrom", "start", "end", "cid"]
 
+    def test_transpile_should_execute_when_cluster_projects_qualified_star(self):
+        """Test that a CLUSTER over a qualified rel.* projection executes.
+
+        Given:
+            A CLUSTER whose projection is a qualified ``t.*`` over an aliased FROM.
+        When:
+            Transpiling for DuckDB and executing it.
+        Then:
+            The query should run rather than raising a binder error for the missing
+            ``t`` alias — the outer FROM is the renamed __giql_lag_calc subquery, so the
+            outer ``t.*`` is rewritten to a bare star that resolves against it — and the
+            cluster ids should be correct (#185).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 15, 30), ("chr1", 100, 110)],
+        )
+
+        # Act
+        sql = transpile(
+            "SELECT t.*, CLUSTER(interval) AS cid FROM peaks t",
+            tables=["peaks"],
+            dialect="duckdb",
+        )
+        rows = conn.execute(sql).fetchall()
+
+        # Assert
+        assert rows == [("chr1", 10, 20, 1), ("chr1", 15, 30, 1), ("chr1", 100, 110, 2)]
+
+    def test_transpile_should_not_duplicate_columns_when_qualified_star(self):
+        """Test that a qualified rel.* CLUSTER does not duplicate required columns.
+
+        Given:
+            A CLUSTER over a qualified ``t.*`` projection, whose required chrom/start/end
+            columns the flag-building subquery would re-inject if it failed to see the
+            qualified star as a full-column projection.
+        When:
+            Transpiling for DuckDB and executing it.
+        Then:
+            The output columns should be exactly the table's columns plus the cluster id,
+            with no duplicated chrom_1/start_1/end_1 columns and no synthesized flag
+            (#185).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?)",
+            [("chr1", 10, 20), ("chr1", 15, 30), ("chr1", 100, 110)],
+        )
+
+        # Act
+        sql = transpile(
+            "SELECT t.*, CLUSTER(interval) AS cid FROM peaks t",
+            tables=["peaks"],
+            dialect="duckdb",
+        )
+        columns = [desc[0] for desc in conn.execute(sql).description]
+
+        # Assert
+        assert columns == ["chrom", "start", "end", "cid"]
+
+    def test_transpile_should_hide_flag_when_cluster_projects_qualified_star(self):
+        """Test that a qualified rel.* CLUSTER EXCEPTs the synthesized flag.
+
+        Given:
+            A top-level CLUSTER with a qualified ``t.*`` projection.
+        When:
+            Transpiling the query.
+        Then:
+            The outer star should be rewritten to a bare ``* EXCEPT`` that drops the
+            synthesized __giql_is_new_cluster flag, extending the bare-star flag-hiding
+            (#184) to the qualified form (#185).
+        """
+        # Act
+        sql = transpile(
+            "SELECT t.*, CLUSTER(interval) AS cid FROM peaks t", tables=["peaks"]
+        )
+
+        # Assert
+        assert 'EXCEPT ("__giql_is_new_cluster")' in sql
+
+    def test_transpile_should_not_reinject_columns_in_lag_calc_when_qualified_star(
+        self,
+    ):
+        """Test that a qualified star does not re-inject required columns into lag_calc.
+
+        Given:
+            A CLUSTER over a qualified ``t.*`` projection, whose lag_calc subquery would
+            re-inject the required chrom/start/end columns if it failed to recognize the
+            qualified star as covering all columns.
+        When:
+            Transpiling the query.
+        Then:
+            The inner __giql_lag_calc projection should carry the qualified star directly
+            followed by the synthesized flag, with no re-injected chrom/start/end columns
+            between them — isolating the duplication defect in the emitted SQL,
+            independent of any engine's tolerance for duplicate column names (#185).
+        """
+        # Act
+        sql = transpile(
+            "SELECT t.*, CLUSTER(interval) AS cid FROM peaks t", tables=["peaks"]
+        )
+
+        # Assert
+        assert "t.*, CASE" in sql
+        assert 't.*, "chrom"' not in sql
+
+    def test_transpile_should_drop_qualifier_when_multipart_qualified_star(self):
+        """Test that a multi-part db.t.* projection drops its qualifier at the outer.
+
+        Given:
+            A CLUSTER over a multi-part qualified ``db.t.*`` projection.
+        When:
+            Transpiling the query.
+        Then:
+            The outer projection should be a bare flag-hiding star with the dangling
+            ``db.t`` qualifier dropped (CLUSTER is single-relation), while the inner
+            lag_calc retains the original ``db.t.*`` against the aliased base table
+            (#185).
+        """
+        # Act
+        sql = transpile(
+            "SELECT db.t.*, CLUSTER(interval) AS cid FROM peaks t", tables=["peaks"]
+        )
+
+        # Assert
+        assert 'SELECT * EXCEPT ("__giql_is_new_cluster"), SUM(' in sql
+        assert "db.t.*, CASE" in sql
+
+    def test_transpile_should_apply_user_except_when_qualified_star(self):
+        """Test that a user's EXCEPT on a qualified star survives while the flag hides.
+
+        Given:
+            A qualified ``t.* EXCEPT (score)`` CLUSTER projection over an aliased FROM.
+        When:
+            Transpiling for DuckDB and executing it.
+        Then:
+            The user-excepted column should be dropped (applied inside the lag_calc
+            subquery, which retains the qualified projection) and the synthesized flag
+            should also be absent, leaving the remaining user columns plus the cluster id
+            (#185).
+        """
+        # Arrange
+        duckdb = pytest.importorskip("duckdb")
+        conn = duckdb.connect(":memory:")
+        conn.execute(
+            "CREATE TABLE peaks "
+            '(chrom VARCHAR, "start" INTEGER, "end" INTEGER, score INTEGER)'
+        )
+        conn.executemany(
+            "INSERT INTO peaks VALUES (?, ?, ?, ?)",
+            [("chr1", 10, 20, 5), ("chr1", 15, 30, 6), ("chr1", 100, 110, 9)],
+        )
+
+        # Act
+        sql = transpile(
+            "SELECT t.* EXCEPT (score), CLUSTER(interval) AS cid FROM peaks t",
+            tables=["peaks"],
+            dialect="duckdb",
+        )
+        columns = [desc[0] for desc in conn.execute(sql).description]
+
+        # Assert
+        assert columns == ["chrom", "start", "end", "cid"]
+
     def test_transpile_should_execute_when_cluster_with_limit_and_offset(self):
         """Test that CLUSTER with LIMIT/OFFSET returns the correct row window.
 

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -1094,6 +1094,62 @@ class TestCrossTargetOracleCluster:
             expected=[("chr1", 10, 20, 1)],
         )
 
+    def test_cluster_qualified_star_agrees_across_targets(self, cross_target_oracle):
+        """Test a qualified rel.* CLUSTER runs and agrees across targets (#185).
+
+        Given:
+            Two overlapping intervals and one isolated interval on chr1, projected
+            with a qualified ``p.*`` over an aliased FROM alongside CLUSTER.
+        When:
+            The qualified-star CLUSTER runs on every target.
+        Then:
+            Every target should rewrite the outer ``p.*`` to a bare flag-hiding star
+            that resolves against the renamed subquery — rather than dangling on the
+            missing ``p`` alias or duplicating the required columns — so the output is
+            exactly the interval columns plus the cluster id, and all targets agree.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT p.*, CLUSTER(interval) AS cid FROM peaks p",
+            peaks=[
+                ("chr1", 100, 200),
+                ("chr1", 150, 300),
+                ("chr1", 5000, 6000),
+            ],
+            expected=[
+                ("chr1", 100, 200, 1),
+                ("chr1", 150, 300, 1),
+                ("chr1", 5000, 6000, 2),
+            ],
+        )
+
+    def test_cluster_distinct_qualified_star_dedups_agrees_across_targets(
+        self, cross_target_oracle
+    ):
+        """Test DISTINCT qualified-star CLUSTER dedups per target (#185/#184/#181).
+
+        Given:
+            Three byte-identical intervals projected with DISTINCT over a qualified
+            ``p.*`` over an aliased FROM alongside CLUSTER.
+        When:
+            The DISTINCT qualified-star CLUSTER runs on every target.
+        Then:
+            Every target should drop the ``p.`` qualifier to a bare flag-hiding star and
+            dedup to the single distinct row — confirming the eager-hiding design holds
+            for the qualified form under a preserved DISTINCT (the documented
+            load-bearing case) — and agree.
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT DISTINCT p.*, CLUSTER(interval) AS cid FROM peaks p",
+            peaks=[
+                ("chr1", 10, 20),
+                ("chr1", 10, 20),
+                ("chr1", 10, 20),
+            ],
+            expected=[("chr1", 10, 20, 1)],
+        )
+
 
 class TestCrossTargetOracleMerge:
     """MERGE identity across all targets (T2)."""


### PR DESCRIPTION
## Summary

A CLUSTER projected over a **qualified** star (`SELECT t.*, CLUSTER(interval) FROM peaks t`) transpiled to non-executable SQL. A bare `*` worked; only the qualified `rel.*` form was affected. Two distinct defects combined, both pre-existing on `main`:

1. **Dangling table alias.** The whole-query rewrite replaces the FROM with the synthesized `__giql_lag_calc` subquery, but the outer projection still read `t.*`. `t` no longer exists at the outer level, so DuckDB raised `Binder Error: Referenced table "t" not found`.
2. **Duplicated required columns.** The inner flag-building subquery injects the required `chrom`/`start`/`end` only when they are not already selected, detecting a pass-through star via `isinstance(expr, exp.Star)`. A qualified `t.*` parses as an `exp.Column` wrapping an `exp.Star`, so the check missed it and the columns were re-injected — surfacing as `chrom_1`/`start_1`/`end_1`.

## Fix

- A single shared `is_star_projection` predicate (hoisted into `_genomic.py`, where `_resolve_query`'s passthrough check already encoded the same "bare or qualified star" test) now recognizes both shapes at every site, so the required-column dedup and the outer-star rewrite cannot drift apart.
- The outer-star rewrite (`_outer_star_over_lag_calc`) splits two concerns onto **separate gates**: it *always* normalizes a bare/qualified star to a bare star — dropping a `rel.` qualifier that would dangle against the renamed subquery is an *executability* fix, and CLUSTER runs over a single relation (joins rejected) so `t.*` ≡ `*` — and hides the synthesized flag with `* EXCEPT` *only when* `hide_reserved` (the default; MERGE opts out). This keeps the executability fix off the cosmetic flag-hiding axis so a future `hide_reserved=False` caller cannot silently reintroduce the dangling alias.
- The required-column detection loop treats a qualified star as covering all columns. The inner `__giql_lag_calc` retains the user's original qualified projection (`t.*` / `t.* EXCEPT (...)`), which resolves against the aliased base table — so any user EXCEPT is still applied inside, and the outer bare star only drops the flag.

## Review

9-reviewer principal-SWE review (`.sdlc/reviews/issue-#185/review-1.md`): **0 blocking**, 11 advisory. Remediated: decoupled the executability fix from `hide_reserved` and extracted the shared predicate (A1/A2/A3), corrected an inaccurate `.name` comment (A4), added an inner-projection duplication assertion (A5), a DISTINCT + qualified-star cross-target oracle (A6), and a multi-part `db.t.*` test (A7), plus doc touch-ups (A8/A9). The pre-existing MERGE-over-user-star dangling shape (A11) was filed as #189. Adversarial (reviewer 2) could not break the fix — including the load-bearing DISTINCT case; regression (reviewer 8) confirmed byte-identical SQL on every existing bare-star / explicit-projection / MERGE path.

## Test plan

| Test | Asserts |
| --- | --- |
| `test_transpile_should_execute_when_cluster_projects_qualified_star` | Qualified `t.*` CLUSTER executes on DuckDB (no dangling alias), correct cluster ids |
| `test_transpile_should_not_duplicate_columns_when_qualified_star` | Output columns are exactly the table columns + cid |
| `test_transpile_should_not_reinject_columns_in_lag_calc_when_qualified_star` | Inner lag_calc projection is `t.*` then the flag — no re-injected chrom/start/end |
| `test_transpile_should_drop_qualifier_when_multipart_qualified_star` | `db.t.*` → bare outer star; inner retains `db.t.*` |
| `test_transpile_should_hide_flag_when_cluster_projects_qualified_star` | Outer star rewritten to `* EXCEPT ("__giql_is_new_cluster")` |
| `test_transpile_should_apply_user_except_when_qualified_star` | `t.* EXCEPT (score)` drops score inside, hides flag outside |
| `test_cluster_qualified_star_agrees_across_targets` | Qualified-star rewrite agrees across DataFusion and DuckDB |
| `test_cluster_distinct_qualified_star_dedups_agrees_across_targets` | DISTINCT + qualified star dedups and agrees across targets |

Full suite: **1881 passed / 1 skipped / 90 xfailed, coverage 95.18%**. Lint/format clean.

Closes #185

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM