### PR TITLE
MERGE over a star projection (SELECT *, MERGE(...) / SELECT t.*, MERGE(...)) emits non-executable SQL — Closes #189

### DIFF
--- a/docs/dialect/aggregation-operators.rst
+++ b/docs/dialect/aggregation-operators.rst
@@ -414,6 +414,21 @@ Notes
    separate queries instead — for example, CLUSTER over a subquery, or MERGE
    over one.
 
+.. note::
+
+   MERGE cannot be projected alongside a star. MERGE aggregates rows into one
+   row per merged region, so a ``SELECT *, MERGE(...)`` or ``SELECT t.*,
+   MERGE(...)`` has no coherent per-row meaning — the star names the
+   pre-aggregation input columns of a relation MERGE has already collapsed and
+   grouped away. Transpiling either shape raises a ``ValueError`` rather than
+   emitting non-executable SQL (a bare ``*`` re-surfaces non-grouped columns
+   under the synthesized ``GROUP BY``; a qualified ``rel.*`` dangles an alias the
+   aggregation no longer exposes). Drop the star, or project only grouping
+   columns and aggregates (e.g. ``COUNT(*)``) alongside ``MERGE`` — not raw input
+   columns, which are neither grouped nor aggregated. This is unlike
+   :ref:`CLUSTER <cluster-operator>`, a per-row window over which a star *is*
+   meaningful and supported.
+
 Related Operators
 ~~~~~~~~~~~~~~~~~
 

--- a/src/giql/expanders/merge.py
+++ b/src/giql/expanders/merge.py
@@ -48,6 +48,7 @@ from giql.expanders._genomic import GenomicColumns
 from giql.expanders._genomic import extract_stranded
 from giql.expanders._genomic import find_projected
 from giql.expanders._genomic import genomic_columns
+from giql.expanders._genomic import is_star_projection
 from giql.expanders._genomic import reject_cluster_merge_mix
 from giql.expanders._genomic import require_top_level_projection
 from giql.expanders._genomic import transplant
@@ -85,6 +86,7 @@ def expand_merge(node: GIQLMerge, ctx: ExpansionContext) -> exp.Expression:
         return node
     require_top_level_projection(select, node, GIQLMerge)
     reject_cluster_merge_mix(select)
+    _reject_star_projection(select)
     columns = genomic_columns(select, ctx.tables)
     # Build from a detached copy, then transplant onto the original SELECT to
     # preserve its identity (and rewrite a root SELECT without a parent to replace
@@ -120,6 +122,43 @@ def expand_merge(node: GIQLMerge, ctx: ExpansionContext) -> exp.Expression:
     if result is not select:
         select.replace(result)
     return node
+
+
+def _reject_star_projection(select: exp.Select) -> None:
+    """Raise if *select* projects a star alongside its MERGE. MERGE-specific guard.
+
+    MERGE is an aggregate whole-query rewrite: its output is one row per merged
+    region (``chrom``, ``MIN(start)``, ``MAX(end)``), so a star projected in the
+    same SELECT has no coherent meaning — it names the *pre-aggregation* input
+    columns of a relation the rewrite has already collapsed into ``__giql_clustered``
+    and grouped away. Left unguarded, a bare ``*`` re-surfaces those non-grouped,
+    non-aggregated columns under the synthesized ``GROUP BY`` and a qualified
+    ``rel.*`` dangles a table alias the outer aggregation no longer exposes — both
+    non-executable SQL (#189). Fail loudly here, mirroring the sibling MERGE guards
+    (multiple-MERGE, CLUSTER/MERGE mix), so the shape raises a clear diagnostic
+    instead.
+
+    This is a genuinely MERGE-specific guard — unlike CLUSTER, a per-row window over
+    which a star is meaningful and supported (#184, #185), MERGE collapses rows, so
+    no star projection alongside it is well-formed — hence it lives here rather than
+    in the operator-neutral toolkit. The check is gated on there being a *projected*
+    MERGE (``find_projected``) so a MERGE parsing outside the projection (WHERE /
+    ORDER BY) is left on the expander's existing out-of-projection no-op path
+    rather than rejected. Legitimate sibling items — extra aggregates such as
+    ``COUNT(*)`` (a ``Star`` wrapped in an aggregate, not a bare or qualified star)
+    — are untouched; only a star is rejected.
+    """
+    if not find_projected(select, GIQLMerge):
+        return
+    if any(is_star_projection(projection) for projection in select.expressions):
+        raise ValueError(
+            "MERGE cannot be combined with a star projection (e.g. SELECT *, "
+            "MERGE(...) or SELECT rel.*, MERGE(...)); MERGE aggregates rows into one "
+            "row per merged region, so a star has no coherent per-row meaning. Drop "
+            "the star, or project only grouping columns and aggregates (e.g. "
+            "COUNT(*)) alongside MERGE — not raw input columns, which are neither "
+            "grouped nor aggregated."
+        )
 
 
 def _transform_select_merge(

--- a/tests/expanders/test_merge.py
+++ b/tests/expanders/test_merge.py
@@ -59,6 +59,118 @@ class TestMergeExpander:
         with pytest.raises(ValueError, match="CLUSTER and MERGE cannot be combined"):
             transpile(query, tables=["peaks"])
 
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "SELECT *, MERGE(interval) FROM peaks",
+            "SELECT MERGE(interval), * FROM peaks",
+            "SELECT t.*, MERGE(interval) FROM peaks t",
+            "SELECT t.*, MERGE(interval) AS m FROM peaks t",
+            "SELECT db.t.*, MERGE(interval) FROM peaks t",
+            'SELECT * EXCEPT ("start"), MERGE(interval) FROM peaks',
+            "SELECT MERGE(interval, stranded := true), * FROM peaks",
+        ],
+        ids=[
+            "bare-star-after",
+            "bare-star-before",
+            "qualified-star",
+            "qualified-star-aliased-merge",
+            "multipart-qualified-star",
+            "star-except",
+            "star-with-parameterized-merge",
+        ],
+    )
+    def test_transpile_should_raise_when_merge_shares_select_with_star(self, query):
+        """Test that a star projected alongside MERGE is rejected.
+
+        Given:
+            A SELECT projecting both a MERGE and a star — a bare ``*`` (either
+            order), a qualified ``t.*``, a multi-part ``db.t.*``, a ``* EXCEPT``
+            star (still an ``exp.Star``, carrying exclusion args), or a star beside
+            a parameterized MERGE — optionally with the MERGE aliased.
+        When:
+            Transpiling the query.
+        Then:
+            It should raise ValueError naming the unsupported star-with-MERGE
+            combination, rather than emitting non-executable SQL — a bare ``*``
+            re-surfaces non-grouped columns under the synthesized GROUP BY and a
+            qualified ``rel.*`` dangles an alias the aggregation no longer exposes
+            (#189).
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError, match="MERGE cannot be combined with a star projection"
+        ):
+            transpile(query, tables=["peaks"])
+
+    def test_transpile_should_not_reject_when_merge_shares_select_with_count_star(self):
+        """Test that a COUNT(*) sibling does not trip the star guard.
+
+        Given:
+            A MERGE projected beside ``COUNT(*)`` — whose inner ``*`` is wrapped in
+            an aggregate, not a bare or qualified star projection.
+        When:
+            Transpiling the query.
+        Then:
+            It should not raise the star-with-MERGE error and should expand into the
+            clustered-aggregation form, proving the guard rejects only a bare or
+            qualified star and not an aggregate-wrapped ``*`` (#189).
+        """
+        # Act
+        sql = transpile(
+            "SELECT MERGE(interval), COUNT(*) AS n FROM peaks", tables=["peaks"]
+        )
+
+        # Assert
+        assert "AS __giql_clustered" in sql
+        assert "COUNT(*)" in sql
+        assert "G_I_Q_L" not in sql
+
+    def test_transpile_should_reject_star_in_merge_own_scalar_subquery(self):
+        """Test that the star guard keys on the MERGE's own SELECT scope.
+
+        Given:
+            A MERGE inside a scalar subquery whose own projection carries a star
+            (``SELECT (SELECT *, MERGE(interval) FROM peaks) AS m FROM other``).
+        When:
+            Transpiling the query.
+        Then:
+            It should raise the star-with-MERGE error — the mirror of the
+            FROM-subquery case — proving the guard inspects the MERGE's own
+            enclosing SELECT, not just the outermost query (#189).
+        """
+        # Act & assert
+        with pytest.raises(
+            ValueError, match="MERGE cannot be combined with a star projection"
+        ):
+            transpile(
+                "SELECT (SELECT *, MERGE(interval) FROM peaks) AS m FROM other",
+                tables=["peaks", "other"],
+            )
+
+    def test_transpile_should_not_reject_star_inside_merge_from_subquery(self):
+        """Test that the star guard fires only on the MERGE's own projection.
+
+        Given:
+            A MERGE whose FROM is a pass-through ``SELECT *`` subquery — a star that
+            belongs to the source relation, not the MERGE's projection.
+        When:
+            Transpiling the query.
+        Then:
+            It should not raise the star-with-MERGE error and should expand into the
+            clustered-aggregation form, proving the guard inspects the MERGE's own
+            SELECT list rather than any star anywhere in the tree (#189).
+        """
+        # Arrange
+        query = "SELECT MERGE(interval) FROM (SELECT * FROM peaks) x"
+
+        # Act
+        sql = transpile(query, tables=["peaks"])
+
+        # Assert
+        assert "AS __giql_clustered" in sql
+        assert "G_I_Q_L" not in sql
+
     def test_transpile_should_group_by_strand_when_merge_stranded(self):
         """Test that a stranded MERGE aggregates within strand.
 
@@ -212,7 +324,7 @@ class TestMergeExpander:
     @pytest.mark.parametrize("predicate_op", ["INTERSECTS", "CONTAINS", "WITHIN"])
     @pytest.mark.parametrize(
         "projection",
-        ["*, MERGE(interval) AS m", "MERGE(interval)"],
+        ["MERGE(interval) AS m, COUNT(*) AS n", "MERGE(interval)"],
         ids=["aliased", "bare"],
     )
     def test_transpile_should_expand_spatial_predicate_copied_into_clustered(
@@ -221,8 +333,9 @@ class TestMergeExpander:
         """Test that a spatial WHERE predicate survives the MERGE rewrite.
 
         Given:
-            A MERGE query (aliased or bare) whose WHERE filters on a spatial
-            predicate, which the rewrite copies into the inner clustered subquery.
+            A MERGE query (aliased alongside an extra aggregate, or bare) whose
+            WHERE filters on a spatial predicate, which the rewrite copies into the
+            inner clustered subquery.
         When:
             Transpiling the query.
         Then:


### PR DESCRIPTION
## Summary

Reject a star projected alongside `MERGE` with a clear `ValueError` instead of emitting non-executable SQL.

`MERGE` is an aggregate whole-query rewrite: its output is one row per merged region (`chrom`, `MIN(start)`, `MAX(end)`), so a star projected in the same `SELECT` has no coherent per-row meaning. The rewrite copied every non-`MERGE` projection item verbatim into the aggregation's `SELECT` list, so `SELECT *, MERGE(...)` re-surfaced non-grouped columns under the synthesized `GROUP BY` (a `column must appear in the GROUP BY clause` error) and a qualified `SELECT t.*, MERGE(...)` dangled a table alias the `__giql_clustered` subquery no longer exposes (a `Referenced table "t" not found` binder error) — both non-executable, never a diagnosable error.

This adds a `MERGE`-specific guard that fails loudly on the shape, consistent with the codebase's fail-loud ethos for combinations that have no coherent rewrite (the multiple-`MERGE` and `CLUSTER`/`MERGE`-mix guards). Unlike `CLUSTER` — a per-row window over which a star is meaningful and supported (#184, #185) — `MERGE` collapses rows, so no star projection alongside it is well-formed. Legitimate sibling aggregates such as `COUNT(*)` remain supported.

Closes #189

## Proposed changes

- **`src/giql/expanders/merge.py`** — Add `_reject_star_projection`, wired into `expand_merge` after `reject_cluster_merge_mix`. It is gated on there being a *projected* `MERGE` (`find_projected`) so a `MERGE` parsing outside the projection (`WHERE` / `ORDER BY`) leaves the expander's existing no-op path untouched, and it recognizes both the bare `*` and qualified `rel.*` shapes via the shared `is_star_projection` predicate. The guard lives in `merge.py` rather than the operator-neutral `_genomic.py` toolkit because it is genuinely `MERGE`-specific.
- **`docs/dialect/aggregation-operators.rst`** — Add a `.. note::` documenting the rejection, mirroring the existing `CLUSTER`/`MERGE`-mix note and contrasting it with `CLUSTER`, over which a star is meaningful.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestMergeExpander` | A `SELECT` projecting a star (bare `*` either order, qualified `t.*`, multi-part `db.t.*`, or aliased-`MERGE` form) alongside `MERGE` | Transpiling the query | Raises `ValueError` naming the star-with-`MERGE` combination | `_reject_star_projection` |
| 2 | `TestMergeExpander` | A `MERGE` whose `FROM` is a pass-through `SELECT *` subquery | Transpiling the query | Expands into the clustered-aggregation form without raising | Guard specificity (inspects the `MERGE`'s own projection) |
| 3 | `TestMergeExpander` | An aliased `MERGE` beside a `COUNT(*)` aggregate with a spatial `WHERE` predicate | Transpiling the query | Copies and expands the predicate into the clustered subquery | Retargeted #144 B1 regression guard off the now-rejected star shape |

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM