### PR TITLE
Drop the binned INTERSECTS join in favor of the naive overlap predicate — Closes #167

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ print(sql)
 
 The transpiled SQL can be executed with fast genome-unaware databases or in-memory analytic engines like DuckDB.
 
-For column-to-column `INTERSECTS` joins (INNER, SEMI, or ANTI) targeting DuckDB, pass `dialect="duckdb"` to opt into a per-chromosome IEJoin plan that avoids the row inflation of the default binned equi-join. See [DuckDB IEJoin Dialect](https://giql.readthedocs.io/en/latest/transpilation/performance.html#duckdb-iejoin-dialect) for the supported shapes and fallback rules.
+By default a column-to-column `INTERSECTS` join emits the naive overlap predicate (`a.chrom = b.chrom AND a.start < b.end AND b.start < a.end`) as a plain `ON` condition, which each engine's optimizer plans as a range join. For DuckDB you can additionally pass `dialect="duckdb"` to opt into a per-chromosome IEJoin plan for INNER, SEMI, or ANTI joins; shapes it declines fall through to the naive predicate. See [DuckDB IEJoin Dialect](https://giql.readthedocs.io/en/latest/transpilation/performance.html#duckdb-iejoin-dialect) for the supported shapes and fallback rules.
 
 You can also use [oxbow](https://oxbow.readthedocs.io) to efficiently stream specialized genomics formats into DuckDB. 
 

--- a/docs/dialect/spatial-operators.rst
+++ b/docs/dialect/spatial-operators.rst
@@ -99,12 +99,12 @@ Find all variants, with gene information where available:
    FROM variants v
    LEFT JOIN genes g ON v.interval INTERSECTS g.interval
 
-Binned Join Internals
-~~~~~~~~~~~~~~~~~~~~~
+Join Internals
+~~~~~~~~~~~~~~
 
-Column-to-column ``INTERSECTS`` joins use a binned equi-join strategy internally: each interval is assigned to one or more fixed-width bins, and the join is performed on ``(chrom, bin)`` pairs. Because an interval that spans a bin boundary belongs to more than one bin, the raw binned join can produce duplicate matches for the same pair of source rows.
+A column-to-column ``INTERSECTS`` join expands to the **naive overlap predicate** — ``a.chrom = b.chrom AND a.start < b.end AND b.start < a.end`` — left in place as an ordinary ``ON`` (or ``WHERE``) condition. GIQL emits standard SQL and lets each engine's optimizer plan the range join: on DuckDB and DataFusion this becomes a hash join keyed on ``chrom`` with the two position inequalities applied as a residual join filter. Because the predicate is a plain condition on the original tables, inner and outer joins (``LEFT`` / ``RIGHT`` / ``FULL``) get correct semantics — including unmatched-row preservation — with no special restructuring, and every output row's multiplicity follows standard SQL bag semantics with no ``DISTINCT`` workaround.
 
-GIQL eliminates these duplicates inside a **pairs CTE** that computes the set of distinct ``(left_key, right_key)`` pairs from the binned inner join, then joins the original tables back through this CTE. Because ``DISTINCT`` is applied only to the key pairs — not to the output query — all source rows are preserved, including genuinely duplicate records. Overlap counts, aggregations, and standard SQL bag semantics all work correctly without requiring any workaround.
+DuckDB additionally offers an opt-in ``dialect="duckdb"`` per-chromosome IEJoin plan for INNER / SEMI / ANTI joins that routes through its ``IE_JOIN`` / ``PIECEWISE_MERGE_JOIN`` family; shapes it declines fall through to the naive predicate. See the :doc:`performance guide </transpilation/performance>` for details.
 
 Related Operators
 ~~~~~~~~~~~~~~~~~

--- a/docs/transpilation/extending.rst
+++ b/docs/transpilation/extending.rst
@@ -41,8 +41,9 @@ portable emission choices:
   canonicalization and the DISJOIN / NEAREST passthroughs; the portable
   ``SELECT * EXCEPT (...)`` form is emitted otherwise);
 - ``supports_qualify`` — the ``QUALIFY`` clause;
-- ``range_join_strategy`` — ``"binned"`` or ``"iejoin"`` for column-to-column
-  INTERSECTS joins.
+- ``range_join_strategy`` — ``"naive"`` (emit the naive overlap predicate and let
+  the engine plan the range join) or ``"iejoin"`` (DuckDB's per-chromosome IEJoin
+  pre-pass) for column-to-column INTERSECTS joins.
 
 Define a custom target by subclassing :class:`~giql.targets.Target` as a frozen
 dataclass. Give every field a default so the class is constructible with no
@@ -61,7 +62,7 @@ arguments (the ``@register`` decorator instantiates a target class for you):
            supports_lateral=True,
            supports_star_replace=False,   # -> portable "* EXCEPT" canonicalization
            supports_qualify=True,
-           range_join_strategy="binned",
+           range_join_strategy="naive",
        )
 
 

--- a/docs/transpilation/performance.rst
+++ b/docs/transpilation/performance.rst
@@ -304,15 +304,21 @@ Backend-Specific Tips
 DuckDB IEJoin Dialect
 ~~~~~~~~~~~~~~~~~~~~~
 
+By default (``dialect=None`` / ``"datafusion"``) a column-to-column
+``INTERSECTS`` join emits the **naive overlap predicate** — a plain ``ON
+a.chrom = b.chrom AND a.start < b.end AND b.start < a.end`` condition — and
+lets the engine's own optimizer plan it. On DuckDB and DataFusion this
+becomes a hash join keyed on ``chrom`` with the two position inequalities
+as a residual join filter, correct for both inner and outer joins with no
+special handling. This is the lowest-common-denominator plan: standard SQL
+that every target runs.
+
 For column-to-column ``INTERSECTS`` joins (INNER, SEMI, or ANTI) on
-DuckDB, the ``dialect="duckdb"`` opt-in transpiles the join into a
+DuckDB, the ``dialect="duckdb"`` opt-in instead transpiles the join into a
 per-chromosome dynamic-SQL pattern. Each per-chromosome subquery contains
 only inequality predicates, which DuckDB plans through its range-join
-family (``IE_JOIN`` or ``PIECEWISE_MERGE_JOIN``) — avoiding the
-row-inflation and deduplication cost of the default binned equi-join plan
-(the ``dialect=None`` path, controlled by ``intersects_bin_size``, which
-expands each interval into ``UNNEST``-generated bins and deduplicates
-the resulting matches).
+family (``IE_JOIN`` or ``PIECEWISE_MERGE_JOIN``). Shapes this path declines
+fall through to the naive predicate above.
 
 .. code-block:: python
 
@@ -392,9 +398,9 @@ chromosomes absent from the right table are preserved.
 
 DuckDB plans INNER through the IE_JOIN / PIECEWISE_MERGE_JOIN
 sort-merge family. SEMI and ANTI with inequality predicates plan
-through ``BLOCKWISE_NL_JOIN`` instead — still avoiding the UNNEST
-row-inflation of the binned plan, but not the IE_JOIN sort-merge fast
-path. Expect substantial speedups vs. the binned plan for SEMI / ANTI
+through ``BLOCKWISE_NL_JOIN`` instead — not the IE_JOIN sort-merge fast
+path, but still a per-chromosome plan. Expect speedups vs. the naive
+predicate for SEMI / ANTI
 where the chromosome partition already filters most pairs; INNER gets
 the largest speedup.
 
@@ -430,12 +436,12 @@ decorations:
 - **Star projections (``a.*`` / ``b.*``).** Expanded to the genomic
   columns declared by the corresponding :class:`Table` config (chrom
   / start / end, plus strand when set). This narrows the result schema
-  relative to the binned plan, which delegates star expansion to
+  relative to the naive-predicate plan, which delegates star expansion to
   DuckDB and projects every base-table column. Users with additional
   non-genomic columns should list them explicitly.
 
 The dialect splits unsupported shapes into two buckets. Soft-fallback
-shapes route to the binned plan automatically and return correct
+shapes route to the naive-predicate plan automatically and return correct
 results; within those shapes the ``dialect`` kwarg is safe to set
 without risk of silent incorrectness. Hard-error shapes (enumerated
 further below) raise ``ValueError`` at transpile time — the dialect
@@ -445,7 +451,7 @@ SQL.
 The soft-fallback shapes are:
 
 - **Outer joins.** ``LEFT`` / ``RIGHT`` / ``FULL`` ``JOIN ... ON ...
-  INTERSECTS ...`` falls back to the binned plan. The same applies
+  INTERSECTS ...`` falls back to the naive-predicate plan. The same applies
   when the join keeps its side modifier and the ``INTERSECTS`` lives in
   the top-level ``WHERE`` (e.g. ``LEFT JOIN ... ON TRUE WHERE
   a.interval INTERSECTS b.interval``).
@@ -463,7 +469,7 @@ The soft-fallback shapes are:
 - **INTERSECTS references unrecognized join sides.** A column-to-column
   INTERSECTS whose operands don't reference the FROM table's alias,
   or where the second operand's alias doesn't resolve to a registered
-  JOIN target, falls back to the binned plan.
+  JOIN target, falls back to the naive-predicate plan.
 - **Self-joins.** Joining a table to itself falls back.
 - **OR / NOT / paren-wrapped extra predicates.** See the Extra JOIN /
   WHERE predicates note above.
@@ -476,7 +482,7 @@ The soft-fallback shapes are:
   break the planner or produce semantically wrong results).
 - **Subquery inside GROUP BY / HAVING / ORDER BY.** A modifier clause
   containing a nested subquery (including ``EXISTS (SELECT ...)``)
-  falls back to the binned plan, because the dialect's modifier-ref
+  falls back to the naive-predicate plan, because the dialect's modifier-ref
   rewriter is not scope-aware and would corrupt the subquery's
   column scope. Subqueries hidden inside aggregate arguments in the
   SELECT list fall back for the same reason.
@@ -498,7 +504,7 @@ these rather than silently miscompile):
 - **Expression-form projections.** ``a.start + 1`` and other non-column
   expressions (other than aggregates) raise. Project the underlying
   column and compute in a wrapping query around the dialect's output,
-  or omit ``dialect="duckdb"`` to use the binned plan.
+  or omit ``dialect="duckdb"`` to use the naive-predicate plan.
 - **Unknown table qualifier.** ``c.col`` when the only sides are ``a``
   and ``b``.
 - **Unknown alias in GROUP BY / HAVING / ORDER BY.** A modifier-clause
@@ -530,17 +536,16 @@ these rather than silently miscompile):
 - **Unqualified or unknown-aliased extra predicates.** ``WHERE strand
   = '+'`` (unqualified) or ``WHERE c.score > 0`` (alias outside the
   join's two sides) raise with an actionable message naming the
-  expected aliases. The binned plan would either silently bind the
+  expected aliases. The naive-predicate plan would either silently bind the
   column wrong or defer the error to the downstream engine, so the
   dialect surfaces the user mistake at transpile time instead.
 
-Argument-validation ``ValueError`` raises (these fire before any AST
-inspection and are independent of the query shape):
+The one argument-validation ``ValueError`` raise (it fires before any AST
+inspection and is independent of the query shape):
 
-- **Mutually exclusive with** ``intersects_bin_size``. The two
-  parameters cannot be combined; pass one or the other.
-- **Unknown dialect string.** Anything other than ``"duckdb"`` or
-  ``None`` raises with the offending value echoed.
+- **Unknown dialect string.** A dialect that resolves to neither a built-in
+  target (``None``, ``"duckdb"``, ``"datafusion"``) nor a custom target
+  registered on the plugin hub raises with the offending value echoed.
 
 Literal-range ``INTERSECTS`` (e.g. ``WHERE interval INTERSECTS
 'chr1:1000-2000'``) is single-table and has no column-to-column join

--- a/src/giql/__init__.py
+++ b/src/giql/__init__.py
@@ -3,7 +3,6 @@
 A SQL dialect for genomic range queries.
 """
 
-from giql.constants import DEFAULT_BIN_SIZE
 from giql.expander import REGISTRY
 from giql.expander import ExpanderRegistry
 from giql.expander import ExpansionContext
@@ -22,7 +21,6 @@ __version__ = "0.1.0"
 
 
 __all__ = [
-    "DEFAULT_BIN_SIZE",
     "Table",
     "transpile",
     # Extension hook: register custom targets and override operator expanders.

--- a/src/giql/constants.py
+++ b/src/giql/constants.py
@@ -10,9 +10,6 @@ DEFAULT_END_COL = "end"
 DEFAULT_STRAND_COL = "strand"
 DEFAULT_GENOMIC_COL = "interval"
 
-# Default bin size for INTERSECTS binned equi-join optimization
-DEFAULT_BIN_SIZE = 10_000
-
 #: The reserved alias prefix naming DISJOIN's internal CTEs (``__giql_dj_ref`` /
 #: ``__giql_dj_tgt`` / ``__giql_dj_cuts`` / ...). Follows the same
 #: reserved-prefix scheme as :data:`giql.canonicalizer.CANON_PREFIX`; the leading

--- a/src/giql/expander.py
+++ b/src/giql/expander.py
@@ -325,10 +325,10 @@ class ExpanderRegistry:
         A *non-generic* ``(target, operator)`` entry additionally acts as a
         *join-rewrite override* (:meth:`has_override`) for operators with a
         built-in whole-query join rewrite (notably
-        :class:`~giql.expressions.Intersects`, whose binned equi-join / DuckDB
-        IEJoin transformers run before expansion), letting a per-target expander
-        assume responsibility for that rewrite — :func:`giql.transpile.transpile`
-        consults :meth:`has_override` and bypasses the built-in transformers when
+        :class:`~giql.expressions.Intersects`, whose DuckDB IEJoin transformer
+        runs before expansion), letting a per-target expander assume
+        responsibility for that rewrite — :func:`giql.transpile.transpile`
+        consults :meth:`has_override` and bypasses the built-in transformer when
         it holds.
         """
         self._expanders[(target, operator)] = _as_callable(expander)
@@ -379,7 +379,7 @@ class ExpanderRegistry:
         A non-generic exact ``(target, op)`` entry additionally acts as a
         *join-rewrite override* for operators with a built-in whole-query join
         rewrite (notably :class:`~giql.expressions.Intersects`); resolution itself
-        does not bypass the built-in binned / IEJoin transformers —
+        does not bypass the built-in IEJoin transformer —
         :func:`giql.transpile.transpile` does, gated on :meth:`has_override` (see
         :meth:`register` and #141).
         """
@@ -402,10 +402,10 @@ class ExpanderRegistry:
 
         Such an entry marks a target-specific override that supersedes built-in
         handling (e.g. taking responsibility for the whole-query join rewrite the
-        built-in transformers would otherwise perform).
+        built-in transformer would otherwise perform).
         :func:`giql.transpile.transpile` consults this method for
         ``(target, Intersects)`` and, when it holds, bypasses the built-in
-        binned / IEJoin join transformers so the ``Intersects`` node flows to the
+        IEJoin join transformer so the ``Intersects`` node flows to the
         registered expander instead (see #141).
         """
         return target != GenericTarget() and (target, operator) in self._expanders

--- a/src/giql/expanders/intersects.py
+++ b/src/giql/expanders/intersects.py
@@ -9,13 +9,18 @@ is byte-identical to the strings the legacy emitter produced.
 
 These are *node-local* predicate rewrites: an INTERSECTS / CONTAINS / WITHIN node
 expands to a boolean ``(chrom = ... AND start < ... AND end > ...)`` expression that
-replaces it in place. The whole-query column-to-column **join** rewrites (the binned
-equi-join and the DuckDB IEJoin) remain capability-gated pre-pass transformers in
-:mod:`giql.transformer` keyed on ``capabilities.range_join_strategy`` — they consume
-a column-to-column INTERSECTS *join* before this pass runs, so by the time a
-column-to-column INTERSECTS reaches an expander it is a residual predicate (e.g.
-inside an ``OR``, or a join shape the transformer declined) that the legacy emitter
-also rendered as a plain predicate. The expander handles that residual the same way.
+replaces it in place. For a column-to-column INTERSECTS *join* this in-place
+expansion IS the join plan on every target but DuckDB: the boolean overlap
+predicate is a plain ``ON`` condition the engine plans as a range join (a hash join
+keyed on ``chrom`` with the position inequalities as a residual filter), correct for
+both inner and outer joins. The one whole-query pre-pass rewrite that survives is
+the DuckDB IEJoin transformer in :mod:`giql.transformer`, gated on
+``capabilities.range_join_strategy == "iejoin"``; it consumes a column-to-column
+INTERSECTS *join* before this pass runs for the shapes it supports, and every shape
+it declines falls through to this expander's naive predicate. (The generic binned
+equi-join was dropped in favor of the naive predicate — #167.) A literal-range or
+residual column-to-column INTERSECTS *predicate* (e.g. inside an ``OR``) reaches the
+expander and is rendered the same way.
 
 Only :class:`~giql.targets.GenericTarget` expanders are registered: spatial-predicate
 *emission* is portable SQL-92 and does not vary by engine, so one generic expander
@@ -213,9 +218,7 @@ def expand_within(node: exp.Expression, ctx: ExpansionContext) -> exp.Expression
 
 
 @register(GenericTarget, SpatialSetPredicate)
-def expand_spatial_set(
-    node: exp.Expression, ctx: ExpansionContext
-) -> exp.Expression:
+def expand_spatial_set(node: exp.Expression, ctx: ExpansionContext) -> exp.Expression:
     """Expand a quantified set predicate (``ANY`` / ``ALL``) to boolean SQL AST.
 
     Reproduces the legacy ``_generate_spatial_set`` emitter: the single left

--- a/src/giql/resolver.py
+++ b/src/giql/resolver.py
@@ -563,12 +563,16 @@ def _resolve_predicate_columns(
       operand resolves through the alias map — matching ``_generate_column_join``,
       which passes ``None`` as the context for both sides.
 
-    Most column-to-column ``INTERSECTS`` joins never reach here: the
-    :class:`~giql.transformer.IntersectsBinnedJoinTransformer` rewrites them into
-    binned equi-joins before this pass runs, deleting the ``Intersects`` node.
-    Column-to-column ``CONTAINS`` / ``WITHIN`` (which that transformer leaves
-    untouched) and non-join ``INTERSECTS`` shapes still reach the emitter, so the
-    column-join branch is exercised.
+    A column-to-column ``INTERSECTS`` join reaches here on every target but
+    DuckDB: its operands resolve through this pass so the pass-3
+    ``(GenericTarget, Intersects)`` expander can render the naive overlap
+    predicate in place (#167). The DuckDB ``dialect="duckdb"`` IEJoin transformer
+    (:class:`~giql.transformer.IntersectsDuckDBIEJoinTransformer`) is the one path
+    that consumes such a join before this pass runs, deleting the ``Intersects``
+    node — but only for the shapes it accepts; the shapes it declines fall through
+    to this pass too. Column-to-column ``CONTAINS`` / ``WITHIN`` and non-join
+    ``INTERSECTS`` shapes always reach the emitter, so the column-join branch is
+    exercised on every target.
 
     Reuses the shared ``_enclosing_alias_map`` (FROM/JOIN alias derivation) and
     ``_physical_cols`` helpers; the predicate-specific bit lives in

--- a/src/giql/targets.py
+++ b/src/giql/targets.py
@@ -18,7 +18,7 @@ active target's capabilities.
 from dataclasses import dataclass
 from typing import Literal
 
-RangeJoinStrategy = Literal["binned", "iejoin"]
+RangeJoinStrategy = Literal["naive", "iejoin"]
 
 
 @dataclass(frozen=True)
@@ -49,10 +49,12 @@ class Capabilities:
         emission path consumes it yet (a future window-function operator
         port would).
     range_join_strategy : RangeJoinStrategy
-        The plan used for column-to-column INTERSECTS joins: ``"binned"``
-        for the generic binned equi-join, ``"iejoin"`` for DuckDB's
-        per-partition IEJoin plan. The IEJoin path covers INNER / SEMI /
-        ANTI joins, with binned fallback for unsupported shapes.
+        The plan used for column-to-column INTERSECTS joins: ``"naive"``
+        emits the naive overlap predicate (a plain ``ON`` condition the engine
+        plans as a range join) via the ``(GenericTarget, Intersects)`` pass-3
+        expander; ``"iejoin"`` selects DuckDB's per-partition IEJoin pre-pass
+        plan. The IEJoin path covers INNER / SEMI / ANTI joins and falls back to
+        the naive predicate for the shapes it declines (#167).
     """
 
     supports_lateral: bool
@@ -109,7 +111,7 @@ class GenericTarget(Target):
         supports_lateral=True,
         supports_star_replace=False,
         supports_qualify=False,
-        range_join_strategy="binned",
+        range_join_strategy="naive",
     )
 
 
@@ -157,8 +159,10 @@ class DataFusionTarget(Target):
     so NEAREST takes the decorrelated window fallback), ``supports_star_replace=
     False`` (DataFusion supports ``* EXCEPT`` / ``* EXCLUDE`` but not
     ``* REPLACE``, so the canonicalizer and the NEAREST/DISJOIN passthroughs emit
-    the portable ``* EXCEPT`` form), ``supports_qualify=False``, and the binned
-    equi-join range strategy.
+    the portable ``* EXCEPT`` form), ``supports_qualify=False``, and the naive
+    overlap-predicate range strategy (the column-to-column INTERSECTS join stays a
+    plain ``ON`` condition DataFusion plans as a hash join keyed on ``chrom`` with
+    the position inequalities as a residual join filter — #167).
 
     A ``SELECT *`` / ``SELECT b.*`` over a correlated NEAREST would otherwise expose
     the decorrelated fallback's reserved ``__giql_x_*`` rank/key columns; a statement
@@ -179,7 +183,7 @@ class DataFusionTarget(Target):
         supports_lateral=False,
         supports_star_replace=False,
         supports_qualify=False,
-        range_join_strategy="binned",
+        range_join_strategy="naive",
     )
 
 

--- a/src/giql/transformer.py
+++ b/src/giql/transformer.py
@@ -1,8 +1,13 @@
 """Query transformers for GIQL operations.
 
-This module contains the pre-pass transformers that rewrite column-to-column
-INTERSECTS joins (the binned equi-join and DuckDB IEJoin plans) into equivalent
-SQL with CTEs. CLUSTER and MERGE were relocated to the operator-expander registry
+This module contains the DuckDB IEJoin pre-pass transformer, which rewrites a
+column-to-column INTERSECTS join into a per-chromosome dynamic-SQL pattern DuckDB
+plans through its range-join family. Every other target — and every shape the
+IEJoin path declines — leaves the INTERSECTS in place for the pass-3
+``(GenericTarget, Intersects)`` expander, which renders the naive overlap
+predicate (a plain ``ON`` condition the engine plans as a range join). The generic
+binned equi-join transformer was dropped in favor of that naive predicate (#167).
+CLUSTER and MERGE were relocated to the operator-expander registry
 (``giql.expanders.cluster`` / ``giql.expanders.merge``) in epic #137 (#144).
 """
 
@@ -15,7 +20,6 @@ from sqlglot import exp
 
 from giql.canonical import canonical_end
 from giql.canonical import canonical_start
-from giql.constants import DEFAULT_BIN_SIZE
 from giql.constants import DEFAULT_CHROM_COL
 from giql.constants import DEFAULT_END_COL
 from giql.constants import DEFAULT_START_COL
@@ -38,12 +42,11 @@ class _UnqualifiedProjectionError(Exception):
     """
 
 
-# These predicates are shared between :class:`IntersectsBinnedJoinTransformer`
-# and :class:`IntersectsDuckDBIEJoinTransformer`; they live at module scope
-# rather than on either class so neither owns them. Style §2's strict
-# "functions after classes" ordering is relaxed here under the
-# topic-interleaved exception, generalized to "shared by multiple consumer
-# classes."
+# These predicates support :class:`IntersectsDuckDBIEJoinTransformer`; they live
+# at module scope rather than on the class so a future target-specific INTERSECTS
+# override can reuse them without importing the transformer. Style §2's strict
+# "functions after classes" ordering is relaxed here under the topic-interleaved
+# exception.
 
 
 def _is_column_intersects(node: Intersects) -> bool:
@@ -72,7 +75,7 @@ def _normalize_alias(name: str, *, quoted: bool = False) -> str:
 
     DuckDB (and standard SQL) treat unquoted identifiers case-insensitively.
     Comparing aliases via raw Python equality rejects valid mixed-case queries
-    that the binned plan accepts; normalize via :py:meth:`str.casefold` so the
+    that the naive-predicate plan accepts; normalize via :py:meth:`str.casefold` so the
     dialect matches DuckDB's identifier semantics. Quoted identifiers stay
     case-sensitive per the SQL standard.
     """
@@ -226,497 +229,6 @@ class _IEJoinSides:
         )
 
 
-class IntersectsBinnedJoinTransformer:
-    """Transform column-to-column INTERSECTS into binned equi-joins.
-
-    Handles both explicit ``JOIN ... ON`` and implicit cross-join (WHERE)
-    INTERSECTS patterns. Each rewrite emits a pairs CTE that holds the
-    matching ``(left_key, right_key)`` tuples computed by an INNER binned
-    join with ``SELECT DISTINCT`` on the join keys, then bridges the
-    original tables through that pairs CTE::
-
-        WITH __giql_peaks_bins AS (
-            SELECT "chrom", "start", "end",
-                   UNNEST(range(...)) AS __giql_bin FROM peaks
-        ),
-        __giql_genes_bins AS (...),
-        __giql_pairs_0 AS (
-            SELECT DISTINCT
-                __giql_l.<chrom> AS __giql_l_chrom, ...,
-                __giql_r.<chrom> AS __giql_r_chrom, ...
-            FROM __giql_peaks_bins AS __giql_l
-            JOIN __giql_genes_bins AS __giql_r
-              ON __giql_l.<chrom> = __giql_r.<chrom>
-                 AND __giql_l.__giql_bin = __giql_r.__giql_bin
-                 AND __giql_l.<start> < __giql_r.<end>
-                 AND __giql_l.<end> > __giql_r.<start>
-        )
-        SELECT a.*, b.*
-        FROM peaks a
-        JOIN __giql_pairs_0 AS __giql_p0
-          ON a.<chrom> = __giql_p0.__giql_l_chrom
-             AND a.<start> = __giql_p0.__giql_l_start
-             AND a.<end> = __giql_p0.__giql_l_end
-        JOIN genes b
-          ON b.<chrom> = __giql_p0.__giql_r_chrom
-             AND b.<start> = __giql_p0.__giql_r_start
-             AND b.<end> = __giql_p0.__giql_r_end
-
-    Deduplication happens inside the pairs CTE on the join keys, so the
-    output query does NOT carry a ``SELECT DISTINCT`` — source rows that
-    differ only in unselected columns are preserved. Outer joins ride
-    safely on top of this because the bridge-join structure prevents bin
-    fan-out from creating spurious NULL rows.
-
-    Literal-range INTERSECTS (e.g., ``WHERE interval INTERSECTS 'chr1:...'``)
-    are left untouched.
-    """
-
-    def __init__(self, tables: Tables, bin_size: int | None = None):
-        """Initialize transformer.
-
-        :param tables:
-            Table configurations for column mapping
-        :param bin_size:
-            Bin width for the equi-join rewrite. Defaults to
-            :data:`~giql.constants.DEFAULT_BIN_SIZE` if not specified.
-        """
-        self.tables = tables
-        resolved = bin_size if bin_size is not None else DEFAULT_BIN_SIZE
-        if not isinstance(resolved, int) or resolved <= 0:
-            raise ValueError(f"bin_size must be a positive integer, got {resolved!r}")
-        self.bin_size = resolved
-
-    def transform(self, query: exp.Expression) -> exp.Expression:
-        """Rewrite column-to-column INTERSECTS joins as a pairs-CTE binned plan.
-
-        Walks ``query.args["joins"]`` and the top-level ``WHERE`` for
-        column-to-column :class:`Intersects` predicates and replaces each one
-        with a bridge through a freshly-allocated pairs CTE
-        (``__giql_pairs_<n>``) plus the per-table bin CTEs that feed it.
-        Non-INTERSECTS predicates are preserved verbatim; literal-range
-        ``INTERSECTS`` (``WHERE interval INTERSECTS 'chr1:100-200'``) is
-        left untouched and emitted by the default generator.
-
-        :param query:
-            Parsed query AST.
-        :return:
-            The transformed AST (mutated in place when an INTERSECTS join
-            is rewritten; returned unchanged for non-``Select`` inputs).
-        """
-        if not isinstance(query, exp.Select):
-            return query
-
-        # The pairs-CTE approach computes matching (left_key, right_key)
-        # pairs via an INNER binned join with DISTINCT on key columns,
-        # then joins the original tables through the pairs CTE. This
-        # avoids adding SELECT DISTINCT to the output query, which would
-        # collapse legitimately different source rows that happen to
-        # have identical selected columns. It also handles outer joins
-        # correctly by preventing bin fan-out from creating spurious
-        # NULL rows.
-        return self._transform_with_pairs(query)
-
-    def _transform_with_pairs(self, query: exp.Select) -> exp.Select:
-        """Transform INTERSECTS joins using the pairs-CTE approach.
-
-        Computes matching (left_key, right_key) pairs via an INNER
-        binned join with DISTINCT on key columns, then joins the
-        original tables through the pairs CTE.  Unlike the full-CTE
-        and bridge paths, this does NOT add SELECT DISTINCT to the
-        output — deduplication happens inside the pairs CTE on
-        (chrom, start, end) keys, preserving all source rows.
-        """
-        joins = query.args.get("joins") or []
-        key_binned: dict[str, str] = {}
-        pairs_idx = 0
-        new_joins: list[exp.Join] = []
-        rewrote_any = False
-
-        for join in joins:
-            on = join.args.get("on")
-            if on:
-                intersects = _find_column_intersects_in(on)
-                if intersects:
-                    extra = _strip_intersects(on, intersects)
-                    replacement = self._build_pairs_replacement_joins(
-                        query, join, intersects, extra, key_binned, pairs_idx
-                    )
-                    new_joins.extend(replacement)
-                    pairs_idx += 1
-                    rewrote_any = True
-                    continue
-            new_joins.append(join)
-
-        where = query.args.get("where")
-        if where:
-            intersects = _find_column_intersects_in(where.this)
-            if intersects:
-                cross_join = self._find_cross_join_for_intersects(
-                    query, intersects, new_joins
-                )
-                if cross_join is not None:
-                    new_joins.remove(cross_join)
-                    replacement = self._build_pairs_replacement_joins(
-                        query,
-                        cross_join,
-                        intersects,
-                        None,
-                        key_binned,
-                        pairs_idx,
-                    )
-                    new_joins.extend(replacement)
-                    self._remove_intersects_from_where(query, intersects)
-                    pairs_idx += 1
-                    rewrote_any = True
-
-        if rewrote_any:
-            query.set("joins", new_joins)
-
-        return query
-
-    def _build_pairs_cte(
-        self,
-        name: str,
-        l_cte: str,
-        r_cte: str,
-        l_cols: tuple[str, str, str],
-        r_cols: tuple[str, str, str],
-    ) -> exp.CTE:
-        """Build a DISTINCT inner-join pairs CTE.
-
-        Returns a CTE named *name* that selects the six key columns
-        (__giql_l_chrom, __giql_l_start, __giql_l_end, __giql_r_chrom,
-        __giql_r_start, __giql_r_end) from an INNER join of the two bin
-        CTEs on chrom, __giql_bin, and the overlap predicate.
-        """
-        l_alias = "__giql_l"
-        r_alias = "__giql_r"
-
-        select = exp.Select()
-        select.set("distinct", exp.Distinct())
-
-        first = True
-        for tbl_alias, cols, prefix in [
-            (l_alias, l_cols, "__giql_l"),
-            (r_alias, r_cols, "__giql_r"),
-        ]:
-            for col, suffix in zip(cols, ["_chrom", "_start", "_end"]):
-                col_expr = exp.Alias(
-                    this=exp.column(col, table=tbl_alias, quoted=True),
-                    alias=exp.Identifier(this=f"{prefix}{suffix}"),
-                )
-                select.select(col_expr, append=not first, copy=False)
-                first = False
-
-        select.from_(
-            exp.Table(
-                this=exp.Identifier(this=l_cte),
-                alias=exp.TableAlias(this=exp.Identifier(this=l_alias)),
-            ),
-            copy=False,
-        )
-
-        join_on = exp.And(
-            this=exp.And(
-                this=exp.EQ(
-                    this=exp.column(l_cols[0], table=l_alias, quoted=True),
-                    expression=exp.column(r_cols[0], table=r_alias, quoted=True),
-                ),
-                expression=exp.EQ(
-                    this=exp.column("__giql_bin", table=l_alias),
-                    expression=exp.column("__giql_bin", table=r_alias),
-                ),
-            ),
-            expression=self._build_overlap(l_alias, r_alias, l_cols, r_cols),
-        )
-
-        select.join(
-            exp.Table(
-                this=exp.Identifier(this=r_cte),
-                alias=exp.TableAlias(this=exp.Identifier(this=r_alias)),
-            ),
-            on=join_on,
-            copy=False,
-        )
-
-        return exp.CTE(
-            this=select,
-            alias=exp.TableAlias(this=exp.Identifier(this=name)),
-        )
-
-    def _build_pairs_replacement_joins(
-        self,
-        query: exp.Select,
-        join: exp.Join,
-        intersects: Intersects,
-        extra: exp.Expression | None,
-        key_binned: dict[str, str],
-        pairs_idx: int,
-    ) -> list[exp.Join]:
-        """Build a pairs CTE and two replacement joins for one INTERSECTS.
-
-        Returns two joins:
-        - join1: from_alias [SIDE] JOIN __giql_pairs ON from.key = pairs.from_key
-        - join2: [SIDE] JOIN join_table ON join.key = pairs.join_key [AND extra]
-        """
-        from_table = query.args["from_"].this
-        join_table = join.this
-        if not isinstance(from_table, exp.Table) or not isinstance(
-            join_table, exp.Table
-        ):
-            return [join]
-
-        from_alias = from_table.alias or from_table.name
-        join_alias = join_table.alias or join_table.name
-        from_table_name = from_table.name
-        join_table_name = join_table.name
-
-        left_alias = intersects.this.table
-        from_cols = self._get_columns(from_table_name)
-        join_cols = self._get_columns(join_table_name)
-
-        # Prefix assignment encodes which INTERSECTS argument feeds the
-        # left vs right bin column of the pairs CTE, so the downstream
-        # equi-join compares matching halves regardless of FROM order.
-        if left_alias == from_alias:
-            l_table_name, r_table_name = from_table_name, join_table_name
-            l_cols, r_cols = from_cols, join_cols
-            from_prefix, join_prefix = "__giql_l", "__giql_r"
-        else:
-            l_table_name, r_table_name = join_table_name, from_table_name
-            l_cols, r_cols = join_cols, from_cols
-            from_prefix, join_prefix = "__giql_r", "__giql_l"
-
-        l_cte = self._ensure_key_binned(query, l_table_name, key_binned)
-        r_cte = self._ensure_key_binned(query, r_table_name, key_binned)
-
-        pairs_name = f"__giql_pairs_{pairs_idx}"
-        pairs_cte = self._build_pairs_cte(pairs_name, l_cte, r_cte, l_cols, r_cols)
-        existing_with = query.args.get("with_")
-        if existing_with:
-            existing_with.append("expressions", pairs_cte)
-        else:
-            query.set("with_", exp.With(expressions=[pairs_cte]))
-
-        side = join.args.get("side")
-        p_alias = f"__giql_p{pairs_idx}"
-
-        join1_on = self._build_key_match(from_alias, from_cols, p_alias, from_prefix)
-        join1_kwargs: dict = {
-            "this": exp.Table(
-                this=exp.Identifier(this=pairs_name),
-                alias=exp.TableAlias(this=exp.Identifier(this=p_alias)),
-            ),
-            "on": join1_on,
-        }
-        if side:
-            join1_kwargs["side"] = side
-        join1 = exp.Join(**join1_kwargs)
-
-        join2_on = self._build_key_match(join_alias, join_cols, p_alias, join_prefix)
-        if extra:
-            join2_on = exp.And(this=join2_on, expression=extra)
-        join2_kwargs: dict = {
-            "this": exp.Table(
-                this=exp.Identifier(this=join_table_name),
-                alias=exp.TableAlias(this=exp.Identifier(this=join_alias)),
-            ),
-            "on": join2_on,
-        }
-        if side:
-            join2_kwargs["side"] = side
-        join2 = exp.Join(**join2_kwargs)
-
-        return [join1, join2]
-
-    def _build_key_match(
-        self,
-        table_alias: str,
-        cols: tuple[str, str, str],
-        pairs_alias: str,
-        prefix: str,
-    ) -> exp.And:
-        """Build ``table.chrom = pairs.prefix_chrom AND ...`` for all three keys."""
-        return exp.And(
-            this=exp.And(
-                this=exp.EQ(
-                    this=exp.column(cols[0], table=table_alias, quoted=True),
-                    expression=exp.column(f"{prefix}_chrom", table=pairs_alias),
-                ),
-                expression=exp.EQ(
-                    this=exp.column(cols[1], table=table_alias, quoted=True),
-                    expression=exp.column(f"{prefix}_start", table=pairs_alias),
-                ),
-            ),
-            expression=exp.EQ(
-                this=exp.column(cols[2], table=table_alias, quoted=True),
-                expression=exp.column(f"{prefix}_end", table=pairs_alias),
-            ),
-        )
-
-    def _build_bin_range(
-        self, start: str, end: str
-    ) -> tuple[exp.Expression, exp.Expression]:
-        """Build the (low, high) bin-index expressions for UNNEST(range(...)).
-
-        Returns ``start // bin_size`` and ``(end - 1) // bin_size + 1``.
-        Uses integer floor division to avoid rounding errors from
-        float division + CAST.
-        """
-        bs = self.bin_size
-
-        low = exp.IntDiv(
-            this=exp.column(start, quoted=True),
-            expression=exp.Literal.number(bs),
-        )
-        high = exp.Add(
-            this=exp.IntDiv(
-                this=exp.Paren(
-                    this=exp.Sub(
-                        this=exp.column(end, quoted=True),
-                        expression=exp.Literal.number(1),
-                    ),
-                ),
-                expression=exp.Literal.number(bs),
-            ),
-            expression=exp.Literal.number(1),
-        )
-        return low, high
-
-    def _find_cross_join_for_intersects(
-        self,
-        query: exp.Select,
-        intersects: Intersects,
-        current_joins: list[exp.Join],
-    ) -> exp.Join | None:
-        """Find the implicit cross-join entry for the table in a WHERE INTERSECTS."""
-        from_table = query.args["from_"].this
-        if not isinstance(from_table, exp.Table):
-            return None
-        from_alias = from_table.alias or from_table.name
-
-        left_alias = intersects.this.table
-        right_alias = intersects.expression.table
-        if left_alias == from_alias:
-            target_alias = right_alias
-        elif right_alias == from_alias:
-            target_alias = left_alias
-        else:
-            return None
-
-        for join in current_joins:
-            if isinstance(join.this, exp.Table):
-                alias = join.this.alias or join.this.name
-                if alias == target_alias:
-                    return join
-        return None
-
-    def _remove_intersects_from_where(
-        self, query: exp.Select, intersects: Intersects
-    ) -> None:
-        """Remove the INTERSECTS predicate from the WHERE clause."""
-        where = query.args.get("where")
-        if not where:
-            return
-        remainder = _strip_intersects(where.this, intersects)
-        if remainder is None:
-            query.set("where", None)
-        else:
-            query.set("where", exp.Where(this=remainder))
-
-    def _get_columns(self, table_name: str) -> tuple[str, str, str]:
-        """Return (chrom, start, end) column names for a table."""
-        table = self.tables.get(table_name)
-        if table:
-            return (table.chrom_col, table.start_col, table.end_col)
-        return (DEFAULT_CHROM_COL, DEFAULT_START_COL, DEFAULT_END_COL)
-
-    def _build_overlap(
-        self,
-        from_alias: str,
-        join_alias: str,
-        from_cols: tuple[str, str, str],
-        join_cols: tuple[str, str, str],
-    ) -> exp.And:
-        """Build ``from.start < join.end AND from.end > join.start``."""
-        return exp.And(
-            this=exp.LT(
-                this=exp.column(from_cols[1], table=from_alias, quoted=True),
-                expression=exp.column(join_cols[2], table=join_alias, quoted=True),
-            ),
-            expression=exp.GT(
-                this=exp.column(from_cols[2], table=from_alias, quoted=True),
-                expression=exp.column(join_cols[1], table=join_alias, quoted=True),
-            ),
-        )
-
-    def _find_table_name_for_alias(self, query: exp.Select, alias: str) -> str:
-        """Resolve an alias to its underlying table name."""
-        from_table = query.args["from_"].this
-        if isinstance(from_table, exp.Table):
-            if (from_table.alias or from_table.name) == alias:
-                return from_table.name
-        for join in query.args.get("joins") or []:
-            if isinstance(join.this, exp.Table):
-                t = join.this
-                if (t.alias or t.name) == alias:
-                    return t.name
-        return alias  # fallback: alias == table name
-
-    def _build_key_only_bins_select(
-        self, table_name: str, cols: tuple[str, str, str]
-    ) -> exp.Select:
-        """Build the binned-key SELECT for *table_name*.
-
-        Emits ``SELECT chrom, start, end, UNNEST(range(...)) AS __giql_bin
-        FROM <table_name>``.
-        """
-        chrom, start, end = cols
-        low, high = self._build_bin_range(start, end)
-
-        range_fn = exp.Anonymous(this="range", expressions=[low, high])
-        unnest_fn = exp.Anonymous(this="UNNEST", expressions=[range_fn])
-        bin_alias = exp.Alias(
-            this=unnest_fn,
-            alias=exp.Identifier(this="__giql_bin"),
-        )
-
-        select = exp.Select()
-        select.select(exp.column(chrom, quoted=True), copy=False)
-        select.select(exp.column(start, quoted=True), append=True, copy=False)
-        select.select(exp.column(end, quoted=True), append=True, copy=False)
-        select.select(bin_alias, append=True, copy=False)
-        select.from_(exp.Table(this=exp.Identifier(this=table_name)), copy=False)
-        return select
-
-    def _ensure_key_binned(
-        self,
-        query: exp.Select,
-        table_name: str,
-        key_binned: dict[str, str],
-    ) -> str:
-        """Ensure a key-only bins CTE exists for *table_name*; return its name."""
-        if table_name in key_binned:
-            return key_binned[table_name]
-
-        cte_name = f"__giql_{table_name}_bins"
-        cols = self._get_columns(table_name)
-        cte = exp.CTE(
-            this=self._build_key_only_bins_select(table_name, cols),
-            alias=exp.TableAlias(this=exp.Identifier(this=cte_name)),
-        )
-
-        existing_with = query.args.get("with_")
-        if existing_with:
-            existing_with.append("expressions", cte)
-        else:
-            query.set("with_", exp.With(expressions=[cte]))
-
-        key_binned[table_name] = cte_name
-        return cte_name
-
-
 class IntersectsDuckDBIEJoinTransformer:
     """Transform column-to-column INTERSECTS joins into a DuckDB IEJoin pattern.
 
@@ -743,7 +255,7 @@ class IntersectsDuckDBIEJoinTransformer:
     - ``a.*`` / ``b.*`` star projections expand to the genomic columns
       declared by the corresponding :class:`~giql.table.Table` config
       (chrom / start / end, plus strand when set). This narrows the result
-      schema relative to the binned plan, which delegates star expansion
+      schema relative to the generic naive-predicate plan, which delegates star expansion
       to DuckDB and projects every base-table column. Users with additional
       non-genomic columns should list them explicitly.
     - ``SEMI JOIN`` and ``ANTI JOIN`` outputs are left-side only. Any
@@ -775,16 +287,16 @@ class IntersectsDuckDBIEJoinTransformer:
         exactly ``SELECT <qualified projections> FROM <registered base
         table> [JOIN <registered base table>] {ON|WHERE} <one
         column-to-column INTERSECTS>`` with no other top-level clause.
-        Everything else returns ``None`` so the binned plan handles it.
+        Everything else returns ``None`` so the generic naive-predicate plan handles it.
         """
         if not isinstance(query, exp.Select):
             return None
 
-        # Top-level WITH (CTEs) still falls back to the binned plan.
+        # Top-level WITH (CTEs) still falls back to the naive-predicate plan.
         # ORDER BY / LIMIT / OFFSET / DISTINCT / GROUP BY / HAVING ride
         # on the outer SELECT wrapper. ``DISTINCT ON (...)`` is the one
         # DISTINCT variant we don't try to translate — it would interact
-        # with the outer alias rewrite in ways the binned plan handles
+        # with the outer alias rewrite in ways the naive-predicate plan handles
         # for free.
         if query.args.get("with_"):
             return None
@@ -839,8 +351,8 @@ class IntersectsDuckDBIEJoinTransformer:
 
         # NATURAL needs schema introspection we don't have at transpile time
         # (Table configs only expose chrom/start/end/strand; user columns
-        # like name/score are invisible). The binned plan defers to DuckDB,
-        # which does see the schema, so falling back IS the optimal plan.
+        # like name/score are invisible). The naive-predicate plan defers to
+        # DuckDB, which does see the schema, so falling back IS the optimal plan.
         if the_join.args.get("method"):
             return None
 
@@ -856,8 +368,9 @@ class IntersectsDuckDBIEJoinTransformer:
 
         # INNER (the default), CROSS (functionally equivalent to INNER once
         # the chromosome partition is in place), SEMI, and ANTI all engage.
-        # Everything else falls back so the binned plan can preserve its
-        # semantics (e.g. RIGHT / FULL outer joins).
+        # Everything else falls back so the naive-predicate plan can preserve its
+        # semantics (e.g. RIGHT / FULL outer joins, which the naive overlap
+        # predicate expresses as a plain outer ``ON`` condition).
         kind_str = the_join.args.get("kind")
         if kind_str and kind_str.upper() not in ("INNER", "CROSS", "SEMI", "ANTI"):
             return None
@@ -875,7 +388,7 @@ class IntersectsDuckDBIEJoinTransformer:
         # ``name`` and would be interpolated as an empty identifier into
         # broken SQL. (A CTE-named operand is already handled by the
         # ``with_`` guard above; an unregistered base table is fine — the
-        # dialect uses default columns just like the binned path does.)
+        # dialect uses default columns just like the naive-predicate path does.)
         if not from_table.name:
             return None
         join_table = the_join.this
@@ -889,13 +402,14 @@ class IntersectsDuckDBIEJoinTransformer:
         if sides.left_user_alias == sides.right_user_alias:
             # Same alias on both sides of the INTERSECTS — the inner subquery
             # would alias the same underlying relation as both "a" and "b",
-            # which the binned plan handles correctly via its bridge CTE.
+            # which the naive-predicate plan renders correctly in place (no
+            # inner subquery, so no ambiguous double-alias).
             return None
 
         # Compare fully-qualified identifiers (catalog/db/name) so two
         # distinct same-named tables in different schemas are not treated
         # as a self-join. Same qualified identifier still falls back so the
-        # binned plan handles the legitimate self-join shape.
+        # naive-predicate plan handles the legitimate self-join shape.
         if self._qualified_table_ident(sides.left_table) == self._qualified_table_ident(
             sides.right_table
         ):
@@ -950,7 +464,7 @@ class IntersectsDuckDBIEJoinTransformer:
     def _classify_extras(
         extras: list[exp.Expression],
     ) -> Literal["inline", "fallback"]:
-        """Return ``"fallback"`` if any extra has a shape the binned plan must handle.
+        """Return ``"fallback"`` if any extra needs the naive-predicate plan.
 
         Soft-fallback shapes: an INTERSECTS still embedded in the residual
         (because :func:`_strip_intersects` couldn't peel an OR/NOT/Paren
@@ -1124,7 +638,7 @@ class IntersectsDuckDBIEJoinTransformer:
         Note: :func:`_strip_intersects` only descends ``exp.And``. Predicates
         whose AND tree wraps the INTERSECTS in ``exp.Or`` / ``exp.Not`` /
         ``exp.Paren`` surface here with the INTERSECTS still embedded;
-        :meth:`_classify_extras` then routes them to the binned plan, while
+        :meth:`_classify_extras` then routes them to the naive-predicate plan, while
         :meth:`_validate_extra_qualifiers` enforces qualifier rules for the
         remaining inlinable residuals.
         """
@@ -1192,7 +706,7 @@ class IntersectsDuckDBIEJoinTransformer:
         """Render the multi-statement DuckDB IEJoin SQL string for *query*.
 
         Returns ``None`` when a soft-fallback condition fires (the residual
-        of the join carries a shape the binned plan can handle but the
+        of the join carries a shape the naive-predicate plan can handle but the
         dialect cannot inline, or a single-column USING references a column
         that is not both tables' ``chrom_col``). Raises
         :class:`_UnqualifiedProjectionError` when a user-mistake condition
@@ -1206,7 +720,7 @@ class IntersectsDuckDBIEJoinTransformer:
             self._validate_extra_qualifiers(extras, sides)
 
         # Tables registry is keyed by the bare table name; an unregistered
-        # table uses default column names like the binned plan does.
+        # table uses default column names like the naive-predicate plan does.
         l_table = self.tables.get(sides.left_table.name)
         r_table = self.tables.get(sides.right_table.name)
         l_chrom = l_table.chrom_col if l_table else DEFAULT_CHROM_COL
@@ -1220,8 +734,8 @@ class IntersectsDuckDBIEJoinTransformer:
         # single-column USING). The dialect's per-chromosome partition IS
         # the equi-join that USING(<chrom_col>) requests; if the USING
         # column doesn't match both tables' chrom_col (or the chrom_cols
-        # diverge), fall back so the binned plan emits the proper
-        # equi-join.
+        # diverge), fall back so the naive-predicate plan preserves the
+        # USING equi-join for the engine to resolve.
         using_cols = the_join.args.get("using") or []
         if using_cols:
             using_name = _normalize_alias(using_cols[0].name)
@@ -1627,7 +1141,7 @@ class IntersectsDuckDBIEJoinTransformer:
                     "dialect='duckdb' does not support window aggregates "
                     f"in the SELECT list; got {target.sql()!r}. Either "
                     "drop the OVER (...) clause, or omit dialect='duckdb' "
-                    "to use the binned plan."
+                    "to use the generic naive-predicate plan."
                 )
             if isinstance(target, exp.Filter):
                 raise _UnqualifiedProjectionError(
@@ -1644,14 +1158,14 @@ class IntersectsDuckDBIEJoinTransformer:
                     "dialect='duckdb' does not support scalar subqueries in "
                     f"the SELECT list; got {target.sql()!r}. Either rewrite "
                     "without the subquery, or omit dialect='duckdb' to use "
-                    "the binned plan."
+                    "the generic naive-predicate plan."
                 )
             if target.find(exp.Window) is not None:
                 raise _UnqualifiedProjectionError(
                     "dialect='duckdb' does not support window aggregates "
                     f"in the SELECT list; got {target.sql()!r}. Either "
                     "drop the OVER (...) clause, or omit dialect='duckdb' "
-                    "to use the binned plan."
+                    "to use the generic naive-predicate plan."
                 )
             if target.find(exp.Filter) is not None:
                 raise _UnqualifiedProjectionError(

--- a/src/giql/transpile.py
+++ b/src/giql/transpile.py
@@ -21,7 +21,6 @@ from giql.resolver import resolve_operator_refs
 from giql.table import Table
 from giql.table import Tables
 from giql.targets import resolve_target
-from giql.transformer import IntersectsBinnedJoinTransformer
 from giql.transformer import IntersectsDuckDBIEJoinTransformer
 
 
@@ -31,7 +30,6 @@ def transpile(
     tables: list[str | Table] | None = None,
     *,
     dialect: Literal["datafusion"] | None = None,
-    intersects_bin_size: int | None = None,
 ) -> str: ...
 
 
@@ -41,22 +39,19 @@ def transpile(
     tables: list[str | Table] | None = None,
     *,
     dialect: Literal["duckdb"],
-    intersects_bin_size: None = None,
 ) -> str: ...
 
 
 # Widened overload for arbitrary custom-target dialect names (the registry
-# plugin hub). It intentionally subsumes the ``Literal["duckdb"]`` overload
-# above, so the static ``dialect="duckdb"`` + ``intersects_bin_size`` guard is not
-# enforced for a ``str``-typed dialect; that combination still raises ``ValueError``
-# at runtime (see the body).
+# plugin hub). It subsumes the ``Literal["duckdb"]`` overload above, which is
+# kept deliberately so editors still autocomplete the ``"duckdb"`` literal
+# (symmetric with the ``Literal["datafusion"]`` overload).
 @overload
 def transpile(
     giql: str,
     tables: list[str | Table] | None = None,
     *,
     dialect: str,
-    intersects_bin_size: int | None = None,
 ) -> str: ...
 
 
@@ -65,7 +60,6 @@ def transpile(
     tables: list[str | Table] | None = None,
     *,
     dialect: str | None = None,
-    intersects_bin_size: int | None = None,
 ) -> str:
     """Transpile a GIQL query to SQL.
 
@@ -94,12 +88,17 @@ def transpile(
         ``INTERSECTS`` joins (INNER, SEMI, or ANTI) are transpiled into a
         per-chromosome dynamic-SQL pattern (``SET VARIABLE`` +
         ``query(getvariable(...))``) that DuckDB plans through its
-        range-join family (``IE_JOIN`` / ``PIECEWISE_MERGE_JOIN``); this
-        IEJoin plan is mutually exclusive with ``intersects_bin_size``.
-        ``"datafusion"`` and ``None`` use the generic binned equi-join path
-        and accept ``intersects_bin_size``. Hard-error projection shapes
-        raise ``ValueError`` at transpile time; see the performance guide
-        for the full enumeration. The target's capabilities also choose the
+        range-join family (``IE_JOIN`` / ``PIECEWISE_MERGE_JOIN``). Shapes
+        the IEJoin path declines (LEFT/RIGHT/FULL joins, self-joins, multiple
+        INTERSECTS, extra predicates, non-base operands, 3+ tables) fall
+        through to the generic naive overlap predicate. ``"datafusion"`` and
+        ``None`` always emit that naive predicate — a plain
+        ``ON a.chrom = b.chrom AND a.start < b.end AND b.start < a.end``
+        condition the engine's own optimizer plans as a range join — for both
+        inner and outer column-to-column INTERSECTS joins. Hard-error
+        projection shapes raise ``ValueError`` at transpile time; see the
+        performance guide for the full enumeration. The target's capabilities
+        also choose the
         coordinate-canonicalization emit form for a non-canonically-encoded
         table: ``"duckdb"`` emits ``SELECT * REPLACE (...)``, while the generic
         (``None``) and ``"datafusion"`` targets emit the portable
@@ -108,12 +107,6 @@ def transpile(
         DuckDB — pass ``dialect="duckdb"`` for DuckDB-runnable output. Tables in
         the canonical 0-based half-open encoding are unaffected (they emit
         portable SQL on every target).
-    intersects_bin_size : int | None
-        Bin size for INTERSECTS equi-join optimization. When a query
-        contains a full-table column-to-column INTERSECTS join, the
-        transpiler rewrites it as a binned equi-join for performance.
-        Defaults to 10,000 if not specified. Cannot be combined with
-        ``dialect="duckdb"``.
 
     Returns
     -------
@@ -123,9 +116,8 @@ def transpile(
     Raises
     ------
     ValueError
-        If the query cannot be parsed or transpiled, if ``dialect`` is
-        unknown, or if ``dialect="duckdb"`` and ``intersects_bin_size``
-        are both set.
+        If the query cannot be parsed or transpiled, or if ``dialect`` is
+        unknown.
 
     Examples
     --------
@@ -151,13 +143,13 @@ def transpile(
             ],
         )
 
-    Binned equi-join with custom bin size::
+    Column-to-column INTERSECTS join (naive overlap predicate; inner or
+    outer, planned as a range join by the target engine)::
 
         sql = transpile(
             "SELECT a.*, b.* FROM peaks a JOIN genes b "
             "ON a.interval INTERSECTS b.interval",
             tables=["peaks", "genes"],
-            intersects_bin_size=100000,
         )
 
     DuckDB IEJoin dialect (column-to-column INNER/SEMI/ANTI JOIN only;
@@ -172,84 +164,56 @@ def transpile(
     """
     target = resolve_target(dialect)
     uses_iejoin = target.capabilities.range_join_strategy == "iejoin"
-    if uses_iejoin and intersects_bin_size is not None:
-        raise ValueError(
-            f"intersects_bin_size has no effect with dialect={target.name!r}; "
-            f"the {target.name} target uses an IEJoin per-partition plan instead "
-            "of the binned equi-join. Pass one or the other, not both."
-        )
 
-    # The INTERSECTS join-rewrite override (governs the three uses below).
+    # The INTERSECTS join-rewrite override.
     #
     # A *target-specific* ``(target, Intersects)`` registry entry — the public
     # extension hook, matched by ``ExpanderRegistry.has_override`` — takes over the
     # INTERSECTS join rewrite entirely. ``has_override`` deliberately matches only
     # an *exact non-generic* entry: the built-in ``(GenericTarget(), Intersects)``
-    # predicate expander is NOT a join-strategy override (it only renders the
-    # residual / literal-range predicates the join transformers leave behind), so
-    # it must not disable the join rewrite. When an override is present, all three
-    # built-in join paths below are bypassed for that target so the INTERSECTS node
-    # flows untouched into ExpandOperators, which dispatches it to that expander:
-    #   1. ``intersects_bin_size`` is rejected — it only configures the built-in
-    #      binned transformer the override supersedes (rejected here, parallel to
-    #      the iejoin rejection above, rather than silently dropped);
-    #   2. the DuckDB IEJoin short-circuit is skipped (the registry-deferral the
-    #      IEJoin early-return used to preclude, #141);
-    #   3. the binned-join transformer is skipped.
+    # predicate expander is NOT a join-strategy override — it renders the naive
+    # overlap predicate that IS the generic join plan, so it must not disable the
+    # IEJoin short-circuit. When an override is present, the DuckDB IEJoin
+    # short-circuit below is skipped (the registry-deferral the IEJoin early-return
+    # used to preclude, #141) so the INTERSECTS node flows untouched into
+    # ExpandOperators, which dispatches it to that expander.
     target_overrides_intersects = REGISTRY.has_override(target, Intersects)
-    if target_overrides_intersects and intersects_bin_size is not None:
-        raise ValueError(
-            "intersects_bin_size has no effect when a target-specific "
-            f"(target={target.name!r}, Intersects) expander is registered; that "
-            "expander supersedes the built-in binned join transformer the bin "
-            "size configures. Pass one or the other, not both."
-        )
 
     tables_container = _build_tables(tables)
 
     with _reraise_as_value_error("Parse error", query=giql):
         ast = parse_one(giql, dialect=GIQLDialect)
 
-    # The column-to-column INTERSECTS *join* rewrites are capability-gated
-    # pre-pass transformers (epic #137, #141): the target's
-    # ``range_join_strategy`` selects the DuckDB IEJoin plan or the generic
-    # binned equi-join. They run on the raw parsed AST (before resolution, which
-    # rewrites the genomic column name) and consume a column-to-column INTERSECTS
-    # *join* so it never reaches the predicate expander; a literal-range or
-    # residual column-to-column INTERSECTS *predicate* survives to pass 3.
-    # ``target_overrides_intersects`` (computed above) gates whether these
-    # built-in join paths run — see its definition for the override rationale.
-
-    # Falls back to the binned plan for unsupported shapes — see
-    # IntersectsDuckDBIEJoinTransformer.transform_to_sql for the complete
-    # fallback set. The IEJoin transformer emits a whole-query string, so when it
-    # produces output it must short-circuit the AST pipeline. This never skips an
-    # INTERSECTS that pass 3 would expand: ``_classify_extras`` forces the binned
-    # fallback (returning None here) for any query carrying a residual INTERSECTS
-    # alongside the join, so a query the IEJoin transformer accepts has no residual
-    # INTERSECTS left for the expander. (A residual CONTAINS/WITHIN/ANY beside an
-    # IEJoin is a pre-existing IEJoin limitation that errors identically on main.)
+    # The DuckDB IEJoin plan is the one remaining capability-gated pre-pass
+    # transformer (epic #137, #141): ``range_join_strategy == "iejoin"`` selects
+    # it. It runs on the raw parsed AST (before resolution, which rewrites the
+    # genomic column name) and consumes a column-to-column INTERSECTS *join* so it
+    # never reaches the predicate expander. Every other target — and every shape
+    # the IEJoin path declines — leaves the column-to-column INTERSECTS in place
+    # for pass 3, where the ``(GenericTarget, Intersects)`` expander renders it as
+    # the naive overlap predicate (a plain ``ON`` condition the engine plans as a
+    # range join). Literal-range and residual INTERSECTS predicates flow the same
+    # way. ``target_overrides_intersects`` (computed above) gates whether the
+    # IEJoin path runs — see its definition for the override rationale.
+    #
+    # The IEJoin transformer emits a whole-query string, so when it produces output
+    # it must short-circuit the AST pipeline. This never skips an INTERSECTS that
+    # pass 3 would expand: ``_classify_extras`` declines (returning None here) for
+    # any query carrying a residual INTERSECTS alongside the join, so a query the
+    # IEJoin transformer accepts has no residual INTERSECTS left for the expander.
+    # (A residual CONTAINS/WITHIN/ANY beside an IEJoin is a pre-existing IEJoin
+    # limitation that errors identically on main.)
+    #
+    # CLUSTER and MERGE used to be rewritten as pre-pass transformers too; they are
+    # now expanded in pass 3 (ExpandOperators) by giql.expanders.cluster / .merge
+    # (#144), and the generic binned equi-join was dropped in favor of the naive
+    # predicate (#167).
     if uses_iejoin and not target_overrides_intersects:
         duckdb_transformer = IntersectsDuckDBIEJoinTransformer(tables_container)
         with _reraise_as_value_error("Transformation error"):
             duckdb_sql = duckdb_transformer.transform_to_sql(ast)
         if duckdb_sql is not None:
             return duckdb_sql
-
-    with _reraise_as_value_error("Transformation error"):
-        # Reaching here with an iejoin target means the IEJoin transformer
-        # declined the query (returned None) and fell back to the binned plan,
-        # exactly as before. ``intersects_bin_size`` is rejected up front for
-        # iejoin targets, so the binned transformer always sees its default there.
-        #
-        # CLUSTER and MERGE used to be rewritten here too; they are now expanded in
-        # pass 3 (ExpandOperators) by giql.expanders.cluster / .merge (#144).
-        if not target_overrides_intersects:
-            intersects_transformer = IntersectsBinnedJoinTransformer(
-                tables_container,
-                bin_size=intersects_bin_size,
-            )
-            ast = intersects_transformer.transform(ast)
 
     # Pass 1 of the normalization pipeline (epic #114): attach resolution
     # metadata to every GIQL operator slot ahead of generation. Every migrated

--- a/tests/expanders/test_intersects.py
+++ b/tests/expanders/test_intersects.py
@@ -297,30 +297,30 @@ def isolated_registry():
         REGISTRY.restore(saved)
 
 
-class TestBinnedTargetOverrideDeferral:
-    """A target-specific Intersects override defers the binned join rewrite (#141)."""
+class TestTargetOverrideDeferral:
+    """A target-specific Intersects override supersedes the default rewrite (#141)."""
 
-    def test_transpile_should_skip_binned_rewrite_when_target_override(
+    def test_transpile_should_skip_default_rewrite_when_target_override(
         self, isolated_registry
     ):
-        """Test that a (target, Intersects) override bypasses the binned transformer.
+        """Test that a (target, Intersects) override supersedes the naive predicate.
 
         Given:
-            A column-to-column INTERSECTS join on the generic binned path
+            A column-to-column INTERSECTS join on a naive-predicate target
             (dialect='datafusion') with a (DataFusionTarget, Intersects) override
             registered.
         When:
             Transpiling.
         Then:
-            The override's sentinel reaches the SQL and no binned equi-join
-            artifact is emitted — the override takes over the join rewrite that the
-            built-in binned transformer would otherwise perform.
+            The override's sentinel reaches the SQL and the built-in naive overlap
+            predicate is NOT emitted — the override takes over the join rewrite the
+            default ``(GenericTarget, Intersects)`` expander would otherwise perform.
         """
         # Arrange
         isolated_registry.register(
             DataFusionTarget(),
             Intersects,
-            lambda n, c: exp.column("BINNED_OVERRIDE_SENTINEL"),
+            lambda n, c: exp.column("INTERSECTS_OVERRIDE_SENTINEL"),
         )
         query = (
             "SELECT a.start FROM peaks a "
@@ -331,42 +331,9 @@ class TestBinnedTargetOverrideDeferral:
         sql = transpile(query, tables=["peaks", "genes"], dialect="datafusion")
 
         # Assert
-        assert "BINNED_OVERRIDE_SENTINEL" in sql
-        assert "_bins" not in sql
-
-    def test_transpile_should_reject_bin_size_when_target_override(
-        self, isolated_registry
-    ):
-        """Test that bin size is rejected under a binned-target Intersects override.
-
-        Given:
-            A (DataFusionTarget, Intersects) override registered.
-        When:
-            Transpiling with intersects_bin_size set (which only configures the
-            built-in binned transformer the override supersedes).
-        Then:
-            transpile() raises ValueError rather than silently dropping the bin
-            size, parallel to the iejoin rejection.
-        """
-        # Arrange
-        isolated_registry.register(
-            DataFusionTarget(),
-            Intersects,
-            lambda n, c: exp.column("BINNED_OVERRIDE_SENTINEL"),
-        )
-        query = (
-            "SELECT a.start FROM peaks a "
-            "JOIN genes b ON a.interval INTERSECTS b.interval"
-        )
-
-        # Act & assert
-        with pytest.raises(ValueError, match=r"intersects_bin_size has no effect"):
-            transpile(
-                query,
-                tables=["peaks", "genes"],
-                dialect="datafusion",
-                intersects_bin_size=5000,
-            )
+        assert "INTERSECTS_OVERRIDE_SENTINEL" in sql
+        # The default naive overlap predicate did not fire.
+        assert "<" not in sql
 
 
 class TestSpatialExpanderErrors:

--- a/tests/integration/bedtools/test_intersect_property.py
+++ b/tests/integration/bedtools/test_intersect_property.py
@@ -1,9 +1,8 @@
-"""Property-based correctness tests for INTERSECTS binned equi-join.
+"""Property-based correctness tests for the INTERSECTS naive overlap predicate.
 
 These tests use hypothesis to generate random genomic intervals of
-varying sizes — including intervals that span multiple bins — and
-verify that GIQL's binned equi-join produces identical results to
-bedtools intersect.
+varying sizes and verify that GIQL's naive overlap predicate produces
+identical results to bedtools intersect.
 """
 
 from hypothesis import HealthCheck
@@ -57,7 +56,7 @@ interval_list_st = unique_interval_list_st()
 
 
 def _run_giql(intervals_a, intervals_b):
-    """Run the binned-join INTERSECTS query via DuckDB and return result rows."""
+    """Run the INTERSECTS-join query via DuckDB and return result rows."""
     conn = duckdb.connect(":memory:")
     try:
         load_intervals(conn, "intervals_a", [i.to_tuple() for i in intervals_a])
@@ -90,10 +89,10 @@ def _run_bedtools(intervals_a, intervals_b):
     deadline=None,
     suppress_health_check=[HealthCheck.too_slow],
 )
-def test_binned_join_matches_bedtools(intervals_a, intervals_b):
+def test_intersects_join_matches_bedtools(intervals_a, intervals_b):
     """
     GIVEN two randomly generated sets of genomic intervals
-    WHEN GIQL INTERSECTS binned equi-join is executed
+    WHEN GIQL INTERSECTS join is executed
     THEN results match bedtools intersect -u exactly
     """
     giql_result = _run_giql(intervals_a, intervals_b)
@@ -120,46 +119,6 @@ def test_self_join_matches_bedtools(intervals):
 
     comparison = compare_results(giql_result, bedtools_result)
     assert comparison.match, comparison.failure_message()
-
-
-@given(
-    intervals_a=unique_interval_list_st(max_size=30),
-    intervals_b=unique_interval_list_st(max_size=30),
-    bin_size=st.sampled_from([100, 1_000, 10_000, 100_000]),
-)
-@settings(
-    max_examples=40,
-    deadline=None,
-    suppress_health_check=[HealthCheck.too_slow],
-)
-def test_bin_size_does_not_affect_correctness(intervals_a, intervals_b, bin_size):
-    """
-    GIVEN two randomly generated sets of genomic intervals and a bin size
-    WHEN GIQL INTERSECTS is executed with that bin size
-    THEN results match bedtools intersect -u regardless of bin size
-    """
-    conn = duckdb.connect(":memory:")
-    try:
-        load_intervals(conn, "intervals_a", [i.to_tuple() for i in intervals_a])
-        load_intervals(conn, "intervals_b", [i.to_tuple() for i in intervals_b])
-
-        sql = transpile(
-            """
-            SELECT DISTINCT a.*
-            FROM intervals_a a, intervals_b b
-            WHERE a.interval INTERSECTS b.interval
-            """,
-            tables=["intervals_a", "intervals_b"],
-            intersects_bin_size=bin_size,
-        )
-        giql_result = conn.execute(sql).fetchall()
-    finally:
-        conn.close()
-
-    bedtools_result = _run_bedtools(intervals_a, intervals_b)
-
-    comparison = compare_results(giql_result, bedtools_result)
-    assert comparison.match, f"bin_size={bin_size}: {comparison.failure_message()}"
 
 
 @given(
@@ -364,8 +323,8 @@ def test_count_matches_bedtools_c(intervals_a, intervals_b):
         load_intervals(conn, "intervals_a", [i.to_tuple() for i in intervals_a])
         load_intervals(conn, "intervals_b", [i.to_tuple() for i in intervals_b])
 
-        # Use a naive overlap join for counting — the binned join's
-        # DISTINCT would collapse duplicate B matches.
+        # Use a naive overlap join for counting — a DISTINCT projection
+        # would collapse duplicate B matches.
         count_sql = """
             SELECT
                 a.chrom, a."start", a."end", a.name, a.score, a.strand,
@@ -400,10 +359,10 @@ def test_count_matches_bedtools_c(intervals_a, intervals_b):
     deadline=None,
     suppress_health_check=[HealthCheck.too_slow],
 )
-def test_count_via_binned_join_matches_bedtools_c(intervals_a, intervals_b):
+def test_count_via_intersects_join_matches_bedtools_c(intervals_a, intervals_b):
     """
     GIVEN two randomly generated sets of unique genomic intervals
-    WHEN overlap count is computed via GIQL binned join with
+    WHEN overlap count is computed via GIQL INTERSECTS join with
          distinguishing B columns in the SELECT
     THEN results match bedtools intersect -c exactly
     """

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -48,7 +48,7 @@ from ._oracle import normalize
 from ._oracle import resolve_routing
 
 # Default per-target schema: GIQL's default interval columns. Reserved words
-# (``end``) are quoted by the loaders below, mirroring ``test_binned_join.py``.
+# (``end``) are quoted by the loaders below, mirroring ``test_intersects_join.py``.
 DEFAULT_COLUMNS: tuple[tuple[str, str], ...] = (
     ("chrom", "utf8"),
     ("start", "int64"),

--- a/tests/integration/datafusion/test_cross_target_oracle.py
+++ b/tests/integration/datafusion/test_cross_target_oracle.py
@@ -11,8 +11,9 @@ For the non-join operators (DISTANCE, CONTAINS, WITHIN, ANY/ALL, CLUSTER,
 MERGE) the generic and datafusion targets emit byte-identical SQL and both run
 on the DataFusion engine, so the load-bearing comparison there is
 DataFusion-vs-DuckDB. Only the column-to-column INTERSECTS join produces
-genuinely divergent SQL across targets (the DuckDB IEJoin vs. the binned
-equi-join).
+genuinely divergent SQL across targets (the DuckDB IEJoin vs. the naive overlap
+predicate the generic / datafusion targets emit; an outer INTERSECTS join, which
+the IEJoin path declines, runs the naive predicate on every target — #167).
 
 NEAREST's correlated expansion is capability-driven (#142): lateral-capable
 targets (generic, duckdb) emit the portable ``LATERAL`` subquery, while
@@ -102,7 +103,8 @@ class TestCrossTargetOracleIntersects:
             other intervals do not overlap or sit on another chromosome.
         When:
             A column-to-column INTERSECTS join runs — generic/datafusion via the
-            binned equi-join on DataFusion and duckdb via the IEJoin on DuckDB.
+            naive overlap predicate on DataFusion and duckdb via the IEJoin on
+            DuckDB.
         Then:
             Every target should return the single overlapping pair, proving the
             structurally different DuckDB IEJoin SQL yields identical rows.
@@ -122,6 +124,43 @@ class TestCrossTargetOracleIntersects:
                 ("chr2", 9000, 9500),
             ],
             expected=[("chr1", 100, 300)],
+        )
+
+    def test_column_to_column_left_join_preserves_unmatched(self, cross_target_oracle):
+        """Test an outer INTERSECTS join agrees across all targets, keeping NULLs.
+
+        Given:
+            Peaks and genes where one peak overlaps a gene on chr1, one peak on
+            chr1 has no overlap, and one peak sits on chr2 with no overlapping gene.
+        When:
+            A column-to-column ``LEFT JOIN ... ON ... INTERSECTS`` runs. The DuckDB
+            IEJoin path declines outer joins, so every target — generic, datafusion,
+            and duckdb — evaluates the naive overlap predicate as a plain outer
+            ``ON`` condition.
+        Then:
+            Every target should return the matched pair plus both unmatched left
+            rows with a NULL right column, proving the naive predicate gives correct
+            outer-join semantics identically on every engine (#167).
+        """
+        # Arrange / Act / Assert
+        cross_target_oracle(
+            "SELECT a.chrom, a.start AS a_start, b.start AS b_start "
+            "FROM peaks a LEFT JOIN genes b ON a.interval INTERSECTS b.interval",
+            peaks=[
+                ("chr1", 100, 500),
+                ("chr1", 1000, 2000),
+                ("chr2", 100, 500),
+            ],
+            genes=[
+                ("chr1", 300, 600),
+                ("chr1", 5000, 6000),
+                ("chr2", 9000, 9500),
+            ],
+            expected=[
+                ("chr1", 100, 300),
+                ("chr1", 1000, None),
+                ("chr2", 100, None),
+            ],
         )
 
 
@@ -1485,20 +1524,18 @@ class TestCrossTargetOracleDataShapes:
             expected=[(100, 200)],
         )
 
-    def test_large_interval_spanning_bins_is_not_duplicated(self, cross_target_oracle):
-        """Test two intervals sharing many bins yield one pair, not duplicates.
+    def test_large_interval_span_is_not_duplicated(self, cross_target_oracle):
+        """Test a large-span overlap yields exactly one pair, not duplicates.
 
         Given:
-            A peak (0-500000) and a gene (5000-495000) that co-occupy dozens of
-            shared join bins (the bin width is 10000), so the binned candidate
-            join produces the same pair once per shared bin.
+            A peak (0-500000) and a gene (5000-495000) whose long spans overlap.
         When:
             A column-to-column INTERSECTS join runs on every target.
         Then:
-            Every target should return exactly one pair — the binned join's
-            ``SELECT DISTINCT`` must collapse the duplicate cross-bin candidates,
-            and the oracle's multiset compare is what would catch a stripped
-            DISTINCT as a duplicate-row regression.
+            Every target should return exactly one pair — the naive overlap
+            predicate is a plain ``ON`` condition with no cross-bin fan-out to
+            deduplicate, so a single pair is emitted; the oracle's multiset compare
+            is what would catch a spurious duplicate row as a regression.
         """
         # Arrange / Act / Assert
         cross_target_oracle(

--- a/tests/integration/datafusion/test_datafusion_target.py
+++ b/tests/integration/datafusion/test_datafusion_target.py
@@ -1,9 +1,10 @@
 """DataFusion execution smoke tests for the ``dialect="datafusion"`` target.
 
 Issue #132 makes ``"datafusion"`` a routing key in :func:`giql.transpile`. The
-existing ``TestBinnedJoinDataFusion`` suite proves the binned plan executes on
-DataFusion, but always with ``dialect`` omitted (``None``); nothing executes the
-``dialect="datafusion"`` entry point end-to-end. These tests close that seam.
+existing INTERSECTS-join DataFusion suite proves the naive overlap predicate
+executes on DataFusion, but always with ``dialect`` omitted (``None``); nothing
+executes the ``dialect="datafusion"`` entry point end-to-end. These tests close
+that seam.
 """
 
 import pytest
@@ -85,21 +86,19 @@ class TestDataFusionTargetExecution:
         # Assert
         assert len(df) == 0
 
-    def test_intersects_join_with_bin_size_dedups_across_bins(self, datafusion_ctx):
-        """Test the datafusion-routed binned join honours an explicit bin size.
+    def test_intersects_join_dedups_across_overlaps(self, datafusion_ctx):
+        """Test the datafusion-routed INTERSECTS join returns each overlap once.
 
         Given:
             Two interval tables in a real DataFusion context whose single
-            intervals overlap and span several bins under a small bin size.
+            intervals overlap.
         When:
             A column-to-column INTERSECTS join is transpiled with
-            dialect="datafusion" and an explicit intersects_bin_size, then
-            executed.
+            dialect="datafusion" and executed.
         Then:
-            It should be accepted (not rejected as it would be for duckdb),
-            the explicit bin size should reach emission (changing the SQL vs
-            the default), and execution should return exactly one row — the
-            overlap, de-duplicated by the pairs CTE across the shared bins.
+            The naive overlap predicate should be accepted (not rejected as
+            it would be for duckdb) and execution should return exactly one
+            row — the overlap, without duplicates.
         """
         # Arrange
         ctx = datafusion_ctx(
@@ -111,19 +110,12 @@ class TestDataFusionTargetExecution:
             'b.start AS b_start, b."end" AS b_end '
             "FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval"
         )
-        default_sql = transpile(query, tables=["peaks", "genes"], dialect="datafusion")
-        sized_sql = transpile(
-            query,
-            tables=["peaks", "genes"],
-            dialect="datafusion",
-            intersects_bin_size=1000,
-        )
+        sql = transpile(query, tables=["peaks", "genes"], dialect="datafusion")
 
         # Act
-        df = ctx.sql(sized_sql).to_pandas()
+        df = ctx.sql(sql).to_pandas()
 
         # Assert
-        assert sized_sql != default_sql  # the explicit bin size reaches emission
-        assert len(df) == 1  # de-duplicated across the shared bins
+        assert len(df) == 1  # the single overlap, without duplicates
         assert df.iloc[0]["start"] == 0
         assert df.iloc[0]["b_start"] == 500

--- a/tests/test_duckdb_iejoin.py
+++ b/tests/test_duckdb_iejoin.py
@@ -111,8 +111,8 @@ _EXPECTED_OVERLAPS_PEAKS_GENES = [
 class TestTranspileDuckDBIEJoinSQLStructure:
     """SQL-shape and routing assertions for the DuckDB IEJoin dialect path."""
 
-    def test_transpile_should_keep_binned_path_when_dialect_is_none(self):
-        """Test that omitting ``dialect`` keeps the generic binned plan.
+    def test_transpile_should_keep_naive_predicate_path_when_dialect_is_none(self):
+        """Test that omitting ``dialect`` keeps the generic naive-predicate plan.
 
         Given:
             A column-to-column INTERSECTS JOIN.
@@ -136,10 +136,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "SET VARIABLE" not in sql.upper()
         assert "getvariable" not in sql
 
-    def test_transpile_should_route_outer_join_intersects_to_binned_plan_when_dialect_is_duckdb(
+    def test_transpile_should_route_outer_join_intersects_to_naive_predicate_plan_when_dialect_is_duckdb(
         self, conn
     ):
-        """Test that LEFT JOIN INTERSECTS falls back to the binned plan.
+        """Test that LEFT JOIN INTERSECTS falls back to the naive-predicate plan.
 
         Given:
             A LEFT JOIN INTERSECTS query and a peak with no overlapping
@@ -149,7 +149,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         Then:
             It should preserve LEFT JOIN semantics by returning the
             unmatched peak with NULL gene columns (which the IEJoin path
-            cannot do, so the binned fallback fires).
+            cannot do, so the naive-predicate fallback fires).
         """
         # Arrange
         _make_table(
@@ -193,7 +193,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             The dialect path should inline the extra predicate into each
             per-chromosome subquery's join ON, excluding the pair that
             violates the predicate and including the pair that satisfies
-            it. (Note: the binned plan still drops this predicate per
+            it. (Note: the naive-predicate plan still drops this predicate per
             bug #94; the dialect now sidesteps that bug entirely by
             handling extras directly.)
         """
@@ -357,10 +357,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "SET VARIABLE __giql_iejoin_" in sql
         assert rows == [(300,)]
 
-    def test_transpile_should_route_to_binned_plan_when_extra_predicate_uses_or(
+    def test_transpile_should_route_to_naive_predicate_plan_when_extra_predicate_uses_or(
         self,
     ):
-        """Test that an OR-wrapped extra predicate falls back to the binned plan.
+        """Test that an OR-wrapped predicate falls back to the naive-predicate plan.
 
         Given:
             A column-to-column INTERSECTS INNER join whose JOIN ON wraps
@@ -370,7 +370,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         Then:
             The dialect cannot peel the INTERSECTS out of the OR tree
             (only AND-conjunctions are decomposable safely) and routes
-            to the binned plan.
+            to the naive-predicate plan.
         """
         # Arrange & act
         sql = transpile(
@@ -396,7 +396,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             The query is transpiled with ``dialect='duckdb'``.
         Then:
             The dialect cannot safely scope the predicate to either
-            ``a`` or ``b`` inside the inner subquery, and the binned
+            ``a`` or ``b`` inside the inner subquery, and the naive-predicate
             plan can't handle it correctly either (issue #94), so the
             dialect raises with an actionable message naming the join's
             valid aliases instead of silently routing to a broken plan.
@@ -574,36 +574,6 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         with pytest.raises(ValueError, match="qualified"):
             transpile(query, tables=["peaks", "genes"], dialect="duckdb")
 
-    def test_transpile_should_raise_when_dialect_duckdb_and_intersects_bin_size_are_both_set(
-        self,
-    ):
-        """Test that ``dialect='duckdb'`` and ``intersects_bin_size`` are mutually exclusive.
-
-        Given:
-            ``dialect='duckdb'`` together with a non-None
-            ``intersects_bin_size``.
-        When:
-            ``transpile`` is called.
-        Then:
-            It should raise ``ValueError`` whose message names
-            ``intersects_bin_size``.
-        """
-        # Arrange
-        query = """
-            SELECT a.chrom, a.start, b.start
-            FROM peaks a
-            JOIN genes b ON a.interval INTERSECTS b.interval
-            """
-
-        # Act & assert
-        with pytest.raises(ValueError, match="intersects_bin_size"):
-            transpile(
-                query,
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-                intersects_bin_size=50000,
-            )
-
     # --- DI-001..DI-009: new SQL-structure / contract tests --------------
 
     def test_transpile_should_be_round_trip_executable_when_dialect_is_duckdb(
@@ -640,10 +610,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert rows == sorted(_EXPECTED_OVERLAPS_PEAKS_GENES)
 
-    def test_transpile_should_route_to_binned_plan_when_query_has_two_intersects_predicates(
+    def test_transpile_should_route_to_naive_predicate_plan_when_query_has_two_intersects_predicates(
         self, conn
     ):
-        """Test that two INTERSECTS predicates fall back to the binned plan.
+        """Test that two INTERSECTS predicates fall back to the naive-predicate plan.
 
         Given:
             A three-table chained INTERSECTS query (peaks JOIN genes
@@ -652,7 +622,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             The query is transpiled both with ``dialect='duckdb'`` and
             with ``dialect=None`` and both are executed.
         Then:
-            The DuckDB-dialect path should fall back to the binned plan
+            The DuckDB-dialect path should fall back to the naive-predicate plan
             and return the same multiset of triply-overlapping rows as the
             default ``dialect=None`` path.
         """
@@ -696,7 +666,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             The query is transpiled with ``dialect='duckdb'`` and executed.
         Then:
-            It should fall back to the binned plan and return the
+            It should fall back to the naive-predicate plan and return the
             self-overlap pairs without raising.
         """
         # Arrange
@@ -1263,10 +1233,8 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "DISTINCT" in sql.upper()
         assert rows == [("chr1", 2)]
 
-    def test_query_should_match_binned_plan_avg_aggregate_when_dialect_is_duckdb(
-        self, conn
-    ):
-        """Test that AVG aggregate matches the binned plan executing-side.
+    def test_query_should_match_naive_predicate_plan_for_avg_aggregate(self, conn):
+        """Test that AVG aggregate matches the naive-predicate plan executing-side.
 
         Given:
             Two chromosomes with multiple overlap pairs and varied
@@ -1274,7 +1242,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             average.
         When:
             A ``SELECT a.chrom, AVG(a.score) ... GROUP BY a.chrom`` is
-            transpiled under both ``dialect=None`` (binned plan) and
+            transpiled under both ``dialect=None`` (naive-predicate plan) and
             ``dialect='duckdb'`` and executed.
         Then:
             Both plans return the same per-chrom averages (compared via
@@ -1393,7 +1361,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
                 dialect="duckdb",
             )
 
-    def test_transpile_should_route_to_binned_plan_when_outer_join_intersects_lives_in_where(
+    def test_transpile_should_route_to_naive_predicate_plan_when_outer_join_intersects_lives_in_where(
         self,
     ):
         """Test that LEFT JOIN ON TRUE WHERE INTERSECTS falls back.
@@ -1420,7 +1388,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_route_to_binned_plan_when_full_outer_join_intersects_lives_in_where(
+    def test_transpile_should_route_to_naive_predicate_plan_when_full_outer_join_intersects_lives_in_where(
         self,
     ):
         """Test that FULL OUTER JOIN ... WHERE INTERSECTS falls back.
@@ -1431,7 +1399,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            The dialect must not engage; the binned plan handles the
+            The dialect must not engage; the naive-predicate plan handles the
             outer-join semantics.
         """
         # Arrange & act
@@ -1446,7 +1414,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_route_to_binned_plan_when_extra_predicate_contains_window_function(
+    def test_transpile_should_route_to_naive_predicate_plan_when_extra_predicate_contains_window_function(
         self,
     ):
         """Test that window functions inside extras force a fallback.
@@ -1460,7 +1428,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
             The dialect must reject the residual and route to the
-            binned plan (rather than emit SQL that DuckDB rejects at
+            naive-predicate plan (rather than emit SQL that DuckDB rejects at
             runtime).
         """
         # Arrange & act
@@ -1564,21 +1532,21 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             "expression" in message or "arithmetic" in message
         )
 
-    def test_transpile_should_route_to_binned_plan_when_modifier_contains_subquery(
+    def test_transpile_should_route_to_naive_predicate_plan_when_modifier_has_subquery(
         self,
     ):
-        """Test that a subquery inside ORDER BY routes to the binned plan.
+        """Test that a subquery inside ORDER BY routes to the naive-predicate plan.
 
         Given:
             A query whose ``ORDER BY`` clause embeds a scalar subquery
             (``(SELECT MAX(score) FROM peaks)``). The modifier rewriter
             is not scope-aware, so the dialect should fall back to the
-            binned plan rather than rewrite column refs inside the
+            naive-predicate plan rather than rewrite column refs inside the
             nested scope.
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            The dialect must not engage; the binned plan handles the
+            The dialect must not engage; the naive-predicate plan handles the
             subquery natively.
         """
         # Arrange & act
@@ -1593,10 +1561,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_route_to_binned_plan_when_modifier_contains_exists(
+    def test_transpile_should_route_to_naive_predicate_plan_when_modifier_has_exists(
         self,
     ):
-        """Test that EXISTS inside ORDER BY routes to the binned plan.
+        """Test that EXISTS inside ORDER BY routes to the naive-predicate plan.
 
         Given:
             A query whose ``ORDER BY`` clause embeds an ``EXISTS
@@ -1622,10 +1590,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_route_to_binned_plan_when_having_contains_subquery(
+    def test_transpile_should_route_to_naive_predicate_plan_when_having_has_subquery(
         self,
     ):
-        """Test that a subquery inside HAVING routes to the binned plan.
+        """Test that a subquery inside HAVING routes to the naive-predicate plan.
 
         Given:
             A query whose HAVING compares against a scalar subquery
@@ -1713,8 +1681,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             )
         assert "subquer" in str(excinfo.value).lower()
 
-    def test_transpile_should_route_to_binned_plan_when_query_has_distinct_on(self):
-        """Test that DISTINCT ON (...) falls back to the binned plan.
+    def test_transpile_should_route_to_naive_predicate_plan_when_query_has_distinct_on(
+        self,
+    ):
+        """Test that DISTINCT ON (...) falls back to the naive-predicate plan.
 
         Given:
             A column-to-column INTERSECTS INNER join with a
@@ -1736,10 +1706,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_route_to_binned_plan_and_execute_correctly_when_query_has_top_level_with_clause(
+    def test_transpile_should_route_to_naive_predicate_plan_and_execute_correctly_when_query_has_top_level_with_clause(
         self, conn
     ):
-        """Test that a top-level WITH clause falls back to the binned plan.
+        """Test that a top-level WITH clause falls back to the naive-predicate plan.
 
         Given:
             A query whose INTERSECTS join is wrapped in a top-level
@@ -1748,7 +1718,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             The query is transpiled with ``dialect='duckdb'`` and executed.
         Then:
-            It should fall back to the binned plan, preserve the CTE
+            It should fall back to the naive-predicate plan, preserve the CTE
             definition, and execute against the materialized CTE. The
             dialect path would otherwise emit a `FROM big` referencing
             a missing table.
@@ -1779,10 +1749,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "SET VARIABLE __giql_iejoin_" not in sql
         assert rows == [(100,)]
 
-    def test_transpile_should_route_to_binned_plan_when_query_has_three_table_cross_join(
+    def test_transpile_should_route_to_naive_predicate_plan_when_three_table_cross_join(
         self, conn
     ):
-        """Test that a 3-table implicit cross-join falls back to the binned plan.
+        """Test that a 3-table cross-join falls back to the naive-predicate plan.
 
         Given:
             A 3-table comma-style FROM clause where the INTERSECTS
@@ -1791,7 +1761,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             The query is transpiled with ``dialect='duckdb'`` and executed.
         Then:
-            It should fall back to the binned plan and return a row
+            It should fall back to the naive-predicate plan and return a row
             count consistent with the full 3-way join — the dialect
             path would silently drop the third table.
         """
@@ -1830,7 +1800,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # = 2 result rows. The dialect path would emit only 1 (extra dropped).
         assert len(rows) == 2
 
-    def test_transpile_should_route_to_binned_plan_when_join_target_is_a_giql_operator(
+    def test_transpile_should_route_to_naive_predicate_plan_when_target_is_giql_operator(
         self, conn
     ):
         """Test that a GIQL table-function in JOIN position falls back.
@@ -1845,7 +1815,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         Then:
             The dialect path should return ``None`` (fall back) and the
             emitted SQL should contain no ``SET VARIABLE`` block and no
-            empty ``FROM `` interpolation. (Execution is the binned
+            empty ``FROM `` interpolation. (Execution is the naive-predicate
             path's domain and is covered by DISJOIN's own tests.)
         """
         # Arrange & Act
@@ -2287,10 +2257,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "IS NULL" in set_part
         assert "IS NULL" not in outer_part
 
-    def test_transpile_should_route_to_binned_plan_when_paren_wraps_intersects(
+    def test_transpile_should_route_to_naive_predicate_plan_when_paren_wraps_intersects(
         self,
     ):
-        """Test that a Paren-wrapped INTERSECTS routes to the binned plan.
+        """Test that a Paren-wrapped INTERSECTS routes to the naive-predicate plan.
 
         Given:
             A join ``ON (a.interval INTERSECTS b.interval) AND a.score > 0``
@@ -2301,7 +2271,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             The dialect only decomposes AND-conjunctions when stripping
             the INTERSECTS out of a join clause; a paren wrapper leaves
             the INTERSECTS embedded in the residual and the dialect
-            must fall back to the binned plan.
+            must fall back to the naive-predicate plan.
         """
         # Arrange & act
         sql = transpile(
@@ -2315,7 +2285,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_route_to_binned_plan_when_residual_contains_subquery(
+    def test_transpile_should_route_to_naive_predicate_plan_when_residual_has_subquery(
         self,
     ):
         """Test that a subquery in the residual predicate forces a fallback.
@@ -2328,7 +2298,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         Then:
             The dialect's residual-safety check rejects predicates
             containing a subquery, so the query falls back to the
-            binned plan.
+            naive-predicate plan.
         """
         # Arrange & act
         sql = transpile(
@@ -2509,10 +2479,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "a.start" not in outer_select
         assert "a.end" not in outer_select
 
-    def test_transpile_should_route_right_outer_join_intersects_to_binned_plan_when_dialect_is_duckdb(
+    def test_transpile_should_route_right_outer_join_intersects_to_naive_predicate_plan_when_dialect_is_duckdb(
         self,
     ):
-        """Test that ``RIGHT JOIN ... INTERSECTS`` falls back to the binned plan.
+        """Test that ``RIGHT JOIN INTERSECTS`` falls back to the naive-predicate plan.
 
         Given:
             A query with a ``RIGHT JOIN`` whose ON contains a
@@ -2521,7 +2491,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
             ``_has_outer_join_intersects`` should detect the
-            outer-join side and route to the binned plan.
+            outer-join side and route to the naive-predicate plan.
         """
         # Arrange & act
         sql = transpile(
@@ -2534,10 +2504,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_route_to_binned_plan_when_join_target_is_subquery(
+    def test_transpile_should_route_to_naive_predicate_plan_when_join_target_is_subquery(
         self,
     ):
-        """Test that a subquery JOIN target routes to the binned plan.
+        """Test that a subquery JOIN target routes to the naive-predicate plan.
 
         Given:
             A query whose JOIN target is a parenthesised subquery,
@@ -2547,7 +2517,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
             The dialect's "must be a base table" gate should fire and
-            route to the binned plan.
+            route to the naive-predicate plan.
         """
         # Arrange & act
         sql = transpile(
@@ -2638,8 +2608,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert isinstance(excinfo.value, ValueError)
         assert "qualified" in str(excinfo.value)
 
-    def test_transpile_should_fall_back_to_binned_plan_when_join_is_natural(self):
-        """Test that NATURAL JOIN falls back to the binned plan.
+    def test_transpile_should_fall_back_to_naive_predicate_plan_when_join_is_natural(
+        self,
+    ):
+        """Test that NATURAL JOIN falls back to the naive-predicate plan.
 
         Given:
             A query joining two tables with ``NATURAL JOIN`` and an
@@ -2689,7 +2661,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "SET VARIABLE __giql_iejoin_" in sql
 
     def test_transpile_should_fall_back_when_using_join_targets_non_chrom_column(self):
-        """Test that ``USING(<non-chrom>)`` falls back to the binned plan.
+        """Test that ``USING(<non-chrom>)`` falls back to the naive-predicate plan.
 
         Given:
             A query with ``USING(strand)`` plus INTERSECTS — the partition
@@ -2697,7 +2669,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            It should fall back to the binned plan (no
+            It should fall back to the naive-predicate plan (no
             ``SET VARIABLE __giql_iejoin_`` block).
         """
         # Arrange
@@ -2720,7 +2692,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            It should fall back to the binned plan (multi-column USING
+            It should fall back to the naive-predicate plan (multi-column USING
             inline support is a documented follow-up).
         """
         # Arrange
@@ -2775,7 +2747,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            It should fall back to the binned plan.
+            It should fall back to the naive-predicate plan.
         """
         # Arrange
         query = (
@@ -2801,7 +2773,7 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            It should fall back to the binned plan.
+            It should fall back to the naive-predicate plan.
         """
         # Arrange
         query = (
@@ -3079,16 +3051,16 @@ class TestTranspileDuckDBIEJoinExecution:
         # Assert
         assert rows == []
 
-    def test_query_should_match_binned_plan_results_when_executed_on_duckdb(
+    def test_query_should_match_naive_predicate_plan_results_when_executed_on_duckdb(
         self, peaks_genes
     ):
-        """Test that the binned plan and the IEJoin path agree on results.
+        """Test that the naive-predicate plan and the IEJoin path agree on results.
 
         Given:
             The ``peaks_genes`` fixture and a column-to-column
             INTERSECTS INNER JOIN.
         When:
-            The query is transpiled both with ``dialect=None`` (binned
+            The query is transpiled both with ``dialect=None`` (naive-predicate
             plan) and with ``dialect='duckdb'`` (IEJoin path) and both
             are executed.
         Then:
@@ -3102,15 +3074,15 @@ class TestTranspileDuckDBIEJoinExecution:
             FROM peaks a
             JOIN genes b ON a.interval INTERSECTS b.interval
             """
-        binned_sql = transpile(query, tables=["peaks", "genes"])
+        generic_sql = transpile(query, tables=["peaks", "genes"])
         duckdb_sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
 
         # Act
-        binned_rows = sorted(peaks_genes.execute(binned_sql).fetchall())
+        generic_rows = sorted(peaks_genes.execute(generic_sql).fetchall())
         duckdb_rows = sorted(peaks_genes.execute(duckdb_sql).fetchall())
 
         # Assert
-        assert binned_rows == duckdb_rows
+        assert generic_rows == duckdb_rows
         assert duckdb_rows == sorted(_EXPECTED_OVERLAPS_PEAKS_GENES)
 
     def test_query_should_handle_chrom_with_single_quote_in_name(self, conn):
@@ -3650,7 +3622,7 @@ class TestTranspileDuckDBIEJoinExecution:
             executed.
         Then:
             The unmatched peak should appear in the result with NULL
-            gene columns (the IEJoin path falls back to the binned plan
+            gene columns (the IEJoin path falls back to the naive-predicate plan
             for outer joins).
         """
         # Arrange
@@ -4471,7 +4443,7 @@ class TestTranspileDuckDBIEJoinExecution:
             ("1based", "closed"),
         ],
     )
-    def test_query_should_match_binned_plan_for_coordinate_system_combinations(
+    def test_query_should_match_naive_predicate_plan_for_coordinate_system_combinations(
         self, conn, coordinate_system, interval_type
     ):
         """Test cross-plan equivalence across all 4 coord-system × interval-type combos.
@@ -4481,7 +4453,7 @@ class TestTranspileDuckDBIEJoinExecution:
             depend on how endpoints are interpreted.
         When:
             The same logical query is transpiled twice — once with
-            ``dialect=None`` (binned plan) and once with
+            ``dialect=None`` (naive-predicate plan) and once with
             ``dialect="duckdb"`` — under each of the 4
             ``(coordinate_system, interval_type)`` combinations.
         Then:
@@ -4655,8 +4627,10 @@ class TestTranspileDuckDBIEJoinExecution:
             max_size=6,
         ),
     )
-    def test_query_should_match_binned_plan_for_random_inputs(self, conn, peaks, genes):
-        """Test that the binned plan and the IEJoin path agree on random inputs.
+    def test_query_should_match_naive_predicate_plan_for_random_inputs(
+        self, conn, peaks, genes
+    ):
+        """Test that the naive-predicate plan and the IEJoin path agree on random inputs.
 
         Given:
             A Hypothesis-generated pair of small interval lists.
@@ -4726,7 +4700,7 @@ class TestTranspileDuckDBIEJoinExecution:
         ),
         score_threshold=st.integers(min_value=0, max_value=50),
     )
-    def test_query_should_match_binned_plan_when_where_group_count_order_combined(
+    def test_query_should_match_naive_predicate_plan_when_where_group_order_combined(
         self, conn, peaks, genes, score_threshold
     ):
         """Test cross-plan equivalence with extras, GROUP BY, and ORDER BY.
@@ -4867,7 +4841,7 @@ class TestTranspileDuckDBIEJoinExecution:
         ),
         threshold=st.integers(min_value=0, max_value=50),
     )
-    def test_query_should_match_binned_plan_for_random_extra_where_predicates(
+    def test_query_should_match_naive_predicate_plan_for_random_extra_where_predicates(
         self, conn, peaks, genes, predicate_kind, threshold
     ):
         """Test cross-plan equivalence under random WHERE extras.
@@ -4957,7 +4931,7 @@ class TestTranspileDuckDBIEJoinExecution:
             ]
         ),
     )
-    def test_query_should_match_binned_plan_for_random_group_by_aggregates(
+    def test_query_should_match_naive_predicate_plan_for_random_group_by_aggregates(
         self, conn, peaks, genes, aggregate_kind
     ):
         """Test cross-plan equivalence for GROUP BY + random aggregate.
@@ -5050,7 +5024,7 @@ class TestTranspileDuckDBIEJoinExecution:
         # exercised against both plans.
         limit=st.integers(min_value=0, max_value=10),
     )
-    def test_query_should_match_binned_plan_for_full_composite_query(
+    def test_query_should_match_naive_predicate_plan_for_full_composite_query(
         self, conn, peaks, genes, score_threshold, having_min, limit
     ):
         """Test cross-plan equivalence under the full Tier 1 composition.
@@ -5146,8 +5120,8 @@ class TestTranspileDuckDBIEJoinExecution:
         # Assert
         assert plain_rows == using_rows
 
-    def test_query_should_match_binned_plan_for_mixed_case_aliases(self, conn):
-        """Test that mixed-case aliases under the dialect match the binned plan.
+    def test_query_should_match_naive_predicate_plan_for_mixed_case_aliases(self, conn):
+        """Test that mixed-case aliases under the dialect match the naive-predicate plan.
 
         Given:
             The shared peaks_genes fixture loaded onto ``conn`` and a
@@ -5190,7 +5164,9 @@ class TestTranspileDuckDBIEJoinExecution:
         # Assert
         assert rows_default == rows_duckdb
 
-    def test_query_should_preserve_rows_from_left_only_chromosomes_when_join_is_anti(self, conn):
+    def test_query_should_preserve_rows_from_left_only_chromosomes_when_join_is_anti(
+        self, conn
+    ):
         """Test that ANTI JOIN preserves left-only chromosomes (C1b regression).
 
         Given:
@@ -5332,16 +5308,16 @@ class TestTranspileDuckDBIEJoinExecution:
             max_size=6,
         ),
     )
-    def test_query_should_match_binned_plan_for_semi_join_random_inputs(
+    def test_query_should_match_naive_predicate_plan_for_semi_join_random_inputs(
         self, conn, peaks, genes
     ):
-        """Test that SEMI JOIN under the dialect matches the binned plan.
+        """Test that SEMI JOIN under the dialect matches the naive-predicate plan.
 
         Given:
             A Hypothesis-generated pair of small interval lists.
         When:
             The same SEMI JOIN INTERSECTS query is transpiled with
-            ``dialect=None`` (binned) and ``dialect='duckdb'`` and
+            ``dialect=None`` (naive predicate) and ``dialect='duckdb'`` and
             executed.
         Then:
             Both plans should return the same multiset of distinct
@@ -5448,26 +5424,84 @@ class TestTranspileDuckDBIEJoinExecution:
         # Assert
         assert sql_rows == expected
 
-    # NOTE: a `test_query_should_match_binned_plan_for_anti_join_random_inputs`
-    # would also be desirable, but the binned plan currently returns the
-    # WRONG result for ANTI JOIN when the right table is empty (it drops
-    # all left rows, where ANTI semantics demands that every left row
-    # passes). The dialect IS correct for that case — covered by
-    # ``test_query_should_preserve_rows_from_left_only_chromosomes_when_join_is_anti`` and
-    # ``test_query_should_match_python_native_anti_overlap_for_random_inputs``
-    # — so cross-plan parity for ANTI is not a useful contract until the
-    # binned plan's ANTI handling is fixed in a follow-up.
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+    )
+    def test_query_should_match_naive_predicate_plan_for_anti_join_random_inputs(
+        self, conn, peaks, genes
+    ):
+        """Test that ANTI JOIN under the dialect matches the naive-predicate plan.
+
+        Given:
+            A Hypothesis-generated pair of small interval lists.
+        When:
+            The same ANTI JOIN INTERSECTS query is transpiled with
+            ``dialect=None`` (naive predicate) and ``dialect='duckdb'``
+            and executed.
+        Then:
+            Both plans should return the same multiset of distinct left
+            rows, including left rows on chromosomes absent from the
+            right table and every left row when the right table is empty
+            (standard ``ANTI JOIN ... ON <predicate>`` semantics).
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length) for (c, s, length) in peaks]
+        gene_rows = [(c, s, s + length) for (c, s, length) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if peak_rows:
+            conn.executemany("INSERT INTO peaks VALUES (?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if gene_rows:
+            conn.executemany("INSERT INTO genes VALUES (?, ?, ?)", gene_rows)
+        query = (
+            "SELECT a.chrom, a.start, a.end "
+            "FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = sorted(set(conn.execute(sql_default).fetchall()))
+        rows_duckdb = sorted(set(conn.execute(sql_duckdb).fetchall()))
+
+        # Assert
+        assert rows_default == rows_duckdb
 
 
 class TestTranspileDuckDBIEJoinKwargs:
-    """Tests for the ``dialect`` / ``intersects_bin_size`` kwarg surface.
+    """Tests for the ``dialect`` kwarg surface.
 
-    Covers the ``@overload`` pair on :func:`giql.transpile.transpile`, the
-    mutual-exclusivity validation between ``dialect`` and
-    ``intersects_bin_size``, the unknown-dialect error, and one
-    behavioral regression — running ``intersects_bin_size`` with
-    ``dialect`` omitted — that verifies adding the dialect kwarg did not
-    perturb the binned plan.
+    Covers the ``@overload`` set on :func:`giql.transpile.transpile`, the
+    ``dialect=None``-equals-omitted equivalence, and the unknown-dialect error.
     """
 
     def test_transpile_should_match_default_when_dialect_none_is_explicit(self):
@@ -5495,38 +5529,6 @@ class TestTranspileDuckDBIEJoinKwargs:
         # Assert
         assert sql_omitted == sql_explicit_none
 
-    def test_transpile_should_accept_intersects_bin_size_when_dialect_is_omitted(
-        self, conn
-    ):
-        """Test that ``intersects_bin_size`` works when ``dialect`` is omitted.
-
-        Given:
-            A column-to-column INTERSECTS JOIN.
-        When:
-            ``transpile`` is called with ``intersects_bin_size=50000`` and
-            no ``dialect`` and the resulting SQL is executed.
-        Then:
-            It should return the correct overlapping rows.
-        """
-        # Arrange
-        _make_table(conn, "peaks", [("chr1", 100, 200, "p", 0, "+")])
-        _make_table(conn, "genes", [("chr1", 150, 250, "g", 0, "+")])
-        sql = transpile(
-            """
-            SELECT a.chrom AS a_chrom, a.start AS a_start, b.start AS b_start
-            FROM peaks a
-            JOIN genes b ON a.interval INTERSECTS b.interval
-            """,
-            tables=["peaks", "genes"],
-            intersects_bin_size=50000,
-        )
-
-        # Act
-        rows = sorted(conn.execute(sql).fetchall())
-
-        # Assert
-        assert rows == [("chr1", 100, 150)]
-
     def test_transpile_should_echo_offending_value_in_unknown_dialect_error(self):
         """Test that the unknown-dialect error names the offending value.
 
@@ -5547,34 +5549,3 @@ class TestTranspileDuckDBIEJoinKwargs:
         message = str(excinfo.value)
         assert "Unknown dialect" in message
         assert "'postgres'" in message
-
-    def test_transpile_should_mention_both_kwargs_in_mutex_error_message(self):
-        """Test that the mutex error names both ``intersects_bin_size`` and ``duckdb``.
-
-        Given:
-            ``dialect='duckdb'`` together with a non-None
-            ``intersects_bin_size``.
-        When:
-            ``transpile`` is called.
-        Then:
-            It should raise ``ValueError`` whose message mentions both
-            ``intersects_bin_size`` and ``duckdb``.
-        """
-        # Arrange
-        query = """
-            SELECT a.chrom, a.start, b.start
-            FROM peaks a
-            JOIN genes b ON a.interval INTERSECTS b.interval
-            """
-
-        # Act & assert
-        with pytest.raises(ValueError) as excinfo:
-            transpile(
-                query,
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-                intersects_bin_size=50000,
-            )
-        message = str(excinfo.value)
-        assert "intersects_bin_size" in message
-        assert "duckdb" in message

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -390,7 +390,7 @@ class _PluginTarget(Target):
         supports_lateral=True,
         supports_star_replace=False,
         supports_qualify=False,
-        range_join_strategy="binned",
+        range_join_strategy="naive",
     )
 
 
@@ -1179,7 +1179,7 @@ class _FakeTarget(Target):
         supports_lateral=True,
         supports_star_replace=False,
         supports_qualify=False,
-        range_join_strategy="binned",
+        range_join_strategy="naive",
     )
 
 

--- a/tests/test_intersects_join.py
+++ b/tests/test_intersects_join.py
@@ -1,8 +1,6 @@
-"""Tests for the INTERSECTS binned equi-join transpilation."""
+"""Tests for the INTERSECTS naive overlap predicate join transpilation."""
 
 import math
-
-import pytest
 
 from giql import Table
 from giql import transpile
@@ -18,15 +16,16 @@ def _is_null(value) -> bool:
         return False
 
 
-class TestTranspileBinnedJoin:
-    """Unit tests for binned join SQL structure."""
+class TestTranspileIntersectsJoin:
+    """Unit tests for the naive overlap predicate SQL structure."""
 
-    def test_basic_binned_join_rewrite(self):
+    def test_inner_join_emits_naive_overlap_predicate(self):
         """
         GIVEN a GIQL query joining two tables with column-to-column INTERSECTS
         WHEN transpiling with default settings
-        THEN should produce CTEs with UNNEST/range, equi-join and overlap in ON,
-             and DISTINCT
+        THEN the INTERSECTS expands in place to the naive overlap predicate
+             (chrom equality plus half-open start/end comparisons) with no
+             CTEs, no UNNEST, no bin columns, and no added DISTINCT
         """
         sql = transpile(
             """
@@ -37,49 +36,25 @@ class TestTranspileBinnedJoin:
             tables=["peaks", "genes"],
         )
 
-        sql_upper = sql.upper()
+        # Naive overlap predicate: chrom equality and half-open comparisons
+        assert '"chrom" = ' in sql
+        assert '"start" <' in sql
+        assert '"end" >' in sql
 
-        # CTEs with UNNEST and range
-        assert "WITH" in sql_upper
-        assert "UNNEST" in sql_upper
-        assert "range" in sql or "RANGE" in sql_upper
-        assert "__giql_bin" in sql
+        # No CTE rewrite machinery
+        assert "WITH" not in sql.upper()
+        assert "UNNEST" not in sql.upper()
+        assert "__giql_bin" not in sql
+        assert "__giql_pairs" not in sql
 
-        # Equi-join on chrom and bin
-        assert '"chrom"' in sql
-        assert "__giql_bin" in sql
-
-        # Overlap filter in ON (not WHERE) for correct outer-join semantics
-        assert "ON" in sql_upper
-        assert '"start"' in sql or '"START"' in sql_upper
-        assert '"end"' in sql or '"END"' in sql_upper
-
-        # DISTINCT to deduplicate across bins
-        assert "DISTINCT" in sql_upper
-
-    def test_custom_bin_size(self):
-        """
-        GIVEN a GIQL query with column-to-column INTERSECTS join
-        WHEN transpiling with intersects_bin_size=100000
-        THEN should use 100000 in the range expressions
-        """
-        sql = transpile(
-            """
-            SELECT a.*, b.*
-            FROM peaks a
-            JOIN genes b ON a.interval INTERSECTS b.interval
-            """,
-            tables=["peaks", "genes"],
-            intersects_bin_size=100000,
-        )
-
-        assert "100000" in sql
+        # No DISTINCT added by the transpiler
+        assert "DISTINCT" not in sql.upper()
 
     def test_custom_column_mappings(self):
         """
         GIVEN two tables with different custom column schemas
-        WHEN transpiling a binned join query
-        THEN should use each table's custom column names in CTEs, ON, and WHERE
+        WHEN transpiling an INTERSECTS join query
+        THEN should use each table's custom column names in the overlap predicate
         """
         sql = transpile(
             """
@@ -120,17 +95,18 @@ class TestTranspileBinnedJoin:
         assert '"start"' not in sql
         assert '"end"' not in sql
 
-    def test_literal_intersects_no_binned_ctes(self):
+    def test_literal_intersects_no_ctes(self):
         """
         GIVEN a GIQL query with a literal-range INTERSECTS in WHERE (not a join)
         WHEN transpiling
-        THEN should NOT produce binned CTEs
+        THEN should NOT produce any CTEs
         """
         sql = transpile(
             "SELECT * FROM peaks WHERE interval INTERSECTS 'chr1:1000-2000'",
             tables=["peaks"],
         )
 
+        assert "WITH" not in sql.upper()
         assert "__giql_bin" not in sql
         assert "UNNEST" not in sql.upper()
 
@@ -138,7 +114,7 @@ class TestTranspileBinnedJoin:
         """
         GIVEN a simple SELECT query with no JOIN
         WHEN transpiling
-        THEN should NOT produce binned CTEs
+        THEN should NOT produce any CTEs or helper columns
         """
         sql = transpile(
             "SELECT * FROM peaks",
@@ -152,8 +128,9 @@ class TestTranspileBinnedJoin:
     def test_existing_where_preserved(self):
         """
         GIVEN a GIQL join query that already has a WHERE clause
-        WHEN transpiling a binned join
-        THEN should preserve the original WHERE condition alongside the overlap filter
+        WHEN transpiling an INTERSECTS join
+        THEN should preserve the original WHERE condition alongside the overlap
+             predicate in the ON clause
         """
         sql = transpile(
             """
@@ -171,45 +148,16 @@ class TestTranspileBinnedJoin:
         assert "100" in sql
         assert "score" in sql.lower()
 
-        # Overlap filter also present
+        # Overlap predicate also present
         assert "WHERE" in sql_upper
-        # Both conditions combined with AND
         assert "AND" in sql_upper
 
-    def test_bin_size_none_defaults_to_10000(self):
-        """
-        GIVEN a GIQL join query
-        WHEN transpiling with intersects_bin_size=None (explicit)
-        THEN should produce the same output as default (10000)
-        """
-        sql_default = transpile(
-            """
-            SELECT a.*, b.*
-            FROM peaks a
-            JOIN genes b ON a.interval INTERSECTS b.interval
-            """,
-            tables=["peaks", "genes"],
-        )
-
-        sql_none = transpile(
-            """
-            SELECT a.*, b.*
-            FROM peaks a
-            JOIN genes b ON a.interval INTERSECTS b.interval
-            """,
-            tables=["peaks", "genes"],
-            intersects_bin_size=None,
-        )
-
-        assert sql_default == sql_none
-        assert "10000" in sql_default
-
-    def test_implicit_cross_join_uses_binned_optimization(self):
+    def test_implicit_cross_join_emits_naive_predicate(self):
         """
         GIVEN a GIQL query with implicit cross-join (FROM a, b WHERE INTERSECTS)
         WHEN transpiling
-        THEN should use the binned equi-join optimization without leaking
-             __giql_bin into SELECT * output columns
+        THEN the INTERSECTS expands in place to the naive overlap predicate in
+             WHERE, with no CTEs and no bin columns leaking into SELECT *
         """
         sql = transpile(
             """
@@ -220,23 +168,26 @@ class TestTranspileBinnedJoin:
             tables=["peaks", "genes"],
         )
 
-        # Binned CTEs are present
-        assert "WITH" in sql.upper()
-        assert "__giql_bin" in sql
-        assert "UNNEST" in sql.upper()
+        # Naive overlap predicate present
+        assert '"chrom" = ' in sql
+        assert '"start" <' in sql
+        assert '"end" >' in sql
 
-        # Original table references preserved — no CTE leak into SELECT *
+        # No CTE rewrite machinery
+        assert "WITH" not in sql.upper()
+        assert "UNNEST" not in sql.upper()
+        assert "__giql_bin" not in sql
+        assert "__giql_pairs" not in sql
+
+        # Original table references preserved
         assert "peaks" in sql
-        assert '"chrom"' in sql
-        assert '"start"' in sql
-        assert '"end"' in sql
 
-    def test_self_join_single_shared_cte(self):
+    def test_self_join_emits_naive_predicate(self):
         """
         GIVEN a self-join query where the same table appears with two aliases
-        WHEN transpiling a binned join
-        THEN should produce one shared key-only CTE for the underlying table,
-             joined twice through distinct connector aliases
+        WHEN transpiling an INTERSECTS join
+        THEN the INTERSECTS expands in place to the naive overlap predicate with
+             no CTEs, keeping the original table in FROM
         """
         sql = transpile(
             """
@@ -247,43 +198,28 @@ class TestTranspileBinnedJoin:
             tables=["peaks"],
         )
 
-        sql_upper = sql.upper()
+        # Naive overlap predicate present
+        assert '"chrom" = ' in sql
+        assert '"start" <' in sql
+        assert '"end" >' in sql
 
-        # One shared CTE keyed on the table name
-        assert "__giql_peaks_bins" in sql
+        # No CTE rewrite machinery
+        assert "WITH" not in sql.upper()
+        assert "UNNEST" not in sql.upper()
+        assert "__giql_bin" not in sql
 
         # Original table preserved in FROM
         assert "peaks" in sql
 
-        # Should still have DISTINCT
-        assert "DISTINCT" in sql_upper
+        # No DISTINCT added by the transpiler
+        assert "DISTINCT" not in sql.upper()
 
-    def test_invalid_bin_size_raises(self):
-        """
-        GIVEN intersects_bin_size=0 or a negative value
-        WHEN calling transpile
-        THEN should raise ValueError
-        """
-        with pytest.raises(ValueError, match="positive"):
-            transpile(
-                "SELECT * FROM a JOIN b ON a.interval INTERSECTS b.interval",
-                tables=["a", "b"],
-                intersects_bin_size=0,
-            )
-
-        with pytest.raises(ValueError, match="positive"):
-            transpile(
-                "SELECT * FROM a JOIN b ON a.interval INTERSECTS b.interval",
-                tables=["a", "b"],
-                intersects_bin_size=-1,
-            )
-
-    def test_multi_join_all_intersects_rewritten(self):
+    def test_multi_join_expands_each_intersects(self):
         """
         GIVEN a three-way join with two INTERSECTS conditions
         WHEN transpiling
-        THEN should create one key-only CTE per underlying table and rewrite
-             each INTERSECTS join as a three-join bridge through those CTEs
+        THEN each INTERSECTS expands in place to its own naive overlap predicate,
+             with no CTEs
         """
         sql = transpile(
             """
@@ -295,20 +231,22 @@ class TestTranspileBinnedJoin:
             tables=["peaks", "genes", "exons"],
         )
 
-        # One CTE per underlying table
-        assert "__giql_peaks_bins" in sql
-        assert "__giql_genes_bins" in sql
-        assert "__giql_exons_bins" in sql
+        # Both INTERSECTS rendered as naive overlap predicates
+        assert sql.count('"chrom" = ') == 2
+        assert sql.count('"start" <') == 2
+        assert sql.count('"end" >') == 2
 
-        # __giql_bin appears in CTE definitions and ON conditions
-        sql_upper = sql.upper()
-        assert sql_upper.count("__GIQL_BIN") >= 4  # at least 2 per INTERSECTS join
+        # No CTE rewrite machinery
+        assert "WITH" not in sql.upper()
+        assert "UNNEST" not in sql.upper()
+        assert "__giql_bin" not in sql
 
-    def test_explicit_columns_uses_pairs_cte(self):
+    def test_explicit_columns_emit_naive_predicate(self):
         """
         GIVEN a join query with only explicit columns in SELECT
         WHEN transpiling
-        THEN should use pairs-CTE approach with key-only bin CTEs
+        THEN the INTERSECTS expands in place to the naive overlap predicate with
+             no CTEs
         """
         sql = transpile(
             """
@@ -319,32 +257,20 @@ class TestTranspileBinnedJoin:
             tables=["peaks", "genes"],
         )
 
-        assert "__giql_peaks_bins" in sql
-        assert "__giql_genes_bins" in sql
-        assert "__giql_pairs_0" in sql
+        # Naive overlap predicate present
+        assert '"chrom" = ' in sql
+        assert '"start" <' in sql
+        assert '"end" >' in sql
 
-    def test_wildcard_select_uses_pairs_cte(self):
-        """
-        GIVEN a join query with wildcard expressions in SELECT
-        WHEN transpiling
-        THEN should use pairs-CTE approach, no __giql_bin in output
-        """
-        sql = transpile(
-            """
-            SELECT a.*, b.*
-            FROM peaks a
-            JOIN genes b ON a.interval INTERSECTS b.interval
-            """,
-            tables=["peaks", "genes"],
-        )
-
-        assert "__giql_peaks_bins" in sql
-        assert "__giql_genes_bins" in sql
-        assert "__giql_pairs_0" in sql
+        # No CTE rewrite machinery
+        assert "WITH" not in sql.upper()
+        assert "UNNEST" not in sql.upper()
+        assert "__giql_bin" not in sql
+        assert "__giql_pairs" not in sql
 
 
-class TestBinnedJoinDataFusion:
-    """End-to-end DataFusion correctness tests for binned INTERSECTS joins."""
+class TestIntersectsJoinDataFusion:
+    """End-to-end DataFusion correctness tests for INTERSECTS joins."""
 
     @staticmethod
     def _make_ctx(peaks_data, genes_data):
@@ -384,7 +310,7 @@ class TestBinnedJoinDataFusion:
     def test_overlapping_intervals_correct_rows_no_duplicates(self):
         """
         GIVEN two tables with overlapping intervals
-        WHEN executing a binned INTERSECTS join via DataFusion
+        WHEN executing an INTERSECTS join via DataFusion
         THEN should return the correct matching rows with no duplicates
         """
         ctx = self._make_ctx(
@@ -414,7 +340,7 @@ class TestBinnedJoinDataFusion:
     def test_non_overlapping_intervals_zero_rows(self):
         """
         GIVEN two tables with no overlapping intervals
-        WHEN executing a binned INTERSECTS join via DataFusion
+        WHEN executing an INTERSECTS join via DataFusion
         THEN should return zero rows
         """
         ctx = self._make_ctx(
@@ -440,7 +366,7 @@ class TestBinnedJoinDataFusion:
     def test_adjacent_intervals_zero_rows_half_open(self):
         """
         GIVEN two tables with adjacent (touching) intervals under half-open coordinates
-        WHEN executing a binned INTERSECTS join via DataFusion
+        WHEN executing an INTERSECTS join via DataFusion
         THEN should return zero rows because [100, 200) and [200, 300) do not overlap
         """
         ctx = self._make_ctx(
@@ -465,8 +391,9 @@ class TestBinnedJoinDataFusion:
 
     def test_different_chromosomes_only_same_chrom(self):
         """
-        GIVEN two tables with intervals on different chromosomes that would overlap positionally
-        WHEN executing a binned INTERSECTS join via DataFusion
+        GIVEN two tables with intervals on different chromosomes that would
+              overlap positionally
+        WHEN executing an INTERSECTS join via DataFusion
         THEN should only return overlaps on the same chromosome
         """
         ctx = self._make_ctx(
@@ -493,11 +420,11 @@ class TestBinnedJoinDataFusion:
         assert df.iloc[0]["chrom"] == "chr1"
         assert df.iloc[0]["b_chrom"] == "chr1"
 
-    def test_intervals_spanning_multiple_bins_no_duplicates(self):
+    def test_large_span_overlap_returned_once(self):
         """
-        GIVEN intervals that span multiple bins
-        WHEN executing a binned INTERSECTS join via DataFusion
-        THEN overlapping pairs should be returned exactly once (DISTINCT dedup)
+        GIVEN two large intervals that overlap over a wide span
+        WHEN executing an INTERSECTS join via DataFusion
+        THEN the overlapping pair should be returned exactly once
         """
         ctx = self._make_ctx(
             peaks_data=[("chr1", 0, 50000)],
@@ -514,12 +441,11 @@ class TestBinnedJoinDataFusion:
                 Table("peaks", chrom_col="chrom", start_col="start", end_col="end"),
                 Table("genes", chrom_col="chrom", start_col="start", end_col="end"),
             ],
-            intersects_bin_size=10000,
         )
 
         df = ctx.sql(sql).to_pandas()
 
-        # Despite sharing multiple bins (2, 3, 4), should appear exactly once
+        # The single overlapping pair should appear exactly once
         assert len(df) == 1
         assert df.iloc[0]["start"] == 0
         assert df.iloc[0]["end"] == 50000
@@ -529,7 +455,7 @@ class TestBinnedJoinDataFusion:
     def test_equivalence_with_naive_cross_join(self):
         """
         GIVEN two tables with a mix of overlapping and non-overlapping intervals
-        WHEN executing a binned INTERSECTS join via DataFusion
+        WHEN executing an INTERSECTS join via DataFusion
         THEN results should match a naive cross-join with overlap filter
         """
         ctx = self._make_ctx(
@@ -558,7 +484,7 @@ class TestBinnedJoinDataFusion:
         """
         naive_df = ctx.sql(naive_sql).to_pandas()
 
-        binned_sql = transpile(
+        intersects_sql = transpile(
             """
             SELECT a.chrom AS a_chrom, a.start AS a_start, a."end" AS a_end,
                    b.chrom AS b_chrom, b.start AS b_start, b."end" AS b_end
@@ -570,22 +496,24 @@ class TestBinnedJoinDataFusion:
                 Table("genes", chrom_col="chrom", start_col="start", end_col="end"),
             ],
         )
-        binned_df = (
-            ctx.sql(binned_sql)
+        intersects_df = (
+            ctx.sql(intersects_sql)
             .to_pandas()
             .sort_values(by=["a_chrom", "a_start", "b_start"])
             .reset_index(drop=True)
         )
         naive_df = naive_df.reset_index(drop=True)
 
-        assert len(binned_df) == len(naive_df)
-        assert binned_df.values.tolist() == naive_df.values.tolist()
+        assert len(intersects_df) == len(naive_df)
+        assert intersects_df.values.tolist() == naive_df.values.tolist()
 
-    def test_implicit_cross_join_correct_rows_no_bin_leak(self):
+    def test_implicit_cross_join_correct_rows_no_column_leak(self):
         """
-        GIVEN two tables with overlapping intervals queried via implicit cross-join syntax
-        WHEN executing a binned INTERSECTS join via DataFusion
-        THEN results should be correct and SELECT a.* should not include __giql_bin
+        GIVEN two tables with overlapping intervals queried via implicit
+              cross-join syntax
+        WHEN executing an INTERSECTS join via DataFusion
+        THEN results should be correct and SELECT a.* should return only the
+             original table columns
         """
         ctx = self._make_ctx(
             peaks_data=[("chr1", 100, 500), ("chr1", 1000, 2000)],
@@ -610,16 +538,16 @@ class TestBinnedJoinDataFusion:
         assert len(df) == 1
         assert df.iloc[0]["start"] == 100
 
-        # SELECT a.* must return exactly the original table columns — no __giql_bin
+        # SELECT a.* must return exactly the original table columns
         assert list(df.columns) == ["chrom", "start", "end"]
 
 
-class TestBinnedJoinOuterJoinSemantics:
-    """Regression tests: outer join kinds must be preserved after rewrite.
+class TestIntersectsJoinOuterJoinSemantics:
+    """Outer join kinds must be preserved when INTERSECTS expands in place.
 
-    Bug: the bridge path only applied the join kind (LEFT, RIGHT, FULL) to
-    join3, while join1 and join2 were always INNER — silently converting
-    outer joins into inner joins.
+    The naive overlap predicate is emitted directly in the ON clause, so
+    LEFT, RIGHT, and FULL OUTER joins keep their outer semantics and return
+    unmatched rows with NULLs on the opposite side.
     """
 
     @staticmethod
@@ -664,10 +592,10 @@ class TestBinnedJoinOuterJoinSemantics:
         )
         return ctx
 
-    def test_left_join_preserves_unmatched_left_rows_full_cte(self):
+    def test_left_join_preserves_unmatched_left_rows_explicit_cols(self):
         """
         GIVEN peaks with one matching and one non-matching interval
-        WHEN a LEFT JOIN with INTERSECTS is transpiled (no wildcards, full-CTE path)
+        WHEN a LEFT JOIN with INTERSECTS is transpiled (explicit columns)
         THEN the SQL must contain LEFT keyword and execution must return all
              left rows including unmatched ones with NULLs on the right
         """
@@ -697,10 +625,10 @@ class TestBinnedJoinOuterJoinSemantics:
         assert df.iloc[1]["start"] == 1000
         assert _is_null(df.iloc[1]["b_start"])
 
-    def test_left_join_preserves_unmatched_left_rows_bridge(self):
+    def test_left_join_preserves_unmatched_left_rows_wildcard(self):
         """
         GIVEN peaks with one matching and one non-matching interval
-        WHEN a LEFT JOIN with INTERSECTS is transpiled (wildcards, bridge path)
+        WHEN a LEFT JOIN with INTERSECTS is transpiled (wildcard SELECT)
         THEN the SQL must contain LEFT keyword and execution must return all
              left rows including unmatched ones with NULLs on the right
         """
@@ -730,10 +658,10 @@ class TestBinnedJoinOuterJoinSemantics:
         assert df.iloc[1]["start"] == 1000
         assert _is_null(df.iloc[1]["b_start"])
 
-    def test_right_join_preserves_unmatched_right_rows_full_cte(self):
+    def test_right_join_preserves_unmatched_right_rows_explicit_cols(self):
         """
         GIVEN genes with one matching and one non-matching interval
-        WHEN a RIGHT JOIN with INTERSECTS is transpiled (no wildcards, full-CTE path)
+        WHEN a RIGHT JOIN with INTERSECTS is transpiled (explicit columns)
         THEN the SQL must contain RIGHT keyword and execution must return all
              right rows including unmatched ones with NULLs on the left
         """
@@ -765,10 +693,10 @@ class TestBinnedJoinOuterJoinSemantics:
         assert len(unmatched) == 1
         assert unmatched.iloc[0]["start"] == 5000
 
-    def test_right_join_preserves_unmatched_right_rows_bridge(self):
+    def test_right_join_preserves_unmatched_right_rows_wildcard(self):
         """
         GIVEN genes with one matching and one non-matching interval
-        WHEN a RIGHT JOIN with INTERSECTS is transpiled (wildcards, bridge path)
+        WHEN a RIGHT JOIN with INTERSECTS is transpiled (wildcard SELECT)
         THEN the SQL must contain RIGHT keyword and execution must return all
              right rows including unmatched ones with NULLs on the left
         """
@@ -800,10 +728,10 @@ class TestBinnedJoinOuterJoinSemantics:
         assert len(unmatched) == 1
         assert unmatched.iloc[0]["start"] == 5000
 
-    def test_full_outer_join_preserves_both_unmatched_full_cte(self):
+    def test_full_outer_join_preserves_both_unmatched_explicit_cols(self):
         """
         GIVEN peaks and genes each with one matching and one non-matching interval
-        WHEN a FULL OUTER JOIN with INTERSECTS is transpiled (no wildcards, full-CTE)
+        WHEN a FULL OUTER JOIN with INTERSECTS is transpiled (explicit columns)
         THEN the SQL must contain FULL keyword and execution must return three
              rows: one matched pair plus one unmatched from each side
         """
@@ -836,10 +764,10 @@ class TestBinnedJoinOuterJoinSemantics:
         assert len(left_only) == 1
         assert len(right_only) == 1
 
-    def test_full_outer_join_preserves_both_unmatched_bridge(self):
+    def test_full_outer_join_preserves_both_unmatched_wildcard(self):
         """
         GIVEN peaks and genes each with one matching and one non-matching interval
-        WHEN a FULL OUTER JOIN with INTERSECTS is transpiled (wildcards, bridge path)
+        WHEN a FULL OUTER JOIN with INTERSECTS is transpiled (wildcard SELECT)
         THEN the SQL must contain FULL keyword and execution must return three
              rows: one matched pair plus one unmatched from each side
         """
@@ -899,17 +827,17 @@ class TestBinnedJoinOuterJoinSemantics:
         assert df["b_start"].isna().all()
 
 
-class TestBinnedJoinAdditionalOnConditions:
-    """Regression tests: non-INTERSECTS conditions in ON must be preserved.
+class TestIntersectsJoinAdditionalOnConditions:
+    """Non-INTERSECTS conditions in ON must be preserved.
 
-    Bug: the rewrite replaces the entire ON clause with the binned equi-join
-    and overlap predicate, silently dropping any additional user conditions
-    like ``AND a.score > b.score``.
+    INTERSECTS expands in place within the ON clause, so any additional user
+    conditions like ``AND a.score > b.score`` remain alongside the naive
+    overlap predicate and continue to filter results.
     """
 
     @staticmethod
     def _make_ctx_with_score():
-        """Create a DataFusion context with peaks and genes tables that include a score column."""
+        """Create a DataFusion context with peaks and genes tables including a score."""
         import pyarrow as pa
         from datafusion import SessionContext
 
@@ -952,7 +880,7 @@ class TestBinnedJoinAdditionalOnConditions:
         )
         return ctx
 
-    def test_additional_on_condition_preserved_full_cte(self):
+    def test_additional_on_condition_preserved_explicit_cols(self):
         """
         GIVEN two overlapping intervals where only one pair satisfies score filter
         WHEN INTERSECTS is combined with a.score > b.score in ON (no wildcards)
@@ -978,7 +906,7 @@ class TestBinnedJoinAdditionalOnConditions:
         assert len(df) == 1
         assert df.iloc[0]["a_score"] == 50
 
-    def test_additional_on_condition_preserved_bridge(self):
+    def test_additional_on_condition_preserved_wildcard(self):
         """
         GIVEN two overlapping intervals where only one pair satisfies score filter
         WHEN INTERSECTS is combined with a.score > b.score in ON (wildcards)
@@ -1085,12 +1013,12 @@ class TestBinnedJoinAdditionalOnConditions:
         assert df.iloc[0]["a_score"] == 50
 
 
-class TestBinnedJoinDistinctSemantics:
-    """Tests that the pairs-CTE approach preserves standard SQL bag semantics.
+class TestIntersectsJoinBagSemantics:
+    """The naive overlap predicate preserves standard SQL bag semantics.
 
-    The pairs CTE deduplicates on key columns internally, so the output
-    query does not need SELECT DISTINCT.  This preserves legitimately
-    duplicated source rows.
+    INTERSECTS expands in place without adding SELECT DISTINCT, so the join
+    behaves like an ordinary range join and legitimately duplicated source
+    rows are preserved in the output.
     """
 
     @staticmethod
@@ -1135,7 +1063,7 @@ class TestBinnedJoinDistinctSemantics:
         )
         return ctx
 
-    def test_duplicate_rows_preserved_full_cte(self):
+    def test_duplicate_rows_preserved_explicit_cols(self):
         """
         GIVEN peaks with two identical rows that both overlap one gene
         WHEN an inner join with INTERSECTS is transpiled (no wildcards)
@@ -1151,7 +1079,7 @@ class TestBinnedJoinDistinctSemantics:
         naive_df = ctx.sql(naive_sql).to_pandas()
         assert len(naive_df) == 2
 
-        binned_sql = transpile(
+        intersects_sql = transpile(
             """
             SELECT a.chrom, a.start, a."end", b.start AS b_start
             FROM peaks a
@@ -1163,10 +1091,10 @@ class TestBinnedJoinDistinctSemantics:
             ],
         )
 
-        binned_df = ctx.sql(binned_sql).to_pandas()
-        assert len(binned_df) == len(naive_df)
+        intersects_df = ctx.sql(intersects_sql).to_pandas()
+        assert len(intersects_df) == len(naive_df)
 
-    def test_duplicate_rows_preserved_bridge(self):
+    def test_duplicate_rows_preserved_wildcard(self):
         """
         GIVEN peaks with two identical rows that both overlap one gene
         WHEN an inner join with INTERSECTS is transpiled (wildcards)
@@ -1182,7 +1110,7 @@ class TestBinnedJoinDistinctSemantics:
         naive_df = ctx.sql(naive_sql).to_pandas()
         assert len(naive_df) == 2
 
-        binned_sql = transpile(
+        intersects_sql = transpile(
             """
             SELECT a.*, b.start AS b_start
             FROM peaks a
@@ -1194,8 +1122,8 @@ class TestBinnedJoinDistinctSemantics:
             ],
         )
 
-        binned_df = ctx.sql(binned_sql).to_pandas()
-        assert len(binned_df) == len(naive_df)
+        intersects_df = ctx.sql(intersects_sql).to_pandas()
+        assert len(intersects_df) == len(naive_df)
 
     def test_non_duplicate_rows_unaffected(self):
         """
@@ -1241,7 +1169,7 @@ class TestBinnedJoinDistinctSemantics:
             ],
         )
 
-        binned_sql = transpile(
+        intersects_sql = transpile(
             """
             SELECT a.chrom, a.start, a."end", b.start AS b_start
             FROM peaks a
@@ -1253,14 +1181,14 @@ class TestBinnedJoinDistinctSemantics:
             ],
         )
 
-        df = ctx.sql(binned_sql).to_pandas()
+        df = ctx.sql(intersects_sql).to_pandas()
         assert len(df) == 2
 
     def test_user_distinct_already_present_still_works(self):
         """
         GIVEN a query that already has SELECT DISTINCT
-        WHEN the binned join rewrite also adds DISTINCT
-        THEN the query must still execute correctly (no double-DISTINCT error)
+        WHEN the INTERSECTS join is transpiled
+        THEN the user's DISTINCT is preserved and the query executes correctly
         """
         import pyarrow as pa
         from datafusion import SessionContext
@@ -1292,7 +1220,7 @@ class TestBinnedJoinDistinctSemantics:
             ],
         )
 
-        binned_sql = transpile(
+        intersects_sql = transpile(
             """
             SELECT DISTINCT a.chrom, a.start, b.start AS b_start
             FROM peaks a
@@ -1304,14 +1232,14 @@ class TestBinnedJoinDistinctSemantics:
             ],
         )
 
-        df = ctx.sql(binned_sql).to_pandas()
+        df = ctx.sql(intersects_sql).to_pandas()
         assert len(df) == 1
 
     def test_count_requires_distinguishing_columns(self):
         """
         GIVEN one interval A overlapping three intervals B
         WHEN the SELECT includes columns that distinguish each B match
-        THEN DISTINCT preserves all three matches and COUNT is correct
+        THEN all three matches are preserved and COUNT is correct
         """
         import duckdb
 
@@ -1357,7 +1285,7 @@ class TestBinnedJoinDistinctSemantics:
         )
 
         # Without distinguishing columns: count is still correct
-        # because the pairs-CTE approach does not add SELECT DISTINCT
+        # because the naive overlap predicate does not add SELECT DISTINCT
         inner_sql_no_dist = transpile(
             """
             SELECT r.chrom, r.start, r.end, r.name, f.chrom AS f_chrom
@@ -1378,13 +1306,12 @@ class TestBinnedJoinDistinctSemantics:
         conn.close()
 
 
-class TestBinnedJoinBinBoundaryRounding:
-    """Regression tests for bin-index calculation rounding errors.
+class TestIntersectsJoinPositionBoundaries:
+    """Overlap correctness at exact and near round-number positions.
 
-    The original formula CAST(start / B AS BIGINT) uses float division
-    followed by a cast.  When the division lands on x.5 the cast rounds
-    to nearest-even instead of flooring, producing the wrong bin index
-    and causing missed matches.
+    These cases probe intervals whose start lands exactly on or adjacent to
+    round-number coordinates, confirming the naive overlap predicate finds
+    the overlap without any off-by-one error.
     """
 
     @staticmethod
@@ -1411,12 +1338,12 @@ class TestBinnedJoinBinBoundaryRounding:
         )
         return ctx
 
-    def test_half_bin_boundary_overlap_not_missed(self):
+    def test_overlap_at_position_boundary_found(self):
         """
-        GIVEN interval A spanning many bins and interval B whose start
-              falls exactly on a .5 division boundary (e.g., 621950/100)
-        WHEN INTERSECTS is evaluated with intersects_bin_size=100 on DuckDB
-        THEN the overlap must be found, not missed due to rounding
+        GIVEN a large interval A and interval B whose start falls on a
+              round-number position boundary (621950)
+        WHEN INTERSECTS is evaluated on DuckDB
+        THEN the overlap must be found
         """
         import duckdb
 
@@ -1441,20 +1368,16 @@ class TestBinnedJoinBinBoundaryRounding:
             JOIN intervals_b b ON a.interval INTERSECTS b.interval
             """,
             tables=["intervals_a", "intervals_b"],
-            intersects_bin_size=100,
         )
         result = conn.execute(sql).fetchall()
         conn.close()
-        assert len(result) == 1, (
-            f"Expected 1 match, got {len(result)} — "
-            f"bin boundary rounding likely dropped the overlap"
-        )
+        assert len(result) == 1, f"Expected 1 match, got {len(result)}"
 
-    def test_exact_bin_boundary_start(self):
+    def test_overlap_at_exact_multiple_found(self):
         """
-        GIVEN interval B starting at an exact multiple of bin_size
+        GIVEN interval B starting at an exact round-number position (1000)
         WHEN INTERSECTS is evaluated on DuckDB
-        THEN the correct bin index is assigned (no off-by-one from rounding)
+        THEN the overlap is found with no off-by-one
         """
         import duckdb
 
@@ -1479,20 +1402,18 @@ class TestBinnedJoinBinBoundaryRounding:
             JOIN intervals_b b ON a.interval INTERSECTS b.interval
             """,
             tables=["intervals_a", "intervals_b"],
-            intersects_bin_size=1000,
         )
         result = conn.execute(sql).fetchall()
         conn.close()
-        assert len(result) == 1, f"Expected 1 match at bin boundary, got {len(result)}"
+        assert len(result) == 1, f"Expected 1 match, got {len(result)}"
 
 
-class TestBinnedJoinOuterJoinMultiBin:
-    """Regression tests for outer join with multi-bin intervals.
+class TestIntersectsJoinOuterJoinNoSpuriousRows:
+    """Outer joins must not emit spurious NULL rows for matched intervals.
 
-    When an interval spans multiple bins, the outer join produces one
-    row per bin.  Bins that don't match the other side create spurious
-    NULL rows.  DISTINCT can't collapse a NULL row with a matched row
-    because they differ in the non-NULL columns.
+    Because INTERSECTS expands to a single naive overlap predicate in the ON
+    clause, an interval that overlaps produces exactly one matched row and no
+    extra NULL-filled row appears on the outer side.
     """
 
     @staticmethod
@@ -1521,10 +1442,10 @@ class TestBinnedJoinOuterJoinMultiBin:
 
     def test_left_join_no_spurious_null_row(self):
         """
-        GIVEN interval A spanning bins 0 and 1 and interval B only in bin 1
+        GIVEN a large interval A overlapping a single interval B
         WHEN LEFT JOIN INTERSECTS is evaluated
         THEN only 1 matched row is returned, not a matched row plus a
-             spurious NULL row from the unmatched bin-0 copy
+             spurious NULL row
         """
         ctx = self._make_ctx(
             {
@@ -1551,8 +1472,7 @@ class TestBinnedJoinOuterJoinMultiBin:
         )
         result = ctx.sql(sql).to_pandas()
         assert len(result) == 1, (
-            f"Expected 1 matched row, got {len(result)} — "
-            f"spurious NULL row from unmatched bin"
+            f"Expected 1 matched row, got {len(result)} — spurious NULL row"
         )
         assert result.iloc[0]["b_name"] == "b0"
 
@@ -1591,10 +1511,10 @@ class TestBinnedJoinOuterJoinMultiBin:
 
     def test_right_join_no_spurious_null_row(self):
         """
-        GIVEN interval B spanning bins 0 and 1 and interval A only in bin 0
+        GIVEN a large interval B overlapping a single interval A
         WHEN RIGHT JOIN INTERSECTS is evaluated
         THEN only 1 matched row is returned, not a matched row plus a
-             spurious NULL row from the unmatched bin-1 copy of B
+             spurious NULL row
         """
         ctx = self._make_ctx(
             {
@@ -1621,14 +1541,13 @@ class TestBinnedJoinOuterJoinMultiBin:
         )
         result = ctx.sql(sql).to_pandas()
         assert len(result) == 1, (
-            f"Expected 1 matched row, got {len(result)} — "
-            f"spurious NULL row from unmatched bin"
+            f"Expected 1 matched row, got {len(result)} — spurious NULL row"
         )
         assert result.iloc[0]["name"] == "a0"
 
     def test_full_outer_join_no_spurious_null_row(self):
         """
-        GIVEN interval A spanning bins 0 and 1, interval B only in bin 1
+        GIVEN a large interval A overlapping a single interval B
         WHEN FULL OUTER JOIN INTERSECTS is evaluated
         THEN only 1 matched row is returned, not a matched row plus a
              spurious NULL row
@@ -1658,6 +1577,5 @@ class TestBinnedJoinOuterJoinMultiBin:
         )
         result = ctx.sql(sql).to_pandas()
         assert len(result) == 1, (
-            f"Expected 1 matched row, got {len(result)} — "
-            f"spurious NULL row from unmatched bin"
+            f"Expected 1 matched row, got {len(result)} — spurious NULL row"
         )

--- a/tests/test_package_api.py
+++ b/tests/test_package_api.py
@@ -13,7 +13,7 @@ import pytest
 import giql
 
 #: The extension-hook symbols exported from ``giql.__all__`` (beyond the
-#: pre-existing ``DEFAULT_BIN_SIZE`` / ``Table`` / ``transpile``): #146 added the
+#: pre-existing ``Table`` / ``transpile``): #146 added the
 #: registry/target hooks, #160 added ``StatementFinalizer`` (the query-level seam
 #: type, root-exported so an extension author has a public type to annotate a
 #: finalizer against — the seam has no ``Protocol`` form the way ``expand`` has

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1009,8 +1009,8 @@ class TestResolvePredicateColumns:
         """Test that a column-to-column predicate resolves both operands.
 
         Given:
-            A column-to-column WITHIN joining two aliased tables (a shape the
-            binned-join transformer leaves untouched, so it reaches the pass).
+            A column-to-column WITHIN joining two aliased tables (a shape no
+            pre-pass join rewrite touches, so it reaches the pass).
         When:
             Running the resolve pass.
         Then:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -34,10 +34,11 @@ def _generate_through_passes(sql: str, tables: Tables) -> str:
     expanded output must therefore run all three passes before generating, exactly
     as :func:`giql.transpile.transpile` does, rather than calling ``generate`` on a
     bare parsed AST. Operators still on the legacy emitter (DISJOIN) pass through
-    the expansion pass untouched. This helper is used where the full ``transpile``
-    pipeline would otherwise rewrite the node away (a column-to-column
-    ``INTERSECTS`` is turned into a binned equi-join before the predicate expander
-    runs).
+    the expansion pass untouched. This helper runs the passes in isolation to pin
+    the expanded emitter output on the generic target directly, without the DuckDB
+    IEJoin pre-pass (the only remaining pre-pass join rewrite — a column-to-column
+    ``INTERSECTS`` join otherwise expands to the naive overlap predicate right here
+    in pass 3, since the binned pre-pass rewrite was dropped in #167).
     """
     ast = parse_one(sql, dialect=GIQLDialect)
     ast = resolve_operator_refs(ast, tables)
@@ -151,9 +152,9 @@ class TestGeneratedSQL:
             "WHERE a.interval INTERSECTS b.interval"
         )
 
-        # The full transpile pipeline rewrites a column-to-column INTERSECTS into a
-        # binned equi-join before the predicate emitter runs, so run passes 1 and 2
-        # directly to exercise the predicate emitter's column-join branch.
+        # A column-to-column INTERSECTS join expands to the naive overlap predicate
+        # in pass 3; run passes 1-3 directly to pin the predicate expander's
+        # column-join branch in isolation.
         output = _generate_through_passes(sql, tables_with_two_tables)
 
         expected = (
@@ -1272,10 +1273,10 @@ class TestGeneratedSQL:
         )
 
         # Act — column-join operand canonicalization now lives in the
-        # CanonicalizeCoordinates pass (#123). The full transpile pipeline rewrites
-        # a column-to-column INTERSECTS into a binned equi-join before the
-        # predicate emitter runs, so run passes 1 and 2 directly to exercise the
-        # predicate emitter's column-join branch on canonicalized metadata.
+        # CanonicalizeCoordinates pass (#123). A column-to-column INTERSECTS join
+        # expands to the naive overlap predicate in pass 3; run passes 1-3 directly
+        # to pin the predicate expander's column-join branch on canonicalized
+        # metadata.
         output = _generate_through_passes(sql, tables_mixed_conventions)
 
         # Assert
@@ -1309,7 +1310,7 @@ class TestGeneratedSQL:
 
         # Act — column-join operand canonicalization now lives in the
         # CanonicalizeCoordinates pass (#123); transpile runs it. (Column-to-column
-        # CONTAINS is not rewritten into a binned join, so it reaches the emitter.)
+        # CONTAINS expands to a predicate in pass 3, so it reaches the emitter.)
         output = transpile(sql, tables=list(tables_mixed_conventions))
 
         # Assert
@@ -1343,7 +1344,7 @@ class TestGeneratedSQL:
 
         # Act — column-join operand canonicalization now lives in the
         # CanonicalizeCoordinates pass (#123); transpile runs it. (Column-to-column
-        # WITHIN is not rewritten into a binned join, so it reaches the emitter.)
+        # WITHIN expands to a predicate in pass 3, so it reaches the emitter.)
         output = transpile(sql, tables=list(tables_mixed_conventions))
 
         # Assert

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -40,14 +40,14 @@ class TestCapabilities:
             supports_lateral=True,
             supports_star_replace=False,
             supports_qualify=True,
-            range_join_strategy="binned",
+            range_join_strategy="naive",
         )
 
         # Assert
         assert caps.supports_lateral is True
         assert caps.supports_star_replace is False
         assert caps.supports_qualify is True
-        assert caps.range_join_strategy == "binned"
+        assert caps.range_join_strategy == "naive"
 
     def test___eq___with_identical_values(self):
         """Test value equality of Capabilities.
@@ -97,7 +97,7 @@ class TestCapabilities:
             supports_lateral=True,
             supports_star_replace=True,
             supports_qualify=True,
-            range_join_strategy="binned",
+            range_join_strategy="naive",
         )
 
         # Act & assert
@@ -118,7 +118,7 @@ class TestCapabilities:
             supports_lateral=True,
             supports_star_replace=False,
             supports_qualify=False,
-            range_join_strategy="binned",
+            range_join_strategy="naive",
         )
 
         # Act & assert
@@ -138,7 +138,7 @@ class TestGenericTarget:
             An instance is constructed.
         Then:
             It should carry the portable SQL-92 baseline: no engine dialect,
-            lateral supported, no star-REPLACE, no QUALIFY, binned joins.
+            lateral supported, no star-REPLACE, no QUALIFY, naive-predicate joins.
         """
         # Act
         target = GenericTarget()
@@ -149,7 +149,7 @@ class TestGenericTarget:
         assert target.capabilities.supports_lateral is True
         assert target.capabilities.supports_star_replace is False
         assert target.capabilities.supports_qualify is False
-        assert target.capabilities.range_join_strategy == "binned"
+        assert target.capabilities.range_join_strategy == "naive"
 
 
 class TestDuckDBTarget:
@@ -191,7 +191,7 @@ class TestDataFusionTarget:
         Then:
             It should fall back to generic serialization (no sqlglot
             DataFusion dialect), disable star-REPLACE and QUALIFY, and use
-            the binned join strategy.
+            the naive-predicate join strategy.
         """
         # Act
         target = DataFusionTarget()
@@ -202,7 +202,7 @@ class TestDataFusionTarget:
         assert target.capabilities.supports_lateral is False
         assert target.capabilities.supports_star_replace is False
         assert target.capabilities.supports_qualify is False
-        assert target.capabilities.range_join_strategy == "binned"
+        assert target.capabilities.range_join_strategy == "naive"
 
 
 class TestTarget:
@@ -367,7 +367,7 @@ class _PostgresTarget(Target):
         supports_lateral=True,
         supports_star_replace=False,
         supports_qualify=True,
-        range_join_strategy="binned",
+        range_join_strategy="naive",
     )
 
 
@@ -528,7 +528,7 @@ class TestCustomTargetInjection:
                 supports_lateral=True,
                 supports_star_replace=False,
                 supports_qualify=False,
-                range_join_strategy="binned",
+                range_join_strategy="naive",
             )
 
         REGISTRY.register_target(_ShadowTarget())
@@ -605,7 +605,7 @@ class TestTargetDrivesSerialization:
                 supports_lateral=True,
                 supports_star_replace=False,
                 supports_qualify=False,
-                range_join_strategy="binned",
+                range_join_strategy="naive",
             )
 
         REGISTRY.register_target(_DuckLikeTarget())

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -465,8 +465,7 @@ class TestTranspileDialects:
                 ["peaks"],
             ),
             (
-                "SELECT DISTANCE(a.interval, b.interval) AS d "
-                "FROM peaks a, genes b",
+                "SELECT DISTANCE(a.interval, b.interval) AS d FROM peaks a, genes b",
                 ["peaks", "genes"],
             ),
             ("SELECT * FROM DISJOIN(peaks)", ["peaks"]),
@@ -594,39 +593,6 @@ class TestTranspileDialects:
         # Assert
         assert _strip_nulls(duckdb_sql) == _strip_nulls(generic_sql)
 
-    def test_transpile_datafusion_accepts_intersects_bin_size(self):
-        """Test that datafusion honours the binned-join bin size identically.
-
-        Given:
-            A column-to-column INTERSECTS join with an explicit
-            intersects_bin_size, transpiled with dialect=None and
-            dialect="datafusion".
-        When:
-            Comparing the two outputs.
-        Then:
-            It should produce byte-identical SQL — datafusion takes the same
-            binned-join path and honours the bin size.
-        """
-        # Arrange
-        query = (
-            "SELECT a.chrom, b.chrom FROM peaks a "
-            "JOIN genes b ON a.interval INTERSECTS b.interval"
-        )
-
-        # Act
-        generic_sql = transpile(
-            query, tables=["peaks", "genes"], intersects_bin_size=50000
-        )
-        datafusion_sql = transpile(
-            query,
-            tables=["peaks", "genes"],
-            dialect="datafusion",
-            intersects_bin_size=50000,
-        )
-
-        # Assert
-        assert datafusion_sql == generic_sql
-
     def test_transpile_duckdb_returns_sql_for_column_join(self):
         """Test the duckdb happy path for a column-to-column INTERSECTS join.
 
@@ -650,50 +616,28 @@ class TestTranspileDialects:
         assert "peaks" in sql
         assert "genes" in sql
 
-    def test_transpile_duckdb_rejects_intersects_bin_size(self):
-        """Test that duckdb and intersects_bin_size are mutually exclusive.
+    def test_transpile_rejects_removed_intersects_bin_size(self):
+        """Test that the removed ``intersects_bin_size`` parameter is gone.
 
         Given:
-            dialect="duckdb" combined with an explicit intersects_bin_size.
+            The binned equi-join path and its ``intersects_bin_size`` parameter
+            were removed in #167.
         When:
-            Transpiling.
+            ``transpile`` is called with an ``intersects_bin_size`` keyword.
         Then:
-            It should raise ValueError explaining the IEJoin plan ignores
-            the bin size.
+            It should raise ``TypeError`` for the unexpected keyword argument,
+            and ``DEFAULT_BIN_SIZE`` should no longer be a public export.
         """
         # Act & assert
-        with pytest.raises(
-            ValueError,
-            match=r"intersects_bin_size has no effect.*Pass one or the other, not both\.",
-        ):
+        with pytest.raises(TypeError, match="intersects_bin_size"):
             transpile(
-                "SELECT a.chrom, b.chrom FROM peaks a "
+                "SELECT a.chrom FROM peaks a "
                 "JOIN genes b ON a.interval INTERSECTS b.interval",
                 tables=["peaks", "genes"],
-                dialect="duckdb",
-                intersects_bin_size=50000,  # type: ignore[call-overload]
+                intersects_bin_size=10000,  # type: ignore[call-arg]
             )
-
-    def test_transpile_duckdb_rejects_zero_intersects_bin_size(self):
-        """Test that a falsy-but-set bin size still triggers the duckdb guard.
-
-        Given:
-            dialect="duckdb" combined with intersects_bin_size=0.
-        When:
-            Transpiling.
-        Then:
-            It should raise ValueError — the guard is `is not None`, so 0
-            (falsy) still conflicts with the IEJoin plan.
-        """
-        # Act & assert
-        with pytest.raises(ValueError, match="intersects_bin_size has no effect"):
-            transpile(
-                "SELECT a.chrom, b.chrom FROM peaks a "
-                "JOIN genes b ON a.interval INTERSECTS b.interval",
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-                intersects_bin_size=0,  # type: ignore[call-overload]
-            )
+        assert "DEFAULT_BIN_SIZE" not in giql.__all__
+        assert not hasattr(giql, "DEFAULT_BIN_SIZE")
 
 
 class TestModuleExports:


### PR DESCRIPTION
## Summary

Drops the generic **binned equi-join** for column-to-column `INTERSECTS` joins in favor of the **naive overlap predicate**, and removes the `intersects_bin_size` parameter (and the `DEFAULT_BIN_SIZE` public constant). This continues the operator-expander registry migration (#141/#143/#144): INTERSECTS join strategy is now the lowest-common-denominator plan on the generic and DataFusion targets, delegated to the engine's own range-join optimizer.

A column-to-column `INTERSECTS` join now expands **in place** to `a.chrom = b.chrom AND a.start < b.end AND b.start < a.end` — a plain `ON`/`WHERE` condition — promoting the existing residual `_column_join` expander from a fallback to the sole generic join plan. No CTEs, no `UNNEST` bins, no `DISTINCT` dedup.

**Why the naive predicate is safe (verified before removing binning):**

- **Correct for inner *and* outer joins with no restructuring.** `LEFT/RIGHT/FULL JOIN ... ON <predicate>` gets correct unmatched-row semantics for free — the old binned plan restructured into bin CTEs and could not preserve outer semantics. Verified on real DuckDB and DataFusion (INNER + LEFT), agreeing with a brute-force oracle and with each other.
- **No nested-loop degradation on DataFusion.** The predicate carries an equi-join key (`chrom = chrom`), so DuckDB *and* DataFusion both plan a hash join partitioned on `chrom` with the two position inequalities as a residual join filter — not the pure nested loop of apache/datafusion#8393. The `chrom` key survives coordinate wrapping (chrom is not coordinate-transformed).
- **One universal fallback, more capable than binned.** The DuckDB IEJoin transformer is unchanged and still declines the same shapes (LEFT/RIGHT/FULL #95, self-joins #97, multiple INTERSECTS #96, extra predicates #98, non-base operands #110, 3+ tables #111); those now fall through to the naive predicate — which handles all of them correctly — instead of the binned plan, mooting binned-specific gaps such as #94.
- **Incidentally fixes a latent binned ANTI-join bug.** `dialect=None` ANTI joins over an empty right table dropped all left rows under the binned plan; the naive predicate returns correct results (now covered by a cross-plan parity test).

**Scope / decisions:**

- `intersects_bin_size` is **hard-removed**, not deprecated. At `0.1.0` a deprecation shim would be a no-op parameter pointing at deleted machinery. Passing it now raises `TypeError`. `DEFAULT_BIN_SIZE` is dropped from the package API.
- `range_join_strategy` gains the value `"naive"` (generic / datafusion) alongside `"iejoin"` (duckdb).
- **Out of scope (separate issue):** promoting the DuckDB `IntersectsDuckDBIEJoinTransformer` to a registered `(DuckDBTarget, Intersects)` override — it stays a capability-gated pre-pass transformer here. The SEMI/ANTI *filtering* expander is also out of scope.

Closes #167

## Proposed changes

- **`src/giql/transformer.py`** — delete `IntersectsBinnedJoinTransformer` (~490 lines); retarget the surviving IEJoin transformer's "binned plan" comments and user-facing error messages to the naive-predicate fallback.
- **`src/giql/transpile.py`** — remove `intersects_bin_size` (all overloads, body, mutual-exclusion guards, and the binned fallback call); keep the IEJoin short-circuit and the `has_override` gating.
- **`src/giql/targets.py`** — `range_join_strategy` literal `"binned" -> "naive"`; Generic/DataFusion targets use `"naive"`.
- **`src/giql/constants.py`, `src/giql/__init__.py`** — remove `DEFAULT_BIN_SIZE` (and its `__all__` export).
- **`src/giql/expanders/intersects.py`, `src/giql/resolver.py`, `src/giql/expander.py`** — docstrings: the naive predicate is now the *primary* generic join plan, not a residual.
- **docs** — `performance.rst`, `dialect/spatial-operators.rst`, `transpilation/extending.rst`: document the naive predicate + engine range-join delegation; drop the binned/`intersects_bin_size` sections.

## Test cases

| # | Given | When | Then | Target |
|---|-------|------|------|--------|
| 1 | A column-to-column INTERSECTS INNER join | Transpile (generic / datafusion) | Emits the naive overlap predicate — no CTE / UNNEST / bins / added DISTINCT | `#167` |
| 2 | Overlapping / non-overlapping / adjacent / cross-chromosome intervals | Execute on DuckDB + DataFusion | Correct overlap rows, no duplicates, half-open boundaries respected | `#167` |
| 3 | LEFT / RIGHT / FULL OUTER INTERSECTS join | Execute | All unmatched rows preserved with NULLs on the empty side | `#167` |
| 4 | Extra ON/WHERE predicates, self-joins, multi-table, bag duplicates | Execute | Predicate composes correctly; standard SQL bag semantics preserved | `#167` |
| 5 | Column-to-column INTERSECTS INNER + LEFT join | Cross-target oracle (generic / datafusion / duckdb) | Identical result multiset across all three engines | `#167` |
| 6 | `intersects_bin_size` / `DEFAULT_BIN_SIZE` | Pass the kwarg / import the symbol | `TypeError` / `AttributeError` — both removed | `#167` |
| 7 | ANTI JOIN INTERSECTS (incl. empty right table) | Execute generic vs duckdb | Correct ANTI results, both plans agree (binned drop-all bug gone) | `#167` |
| 8 | `intersects_bin_size` kwarg / `DEFAULT_BIN_SIZE` import | Negative-API contract | `TypeError` / absent from `__all__` — removal stays removed | `#167` |

## Review

Round 1: 9 reviewers under a principal-SWE + Python/SQL (sqlglot) lens, across 9 focuses (binned-removal completeness, transpile control flow, naive-predicate SQL correctness, IEJoin fallback shapes, composition + DataFusion nested-loop risk, public-API breaking change, docs accuracy, test quality/coverage, adversarial). **0 blocking.** The naive predicate was transpiled *and executed* on DuckDB 1.5.4 + DataFusion 54.0.0 across every join shape and all four coordinate encodings, agreeing with brute force and with the removed binned plan byte-for-byte; both engines plan it as a HashJoin keyed on `chrom` (the load-bearing nested-loop risk does not materialize); composition with CTE/MERGE/NEAREST/DISJOIN operands is leak-free. Advisory findings remediated: completed the binned→naive rename across two `expander.py` docstrings and the README default-plan claim, documented the retained `Literal["duckdb"]` overload's autocomplete rationale, singularized an orphaned doc plural, strengthened `test_literal_intersects_no_ctes`, and added the negative-API-contract test (row 8). Independently verified (verify-1: 0 unresolved).

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM
