### PR TITLE
Promote the DuckDB IEJoin INTERSECTS implementation to a registered (DuckDBTarget, Intersects) override expander, and fix SEMI/ANTI WHERE-residual inlining — Closes #169, #200

### DIFF
--- a/docs/transpilation/extending.rst
+++ b/docs/transpilation/extending.rst
@@ -40,10 +40,13 @@ portable emission choices:
 - ``supports_star_replace`` — ``SELECT * REPLACE (...)`` (used for coordinate
   canonicalization and the DISJOIN / NEAREST passthroughs; the portable
   ``SELECT * EXCEPT (...)`` form is emitted otherwise);
-- ``supports_qualify`` — the ``QUALIFY`` clause;
-- ``range_join_strategy`` — ``"naive"`` (emit the naive overlap predicate and let
-  the engine plan the range join) or ``"iejoin"`` (DuckDB's per-chromosome IEJoin
-  pre-pass) for column-to-column INTERSECTS joins.
+- ``supports_qualify`` — the ``QUALIFY`` clause.
+
+The column-to-column INTERSECTS *join* strategy is **not** a capability flag: it is
+selected by the operator-expander registry. Every target emits the naive overlap
+predicate (the ``(GenericTarget, Intersects)`` expander) unless it registers a
+target-specific ``(YourTarget, Intersects)`` override — as DuckDB does for its
+per-chromosome IEJoin plan (:mod:`giql.expanders.intersects_duckdb`).
 
 Define a custom target by subclassing :class:`~giql.targets.Target` as a frozen
 dataclass. Give every field a default so the class is constructible with no
@@ -62,7 +65,6 @@ arguments (the ``@register`` decorator instantiates a target class for you):
            supports_lateral=True,
            supports_star_replace=False,   # -> portable "* EXCEPT" canonicalization
            supports_qualify=True,
-           range_join_strategy="naive",
        )
 
 
@@ -170,9 +172,12 @@ time but fails at engine runtime. The built-in fallback guards this by wrapping
 only when the projection genuinely surfaces the columns it excepts; a custom
 finalizer should apply the same discipline.
 
-The one query-level rewrite that is *not* an expander is a fold that **adds or
-reshapes joins** across relations: the DuckDB IEJoin plan for column-to-column
-INTERSECTS joins stays a capability-gated pre-pass transformer by design.
+A query-level fold that **adds or reshapes joins** across relations uses the same
+finalizer seam. The DuckDB IEJoin plan for column-to-column INTERSECTS joins is
+exactly this: its ``(DuckDBTarget, Intersects)`` override
+(:mod:`giql.expanders.intersects_duckdb`) builds a whole-query per-chromosome
+rewrite and registers a finalizer that replaces the statement root with it, rather
+than replacing a single node in place (#169).
 
 
 Undoing a registration

--- a/src/giql/expander.py
+++ b/src/giql/expander.py
@@ -179,8 +179,9 @@ class ExpansionContext:
         it is an :class:`~sqlglot.expressions.Expression`, it is **not**
         semantically re-validated — so it must not reference columns or relations
         absent from the projection it rewrites: a wrapper over an absent column
-        builds without error but fails at engine runtime. Finalizers registered on a standalone context (one built
-        outside the pass) are collected but never applied.
+        builds without error but fails at engine runtime. Finalizers registered on
+        a standalone context (one built outside the pass) are collected but never
+        applied.
         """
         self._finalizers.append(finalizer)
 
@@ -213,9 +214,10 @@ class OperatorExpander(Protocol):
     for example to project internal helper columns away from a surfacing
     ``SELECT *`` — the expander registers a query-level :data:`StatementFinalizer`
     via :meth:`ExpansionContext.add_statement_finalizer`, applied to the statement
-    after every node-local replacement. The INTERSECTS IEJoin whole-query fold is a
-    separate concern still handled by the pre-pass join transformers, not by an
-    expander.
+    after every node-local replacement. The DuckDB INTERSECTS IEJoin whole-query
+    fold uses exactly this seam: its ``(DuckDBTarget, Intersects)`` expander
+    (:mod:`giql.expanders.intersects_duckdb`, #169) registers a finalizer that
+    replaces the statement root with the per-chromosome dynamic-SQL rewrite.
     """
 
     def expand(self, node: exp.Expression, ctx: ExpansionContext) -> exp.Expression: ...
@@ -322,14 +324,14 @@ class ExpanderRegistry:
         against it — a user overriding one operator need not also declare the
         target separately.
 
-        A *non-generic* ``(target, operator)`` entry additionally acts as a
-        *join-rewrite override* (:meth:`has_override`) for operators with a
-        built-in whole-query join rewrite (notably
-        :class:`~giql.expressions.Intersects`, whose DuckDB IEJoin transformer
-        runs before expansion), letting a per-target expander assume
-        responsibility for that rewrite — :func:`giql.transpile.transpile`
-        consults :meth:`has_override` and bypasses the built-in transformer when
-        it holds.
+        A later registration for the same ``(target, operator)`` key replaces the
+        earlier one (last-write-wins), so a user override of a *built-in*
+        target-specific expander — notably the DuckDB IEJoin
+        ``(DuckDBTarget, Intersects)`` join rewrite
+        (:mod:`giql.expanders.intersects_duckdb`) — simply supersedes it in the
+        registry; the pass then dispatches the operator node to the user's
+        expander instead. (:meth:`has_override` reports whether such an exact
+        non-generic entry exists for introspection.)
         """
         self._expanders[(target, operator)] = _as_callable(expander)
         self.register_target(target)
@@ -376,12 +378,12 @@ class ExpanderRegistry:
         expander is registered; the :class:`ExpandOperators` pass treats that as
         an internal invariant violation and raises (there is no legacy emitter).
 
-        A non-generic exact ``(target, op)`` entry additionally acts as a
-        *join-rewrite override* for operators with a built-in whole-query join
-        rewrite (notably :class:`~giql.expressions.Intersects`); resolution itself
-        does not bypass the built-in IEJoin transformer —
-        :func:`giql.transpile.transpile` does, gated on :meth:`has_override` (see
-        :meth:`register` and #141).
+        Resolution is the single dispatch path for every operator, including the
+        DuckDB IEJoin join rewrite: on ``duckdb`` this returns the built-in
+        ``(DuckDBTarget, Intersects)`` override
+        (:mod:`giql.expanders.intersects_duckdb`), and a user registration for the
+        same key replaces it (last-write-wins) so this returns the user's expander
+        instead (#169). There is no separate pre-pass for INTERSECTS anymore.
         """
         fn = self._expanders.get((target, operator))
         if fn is not None:
@@ -400,13 +402,13 @@ class ExpanderRegistry:
         ``(GenericTarget(), operator)`` fallback is *not* an override and does not
         count here.
 
-        Such an entry marks a target-specific override that supersedes built-in
-        handling (e.g. taking responsibility for the whole-query join rewrite the
-        built-in transformer would otherwise perform).
-        :func:`giql.transpile.transpile` consults this method for
-        ``(target, Intersects)`` and, when it holds, bypasses the built-in
-        IEJoin join transformer so the ``Intersects`` node flows to the
-        registered expander instead (see #141).
+        Such an entry marks a target-specific override that supersedes the
+        ``(GenericTarget, operator)`` fallback — for example the built-in DuckDB
+        IEJoin ``(DuckDBTarget, Intersects)`` join rewrite
+        (:mod:`giql.expanders.intersects_duckdb`), or a plugin's own override of
+        it. This is an introspection helper (the dispatch itself flows through
+        :meth:`resolve`); it is *not* a gate on any pre-pass, since INTERSECTS join
+        strategy is fully registry-driven (#169) with no pre-pass to bypass.
         """
         return target != GenericTarget() and (target, operator) in self._expanders
 
@@ -702,12 +704,12 @@ def _node_depth(node: exp.Expression) -> int:
 
 
 class ExpandOperators:
-    """Callable wrapper for :func:`expand_operators`, parallel to the transformers.
+    """Callable wrapper giving :func:`expand_operators` a uniform pass shape.
 
-    The transpile pipeline composes transformer *objects* bound to their
-    :class:`~giql.table.Tables`; this wrapper gives the expansion pass the same
-    shape — construct it with the active target and tables, then call it on the
-    AST — so it slots into the pipeline uniformly after
+    The transpile pipeline composes each normalization pass as a callable bound
+    to its :class:`~giql.table.Tables`; this wrapper gives the expansion pass the
+    same shape — construct it with the active target and tables, then call it on
+    the AST — so it slots into the pipeline uniformly after
     :class:`giql.canonicalizer.canonicalize_coordinates`.
     """
 

--- a/src/giql/expanders/cluster.py
+++ b/src/giql/expanders/cluster.py
@@ -26,8 +26,9 @@ qualified star projection — emits the outer star as ``* EXCEPT (__giql_is_new_
 to hide the synthesized flag from the output (#184, #185).)
 
 This module is the AST-expansion replacement for the legacy
-:class:`giql.transformer.ClusterTransformer`, which ran as a pre-pass transformer
-on the raw parsed AST. It produces the same SQL; the existing CLUSTER
+``ClusterTransformer``, which ran as a pre-pass transformer on the raw parsed AST
+(in the former ``giql.transformer`` module, removed once every join rewrite became
+registry-driven — #144, #169). It produces the same SQL; the existing CLUSTER
 transpilation and bedtools oracle tests are the migration oracle.
 
 Unlike the node-local expanders for DISTANCE / NEAREST / DISJOIN — whose result

--- a/src/giql/expanders/intersects.py
+++ b/src/giql/expanders/intersects.py
@@ -13,18 +13,22 @@ replaces it in place. For a column-to-column INTERSECTS *join* this in-place
 expansion IS the join plan on every target but DuckDB: the boolean overlap
 predicate is a plain ``ON`` condition the engine plans as a range join (a hash join
 keyed on ``chrom`` with the position inequalities as a residual filter), correct for
-both inner and outer joins. The one whole-query pre-pass rewrite that survives is
-the DuckDB IEJoin transformer in :mod:`giql.transformer`, gated on
-``capabilities.range_join_strategy == "iejoin"``; it consumes a column-to-column
-INTERSECTS *join* before this pass runs for the shapes it supports, and every shape
-it declines falls through to this expander's naive predicate. (The generic binned
-equi-join was dropped in favor of the naive predicate — #167.) A literal-range or
-residual column-to-column INTERSECTS *predicate* (e.g. inside an ``OR``) reaches the
-expander and is rendered the same way.
+both inner and outer joins. (The generic binned equi-join was dropped in favor of
+this naive predicate — #167.)
 
-Only :class:`~giql.targets.GenericTarget` expanders are registered: spatial-predicate
-*emission* is portable SQL-92 and does not vary by engine, so one generic expander
-covers every target via the registry's ``(generic, op)`` fallback.
+DuckDB overrides the column-to-column *join* case with its per-chromosome IEJoin
+plan, registered as the ``(DuckDBTarget, Intersects)`` expander in
+:mod:`giql.expanders.intersects_duckdb` (#169) — a pass-3 override, not a pre-pass.
+That override reuses this module's :func:`_expand_spatial_op` for every shape it
+declines (LEFT/RIGHT/FULL, self-joins, multiple INTERSECTS, …) and for literal-range
+or residual INTERSECTS *predicates*, so the naive predicate here is the universal
+fallback on DuckDB too.
+
+The INTERSECTS / CONTAINS / WITHIN / set-predicate expanders are registered only for
+:class:`~giql.targets.GenericTarget`: spatial-predicate *emission* is portable
+SQL-92 and does not vary by engine, so one generic expander covers every target via
+the registry's ``(generic, op)`` fallback (the DuckDB IEJoin override is the sole
+target-specific INTERSECTS entry, and it delegates back here).
 """
 
 from __future__ import annotations
@@ -166,6 +170,23 @@ def _column_join(
     return exp.paren(cond)
 
 
+#: Meta key marking an AST node as the expansion of a GIQL spatial predicate
+#: (INTERSECTS / CONTAINS / WITHIN / ``ANY`` / ``ALL``). The DuckDB IEJoin override
+#: (:mod:`giql.expanders.intersects_duckdb`) reads it to decline its per-chromosome
+#: rewrite when a *sibling* spatial predicate shares the query. Because pass 3 may
+#: expand that sibling to plain comparison SQL before the join ``INTERSECTS`` node
+#: is visited, the override cannot rely on finding an un-expanded GIQL node — the
+#: tag survives expansion so the sibling stays detectable, preserving the former
+#: pre-pass's "decline when a residual spatial predicate is present" invariant (#169).
+SPATIAL_PREDICATE_META = "__giql_spatial_predicate"
+
+
+def _tag_spatial(expr: exp.Expression) -> exp.Expression:
+    """Mark *expr* as a spatial-predicate expansion (:data:`SPATIAL_PREDICATE_META`)."""
+    expr.meta[SPATIAL_PREDICATE_META] = True
+    return expr
+
+
 def _expand_spatial_op(
     node: exp.Expression, ctx: ExpansionContext, op_type: str
 ) -> exp.Expression:
@@ -176,14 +197,16 @@ def _expand_spatial_op(
     ``ctx.resolution.column("expression")``, the slot pass 1 attaches a
     :class:`ResolvedColumn` to when the right operand is a column reference —
     selects the column-to-column path; its absence means the right operand is a
-    literal range, parsed in place.
+    literal range, parsed in place. The result carries the
+    :data:`SPATIAL_PREDICATE_META` tag so a sibling DuckDB IEJoin join override can
+    still recognize this expansion after the fact (#169).
     """
     resolution = ctx.resolution
     right_column = resolution.column("expression") if resolution is not None else None
     left = _predicate_column(ctx, "this")
 
     if right_column is not None:
-        return _column_join(left, right_column, op_type)
+        return _tag_spatial(_column_join(left, right_column, op_type))
 
     # Literal range string (e.g. interval INTERSECTS 'chr1:1000-2000'). Reproduce
     # the legacy emitter's parse-and-wrap-error behavior verbatim: any parse
@@ -194,7 +217,7 @@ def _expand_spatial_op(
     try:
         range_str = raw.strip("'\"")
         parsed = RangeParser.parse(range_str).to_zero_based_half_open()
-        return _range_predicate(left, parsed, op_type)
+        return _tag_spatial(_range_predicate(left, parsed, op_type))
     except Exception as e:
         raise ValueError(f"Could not parse genomic range: {raw}. Error: {e}") from e
 
@@ -244,4 +267,4 @@ def expand_spatial_set(node: exp.Expression, ctx: ExpansionContext) -> exp.Expre
     else:
         combined = exp.and_(*conditions)
 
-    return exp.paren(combined)
+    return _tag_spatial(exp.paren(combined))

--- a/src/giql/expanders/intersects_duckdb.py
+++ b/src/giql/expanders/intersects_duckdb.py
@@ -1,14 +1,27 @@
-"""Query transformers for GIQL operations.
+"""The DuckDB IEJoin column-to-column INTERSECTS join override (epic #137, #169).
 
-This module contains the DuckDB IEJoin pre-pass transformer, which rewrites a
-column-to-column INTERSECTS join into a per-chromosome dynamic-SQL pattern DuckDB
-plans through its range-join family. Every other target — and every shape the
-IEJoin path declines — leaves the INTERSECTS in place for the pass-3
-``(GenericTarget, Intersects)`` expander, which renders the naive overlap
-predicate (a plain ``ON`` condition the engine plans as a range join). The generic
-binned equi-join transformer was dropped in favor of that naive predicate (#167).
-CLUSTER and MERGE were relocated to the operator-expander registry
-(``giql.expanders.cluster`` / ``giql.expanders.merge``) in epic #137 (#144).
+The registered ``(DuckDBTarget, Intersects)`` override expander for DuckDB.
+:class:`IntersectsDuckDBIEJoinTransformer` rewrites a column-to-column INTERSECTS
+*join* into a per-chromosome dynamic-SQL pattern DuckDB plans through its
+range-join family (``IE_JOIN`` / ``PIECEWISE_MERGE_JOIN``);
+:func:`expand_intersects_duckdb` wires it into the operator-expander registry so
+pass 3 (:class:`giql.expander.ExpandOperators`) dispatches DuckDB's ``Intersects``
+nodes here. For the shapes it declines, and for every literal-range or residual
+``Intersects`` predicate, the override defers to the shared naive overlap
+predicate (:func:`giql.expanders.intersects._expand_spatial_op`) that
+``dialect=None`` / ``"datafusion"`` emit on every target — a plain ``ON`` condition
+the engine plans as a range join (#167).
+
+Because the IEJoin rewrite emits a *whole-query* multi-statement string
+(``SET VARIABLE ...; SELECT ... FROM query(getvariable(...))``) rather than a
+node-local expression, :func:`expand_intersects_duckdb` produces it through the
+query-level :meth:`~giql.expander.ExpansionContext.add_statement_finalizer` seam,
+wrapping the built string in an :class:`sqlglot.expressions.Command` so it
+serializes verbatim through the stock per-target serializer. This relocates the
+former capability-gated pre-pass IEJoin transformer into the registry, mirroring
+the CLUSTER / MERGE relocation (#144); INTERSECTS join strategy is now fully
+registry-driven and target-overridable. The generic binned equi-join transformer
+was dropped in favor of the naive predicate earlier (#167).
 """
 
 from dataclasses import dataclass
@@ -23,9 +36,17 @@ from giql.canonical import canonical_start
 from giql.constants import DEFAULT_CHROM_COL
 from giql.constants import DEFAULT_END_COL
 from giql.constants import DEFAULT_START_COL
+from giql.expander import ExpansionContext
+from giql.expander import register
+from giql.expanders.intersects import SPATIAL_PREDICATE_META
+from giql.expanders.intersects import _expand_spatial_op
+from giql.expressions import Contains
 from giql.expressions import Intersects
+from giql.expressions import SpatialSetPredicate
+from giql.expressions import Within
 from giql.table import Table
 from giql.table import Tables
+from giql.targets import DuckDBTarget
 
 
 class _UnqualifiedProjectionError(Exception):
@@ -1204,3 +1225,74 @@ class IntersectsDuckDBIEJoinTransformer:
             inner_projections.append("1 AS __giql_placeholder")
 
         return inner_projections, outer_projections, projection_map
+
+
+def _has_sibling_spatial_predicate(node: Intersects, root: exp.Expression) -> bool:
+    """Return True if *root* holds a spatial predicate other than the join *node*.
+
+    The former pre-pass ran on the raw parsed AST, so a residual GIQL spatial
+    predicate (``CONTAINS`` / ``WITHIN`` / ``ANY`` / ``ALL`` / a second
+    ``INTERSECTS``) sharing the query was always still an un-expanded GIQL node —
+    the transformer detected it and declined its IEJoin rewrite. In pass 3 the
+    ``ExpandOperators`` walk expands nodes deepest-first, so a sibling spatial
+    predicate may already have been rewritten to plain comparison SQL by the time
+    this override runs, which the transformer's ``_classify_extras`` can no longer
+    recognize (it would wrongly inline the residual into a per-chromosome ``ON``,
+    corrupting SEMI/ANTI results — #169). Detect the sibling either way: as an
+    un-expanded GIQL spatial node, or via the :data:`SPATIAL_PREDICATE_META` tag the
+    generic spatial expanders stamp on their output. Either signal means the join
+    must defer to the naive predicate, which composes correctly with any residual.
+    """
+    spatial_types = (Intersects, Contains, Within, SpatialSetPredicate)
+    for candidate in root.walk():
+        if candidate is node:
+            continue
+        if isinstance(candidate, spatial_types):
+            return True
+        if candidate.meta.get(SPATIAL_PREDICATE_META):
+            return True
+    return False
+
+
+@register(DuckDBTarget, Intersects)
+def expand_intersects_duckdb(
+    node: exp.Expression, ctx: ExpansionContext
+) -> exp.Expression:
+    """Expand a DuckDB ``Intersects`` node — IEJoin join rewrite or naive predicate.
+
+    The registered ``(DuckDBTarget, Intersects)`` override. For a column-to-column
+    INTERSECTS *join* whose whole-query shape the IEJoin path supports,
+    :meth:`IntersectsDuckDBIEJoinTransformer.transform_to_sql` builds the
+    per-chromosome ``SET VARIABLE ...; SELECT ... FROM query(getvariable(...))``
+    string; since that is a whole-query multi-statement rewrite, not a node-local
+    expression, this registers a query-level finalizer
+    (:meth:`~giql.expander.ExpansionContext.add_statement_finalizer`) that replaces
+    the statement root with a :class:`~sqlglot.expressions.Command` wrapping the
+    built SQL (which serializes verbatim), and returns the ``Intersects`` node
+    unchanged (mirroring the CLUSTER / MERGE whole-query expanders).
+
+    Every other shape — a join the IEJoin path declines (LEFT/RIGHT/FULL, self-join,
+    multiple INTERSECTS, extra predicates, non-base operands, 3+ tables), a
+    literal-range predicate, or a residual column-to-column predicate — defers to
+    :func:`giql.expanders.intersects._expand_spatial_op`, the same naive overlap
+    predicate the ``(GenericTarget, Intersects)`` expander emits on every target
+    (#167). A query carrying any *sibling* spatial predicate also defers (see
+    :func:`_has_sibling_spatial_predicate`), so the IEJoin never inlines a
+    residual it cannot see. ``transform_to_sql`` then runs on the pass-3 AST, which
+    for the shapes the IEJoin path accepts is structurally identical to the raw
+    parse — those shapes provably carry no other GIQL operator, and pass 1 only
+    attaches resolution metadata while pass 2 synthesizes no CTE for a
+    column-to-column INTERSECTS (its operands are column slots, not reference
+    slots) — so the rewrite reads the same query the former pre-pass did.
+    """
+    if isinstance(node, Intersects) and _is_column_intersects(node):
+        root = node.root()
+        if isinstance(root, exp.Select) and not _has_sibling_spatial_predicate(
+            node, root
+        ):
+            transformer = IntersectsDuckDBIEJoinTransformer(ctx.tables)
+            iejoin_sql = transformer.transform_to_sql(root)
+            if iejoin_sql is not None:
+                ctx.add_statement_finalizer(lambda _root: exp.Command(this=iejoin_sql))
+                return node
+    return _expand_spatial_op(node, ctx, "intersects")

--- a/src/giql/expanders/intersects_duckdb.py
+++ b/src/giql/expanders/intersects_duckdb.py
@@ -437,7 +437,9 @@ class IntersectsDuckDBIEJoinTransformer:
             return None
 
         # Extra predicates are inlined into each per-chromosome subquery's
-        # join ON (see :meth:`_build_sql`). Soft-fallback residuals (subquery,
+        # join ON, except WHERE residuals under a left-only (SEMI / ANTI) join,
+        # which :meth:`_build_sql` applies as an outer wrapper filter (#200).
+        # Soft-fallback residuals (subquery,
         # aggregate, window, or an INTERSECTS still wrapped in OR/NOT/Paren)
         # cause ``_build_sql`` to return None. User-mistake residuals
         # (unqualified or unknown-aliased columns, or columns with a
@@ -648,13 +650,25 @@ class IntersectsDuckDBIEJoinTransformer:
         self,
         query: exp.Select,
         intersects: Intersects,
-    ) -> list[exp.Expression]:
-        """Return the non-INTERSECTS predicate residuals from joins and WHERE.
+    ) -> tuple[list[exp.Expression], list[exp.Expression]]:
+        """Return the non-INTERSECTS residuals split by provenance.
 
         Walks the AND tree under each JOIN ON and the WHERE, strips the
-        target INTERSECTS node, and returns the residual predicates in
-        document order. An empty list means the query has no extras
-        beyond the target INTERSECTS.
+        target INTERSECTS node, and returns ``(on_residuals, where_residuals)``
+        in document order. ``on_residuals`` are the predicates that sat in a
+        ``JOIN ... ON`` alongside the INTERSECTS; ``where_residuals`` are the
+        predicates that sat in the top-level ``WHERE``. Both lists empty means
+        the query has no extras beyond the target INTERSECTS.
+
+        The split matters because the two sources are *not* interchangeable
+        for every join kind. An ON residual is a genuine join condition and is
+        correct to inline into the per-chromosome ON for INNER / SEMI / ANTI
+        alike. A WHERE residual is a post-join filter: inlining it into the ON
+        is only sound for INNER (where ``ON overlap WHERE r`` ≡ ``ON overlap
+        AND r``) and SEMI (a left-only ``r`` is invariant over the right side);
+        for ANTI it inverts the anti-join for rows failing ``r`` (#200). See
+        :meth:`_build_sql`, which routes WHERE residuals to an outer filter for
+        the left-only (SEMI / ANTI) shapes.
 
         Note: :func:`_strip_intersects` only descends ``exp.And``. Predicates
         whose AND tree wraps the INTERSECTS in ``exp.Or`` / ``exp.Not`` /
@@ -663,20 +677,21 @@ class IntersectsDuckDBIEJoinTransformer:
         :meth:`_validate_extra_qualifiers` enforces qualifier rules for the
         remaining inlinable residuals.
         """
-        residuals: list[exp.Expression] = []
+        on_residuals: list[exp.Expression] = []
         for join in query.args.get("joins") or []:
             on = join.args.get("on")
             if on is None:
                 continue
             residual = _strip_intersects(on, intersects)
             if residual is not None:
-                residuals.append(residual)
+                on_residuals.append(residual)
+        where_residuals: list[exp.Expression] = []
         where = query.args.get("where")
         if where:
             residual = _strip_intersects(where.this, intersects)
             if residual is not None:
-                residuals.append(residual)
-        return residuals
+                where_residuals.append(residual)
+        return on_residuals, where_residuals
 
     def _find_target_join(
         self, query: exp.Select
@@ -734,11 +749,27 @@ class IntersectsDuckDBIEJoinTransformer:
         fires; callers translating to the public surface wrap the raise to
         :class:`ValueError`.
         """
-        extras = self._extract_extra_predicates(query, intersects)
-        if extras and self._classify_extras(extras) == "fallback":
+        on_residuals, where_residuals = self._extract_extra_predicates(query, intersects)
+        all_residuals = on_residuals + where_residuals
+        if all_residuals and self._classify_extras(all_residuals) == "fallback":
             return None
-        if extras:
-            self._validate_extra_qualifiers(extras, sides)
+        if all_residuals:
+            self._validate_extra_qualifiers(all_residuals, sides)
+
+        # ON residuals are genuine join conditions and inline into the
+        # per-chromosome ON for every kind. WHERE residuals are post-join
+        # filters: inlining them into the ON is only sound for INNER (and the
+        # equivalent SEMI case), but inverts the anti-join for rows failing the
+        # residual under ANTI (#200). For the left-only shapes (SEMI / ANTI) we
+        # therefore layer WHERE residuals as an outer filter on the wrapper
+        # relation instead of folding them into the join. INNER keeps inlining
+        # them (byte-identical output, provably equivalent).
+        if sides.is_left_only_join:
+            inline_residuals = on_residuals
+            outer_where_residuals = where_residuals
+        else:
+            inline_residuals = on_residuals + where_residuals
+            outer_where_residuals = []
 
         # Tables registry is keyed by the bare table name; an unregistered
         # table uses default column names like the naive-predicate plan does.
@@ -777,6 +808,7 @@ class IntersectsDuckDBIEJoinTransformer:
             r_table,
             (l_chrom, l_start, l_end),
             (r_chrom, r_start, r_end),
+            outer_where_residuals,
         )
 
         # Per-call random token (full uuid4 hex = 128 bits) so the SET
@@ -822,7 +854,7 @@ class IntersectsDuckDBIEJoinTransformer:
             f"{l_start_expr} < {r_end_expr}",
             f"{l_end_expr} > {r_start_expr}",
         ]
-        for residual in extras:
+        for residual in inline_residuals:
             on_clause_predicates.append(
                 self._rewrite_refs_for_per_chrom_subquery(residual, sides)
             )
@@ -895,6 +927,21 @@ class IntersectsDuckDBIEJoinTransformer:
             f"FROM query(getvariable('{var_name}')) AS {wrapper_alias}"
         ]
 
+        # WHERE residuals for the left-only (SEMI / ANTI) shapes are applied
+        # here as a post-join filter on the wrapper relation, rewritten to the
+        # wrapper's inner-alias column names — never folded into the per-chrom
+        # ON, which would invert the anti-join for rows failing the residual
+        # (#200). Every referenced column was pre-allocated into the wrapper's
+        # projection list by :meth:`_resolve_projections`.
+        if outer_where_residuals:
+            where_sql = " AND ".join(
+                self._rewrite_refs_for_wrapper_relation(
+                    residual, projection_map, sides, "WHERE"
+                )
+                for residual in outer_where_residuals
+            )
+            outer_select_parts.append(f"WHERE {where_sql}")
+
         # The rewriter translates any ``a.col`` / ``b.col`` references in
         # the GROUP BY / HAVING / ORDER BY clauses to the wrapper
         # relation's inner-alias column names (``__giql_p<n>``), since
@@ -943,8 +990,16 @@ class IntersectsDuckDBIEJoinTransformer:
         r_table: Table | None,
         l_cols: tuple[str, str, str],
         r_cols: tuple[str, str, str],
+        outer_where_residuals: list[exp.Expression] | None = None,
     ) -> tuple[list[str], list[str], dict[tuple[str, str], str]]:
         """Resolve the SELECT list (and any modifier-referenced columns).
+
+        ``outer_where_residuals`` are the WHERE residuals that :meth:`_build_sql`
+        applies as an outer filter on the wrapper relation (the left-only
+        SEMI / ANTI shapes — #200). Their columns are pre-allocated into
+        ``inner_projections`` here so the wrapper exposes them even when they
+        appear only in the filter and not in the SELECT list. For INNER the
+        list is empty because those residuals inline into the per-chromosome ON.
 
         Returns ``(inner_projections, outer_projections, projection_map)``:
 
@@ -1062,6 +1117,18 @@ class IntersectsDuckDBIEJoinTransformer:
             if modifier_node is None:
                 continue
             for col in modifier_node.find_all(exp.Column):
+                col_table = _normalize_alias(col.table) if col.table else ""
+                if col_table in (l_alias, r_alias):
+                    reject_right_side_if_left_only(col_table, col.sql())
+                    allocate(col_table, col.name)
+
+        # Pre-allocate inner aliases for columns referenced in the WHERE
+        # residuals routed to the outer wrapper filter (SEMI / ANTI, #200), so
+        # the wrapper exposes them even when they appear only in the filter.
+        # A right-side reference is rejected here (the left-only outer SELECT
+        # cannot resolve it), matching the SELECT-list / modifier behavior.
+        for residual in outer_where_residuals or []:
+            for col in residual.find_all(exp.Column):
                 col_table = _normalize_alias(col.table) if col.table else ""
                 if col_table in (l_alias, r_alias):
                     reject_right_side_if_left_only(col_table, col.sql())

--- a/src/giql/expanders/merge.py
+++ b/src/giql/expanders/merge.py
@@ -18,9 +18,10 @@ becomes::
 identifiers, appends ``NULLS LAST``, and the inner ``CLUSTER(...)`` is itself
 expanded into the two-level ``__giql_lag_calc`` form.)
 
-This module is the AST-expansion replacement for the legacy
-:class:`giql.transformer.MergeTransformer`; it produces the same SQL (the existing
-MERGE transpilation and bedtools oracle tests are the migration oracle).
+This module is the AST-expansion replacement for the legacy ``MergeTransformer``
+(in the former ``giql.transformer`` module, removed once every join rewrite became
+registry-driven — #144, #169); it produces the same SQL (the existing MERGE
+transpilation and bedtools oracle tests are the migration oracle).
 
 Like CLUSTER (:mod:`giql.expanders.cluster`), MERGE is a **whole-query rewrite**:
 it navigates to the enclosing :class:`~sqlglot.expressions.Select`, mutates it in

--- a/src/giql/resolver.py
+++ b/src/giql/resolver.py
@@ -1,9 +1,9 @@
 """Pass 1 of the GIQL normalization pipeline: ``ResolveOperatorRefs``.
 
 This module implements the first normalization pass described in epic #114. It
-runs between the transformer chain and the generator and attaches resolution
-metadata to every GIQL operator node so that later epic steps can turn the
-generator into a pure formatter.
+runs ahead of coordinate canonicalization and the operator-expansion pass and
+attaches resolution metadata to every GIQL operator node so the downstream passes
+and the stock serializer can rely on it.
 
 The pass is built on ``sqlglot``'s scope machinery
 (:func:`sqlglot.optimizer.scope.traverse_scope`), which yields scopes
@@ -398,12 +398,13 @@ def resolve_operator_refs(expression: exp.Expression, tables: Tables) -> exp.Exp
     closes with :func:`validate_operator_refs`.
 
     The pass mutates and returns *expression* in place. It is behavior-
-    preserving: the attached metadata is additive and the generator ignores it.
+    preserving: the attached metadata is additive and the stock serializer
+    ignores it.
 
     Parameters
     ----------
     expression : exp.Expression
-        The (post-transformer) AST to annotate.
+        The parsed AST to annotate.
     tables : Tables
         The registered table configurations.
 
@@ -563,14 +564,15 @@ def _resolve_predicate_columns(
       operand resolves through the alias map — matching ``_generate_column_join``,
       which passes ``None`` as the context for both sides.
 
-    A column-to-column ``INTERSECTS`` join reaches here on every target but
-    DuckDB: its operands resolve through this pass so the pass-3
+    A column-to-column ``INTERSECTS`` join reaches here on *every* target,
+    including DuckDB (#169): its operands resolve through this pass so the pass-3
     ``(GenericTarget, Intersects)`` expander can render the naive overlap
-    predicate in place (#167). The DuckDB ``dialect="duckdb"`` IEJoin transformer
-    (:class:`~giql.transformer.IntersectsDuckDBIEJoinTransformer`) is the one path
-    that consumes such a join before this pass runs, deleting the ``Intersects``
-    node — but only for the shapes it accepts; the shapes it declines fall through
-    to this pass too. Column-to-column ``CONTAINS`` / ``WITHIN`` and non-join
+    predicate in place (#167). The DuckDB ``(DuckDBTarget, Intersects)`` IEJoin
+    override (:mod:`giql.expanders.intersects_duckdb`) also runs in pass 3, after
+    this one; it rebuilds the join from the raw AST + table configs (ignoring this
+    resolution metadata), so the resolution here is a harmless no-op for the shapes
+    it rewrites and the load-bearing input for the shapes it declines to the naive
+    predicate. Column-to-column ``CONTAINS`` / ``WITHIN`` and non-join
     ``INTERSECTS`` shapes always reach the emitter, so the column-join branch is
     exercised on every target.
 

--- a/src/giql/targets.py
+++ b/src/giql/targets.py
@@ -8,17 +8,16 @@ This is step 1 of epic #137. The targets and capability descriptors defined
 here are the foundation that later steps build on — the operator-expander
 registry is keyed by ``(target, operator)`` and emission choices are
 capability lookups rather than scattered ``if dialect == ...`` branches.
-As of #143/#145 the model actively drives emission: the INTERSECTS join
-strategy (``range_join_strategy``), the NEAREST LATERAL-vs-window form
-(``supports_lateral``), and the coordinate-canonicalization wrapper and
-NEAREST/DISJOIN passthroughs (``supports_star_replace``) all read from the
-active target's capabilities.
+As of #143/#145 the model actively drives emission: the NEAREST LATERAL-vs-window
+form (``supports_lateral``) and the coordinate-canonicalization wrapper and
+NEAREST/DISJOIN passthroughs (``supports_star_replace``) read from the active
+target's capabilities. The INTERSECTS join strategy is instead selected by the
+operator-expander registry (#169): DuckDB registers a ``(DuckDBTarget, Intersects)``
+IEJoin override, and every other target falls back to the generic naive-predicate
+expander — no capability flag is consulted.
 """
 
 from dataclasses import dataclass
-from typing import Literal
-
-RangeJoinStrategy = Literal["naive", "iejoin"]
 
 
 @dataclass(frozen=True)
@@ -48,19 +47,11 @@ class Capabilities:
         Whether the engine supports the ``QUALIFY`` clause. Reserved: no
         emission path consumes it yet (a future window-function operator
         port would).
-    range_join_strategy : RangeJoinStrategy
-        The plan used for column-to-column INTERSECTS joins: ``"naive"``
-        emits the naive overlap predicate (a plain ``ON`` condition the engine
-        plans as a range join) via the ``(GenericTarget, Intersects)`` pass-3
-        expander; ``"iejoin"`` selects DuckDB's per-partition IEJoin pre-pass
-        plan. The IEJoin path covers INNER / SEMI / ANTI joins and falls back to
-        the naive predicate for the shapes it declines (#167).
     """
 
     supports_lateral: bool
     supports_star_replace: bool
     supports_qualify: bool
-    range_join_strategy: RangeJoinStrategy
 
 
 @dataclass(frozen=True)
@@ -111,7 +102,6 @@ class GenericTarget(Target):
         supports_lateral=True,
         supports_star_replace=False,
         supports_qualify=False,
-        range_join_strategy="naive",
     )
 
 
@@ -120,7 +110,9 @@ class DuckDBTarget(Target):
     """DuckDB target.
 
     Serializes through sqlglot's ``duckdb`` dialect and uses the IEJoin
-    per-partition plan for column-to-column INTERSECTS joins.
+    per-partition plan for column-to-column INTERSECTS joins, registered as the
+    ``(DuckDBTarget, Intersects)`` override in the operator-expander registry
+    (:mod:`giql.expanders.intersects_duckdb`, #169).
 
     Serializing through the ``duckdb`` dialect makes null ordering **explicit** on
     ``ORDER BY`` / window terms, emitting ``NULLS FIRST`` where the generic
@@ -138,7 +130,6 @@ class DuckDBTarget(Target):
         supports_lateral=True,
         supports_star_replace=True,
         supports_qualify=True,
-        range_join_strategy="iejoin",
     )
 
 
@@ -159,10 +150,11 @@ class DataFusionTarget(Target):
     so NEAREST takes the decorrelated window fallback), ``supports_star_replace=
     False`` (DataFusion supports ``* EXCEPT`` / ``* EXCLUDE`` but not
     ``* REPLACE``, so the canonicalizer and the NEAREST/DISJOIN passthroughs emit
-    the portable ``* EXCEPT`` form), ``supports_qualify=False``, and the naive
-    overlap-predicate range strategy (the column-to-column INTERSECTS join stays a
-    plain ``ON`` condition DataFusion plans as a hash join keyed on ``chrom`` with
-    the position inequalities as a residual join filter — #167).
+    the portable ``* EXCEPT`` form), and ``supports_qualify=False``. DataFusion
+    registers no INTERSECTS override, so a column-to-column INTERSECTS join falls
+    back to the generic naive overlap predicate — a plain ``ON`` condition
+    DataFusion plans as a hash join keyed on ``chrom`` with the position
+    inequalities as a residual join filter (#167).
 
     A ``SELECT *`` / ``SELECT b.*`` over a correlated NEAREST would otherwise expose
     the decorrelated fallback's reserved ``__giql_x_*`` rank/key columns; a statement
@@ -183,7 +175,6 @@ class DataFusionTarget(Target):
         supports_lateral=False,
         supports_star_replace=False,
         supports_qualify=False,
-        range_join_strategy="naive",
     )
 
 

--- a/src/giql/transpile.py
+++ b/src/giql/transpile.py
@@ -14,14 +14,11 @@ from sqlglot import parse_one
 import giql.expanders  # noqa: F401
 from giql.canonicalizer import canonicalize_coordinates
 from giql.dialect import GIQLDialect
-from giql.expander import REGISTRY
 from giql.expander import ExpandOperators
-from giql.expressions import Intersects
 from giql.resolver import resolve_operator_refs
 from giql.table import Table
 from giql.table import Tables
 from giql.targets import resolve_target
-from giql.transformer import IntersectsDuckDBIEJoinTransformer
 
 
 @overload
@@ -163,57 +160,25 @@ def transpile(
         )
     """
     target = resolve_target(dialect)
-    uses_iejoin = target.capabilities.range_join_strategy == "iejoin"
-
-    # The INTERSECTS join-rewrite override.
-    #
-    # A *target-specific* ``(target, Intersects)`` registry entry — the public
-    # extension hook, matched by ``ExpanderRegistry.has_override`` — takes over the
-    # INTERSECTS join rewrite entirely. ``has_override`` deliberately matches only
-    # an *exact non-generic* entry: the built-in ``(GenericTarget(), Intersects)``
-    # predicate expander is NOT a join-strategy override — it renders the naive
-    # overlap predicate that IS the generic join plan, so it must not disable the
-    # IEJoin short-circuit. When an override is present, the DuckDB IEJoin
-    # short-circuit below is skipped (the registry-deferral the IEJoin early-return
-    # used to preclude, #141) so the INTERSECTS node flows untouched into
-    # ExpandOperators, which dispatches it to that expander.
-    target_overrides_intersects = REGISTRY.has_override(target, Intersects)
 
     tables_container = _build_tables(tables)
 
     with _reraise_as_value_error("Parse error", query=giql):
         ast = parse_one(giql, dialect=GIQLDialect)
 
-    # The DuckDB IEJoin plan is the one remaining capability-gated pre-pass
-    # transformer (epic #137, #141): ``range_join_strategy == "iejoin"`` selects
-    # it. It runs on the raw parsed AST (before resolution, which rewrites the
-    # genomic column name) and consumes a column-to-column INTERSECTS *join* so it
-    # never reaches the predicate expander. Every other target — and every shape
-    # the IEJoin path declines — leaves the column-to-column INTERSECTS in place
-    # for pass 3, where the ``(GenericTarget, Intersects)`` expander renders it as
-    # the naive overlap predicate (a plain ``ON`` condition the engine plans as a
-    # range join). Literal-range and residual INTERSECTS predicates flow the same
-    # way. ``target_overrides_intersects`` (computed above) gates whether the
-    # IEJoin path runs — see its definition for the override rationale.
-    #
-    # The IEJoin transformer emits a whole-query string, so when it produces output
-    # it must short-circuit the AST pipeline. This never skips an INTERSECTS that
-    # pass 3 would expand: ``_classify_extras`` declines (returning None here) for
-    # any query carrying a residual INTERSECTS alongside the join, so a query the
-    # IEJoin transformer accepts has no residual INTERSECTS left for the expander.
-    # (A residual CONTAINS/WITHIN/ANY beside an IEJoin is a pre-existing IEJoin
-    # limitation that errors identically on main.)
-    #
-    # CLUSTER and MERGE used to be rewritten as pre-pass transformers too; they are
-    # now expanded in pass 3 (ExpandOperators) by giql.expanders.cluster / .merge
-    # (#144), and the generic binned equi-join was dropped in favor of the naive
-    # predicate (#167).
-    if uses_iejoin and not target_overrides_intersects:
-        duckdb_transformer = IntersectsDuckDBIEJoinTransformer(tables_container)
-        with _reraise_as_value_error("Transformation error"):
-            duckdb_sql = duckdb_transformer.transform_to_sql(ast)
-        if duckdb_sql is not None:
-            return duckdb_sql
+    # Every INTERSECTS join strategy is now registry-driven (epic #137, #169). A
+    # column-to-column INTERSECTS *join* flows untouched through the pipeline into
+    # pass 3, where ``ExpandOperators`` dispatches it to its registered expander:
+    # the ``(GenericTarget, Intersects)`` expander renders the naive overlap
+    # predicate (a plain ``ON`` condition the engine plans as a range join) on
+    # ``None`` / ``"datafusion"``, and the ``(DuckDBTarget, Intersects)`` override
+    # (giql.expanders.intersects_duckdb) rewrites it into the per-chromosome IEJoin
+    # plan on ``"duckdb"``, deferring to that same naive predicate for the shapes it
+    # declines. Literal-range and residual INTERSECTS predicates flow the same way.
+    # There is no capability-gated pre-pass anymore — the former DuckDB IEJoin
+    # pre-pass (and the CLUSTER / MERGE pre-passes, #144) were all relocated into
+    # the operator-expander registry, and the generic binned equi-join was dropped
+    # in favor of the naive predicate (#167).
 
     # Pass 1 of the normalization pipeline (epic #114): attach resolution
     # metadata to every GIQL operator slot ahead of generation. Every migrated
@@ -281,9 +246,10 @@ def _build_tables(tables: list[str | Table] | None) -> Tables:
 def _reraise_as_value_error(prefix: str, query: str | None = None) -> Iterator[None]:
     """Re-raise non-:class:`ValueError` exceptions as :class:`ValueError` with *prefix*.
 
-    Lets user-facing :class:`ValueError`\\s from the parser, transformer chain,
-    expander pass, and stock serializer propagate verbatim (so the dialect's
-    targeted error messages survive the boundary) while wrapping unexpected
+    Lets user-facing :class:`ValueError`\\s from the parser, the resolution /
+    canonicalization / operator-expansion passes, and the stock serializer
+    propagate verbatim (so the dialect's targeted error messages survive the
+    boundary) while wrapping unexpected
     exceptions in a uniform
     :class:`ValueError` prefixed with the stage name. When *query* is supplied,
     the original input is appended to the message so parse errors retain the

--- a/tests/test_duckdb_iejoin.py
+++ b/tests/test_duckdb_iejoin.py
@@ -357,6 +357,92 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "SET VARIABLE __giql_iejoin_" in sql
         assert rows == [(300,)]
 
+    def test_transpile_should_apply_anti_join_where_residual_as_outer_wrapper_filter(
+        self,
+    ):
+        """Test that an ANTI-join WHERE residual filters outside the per-chrom join.
+
+        Given:
+            An ``ANTI JOIN ... ON a.interval INTERSECTS b.interval`` whose
+            top-level ``WHERE a.start >= 550`` is a post-join filter.
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            The residual is applied as a ``WHERE`` on the outer wrapper
+            relation, never inlined into the per-chromosome ANTI ``ON`` (which
+            would invert the anti-join for rows failing the residual, #200).
+        """
+        # Arrange & act
+        sql = transpile(
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.start >= 550",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        per_chrom_template, _, outer_select = sql.partition("query(getvariable")
+        assert "SET VARIABLE __giql_iejoin_" in sql
+        assert "ANTI JOIN" in per_chrom_template
+        # The residual predicate sits in the outer wrapper filter, never in the
+        # per-chromosome ANTI ON template that DuckDB expands via string_agg.
+        # Anchor on ``>= 550`` (the rendered comparison) rather than the bare
+        # ``550`` literal: the per-chromosome template embeds the random
+        # ``uuid4`` var-name token, whose hex could coincidentally contain the
+        # substring ``550`` — but never the operator-and-space form.
+        assert "AS __giql_iejoin_wrapper WHERE" in outer_select
+        assert ">= 550" in outer_select
+        assert ">= 550" not in per_chrom_template
+
+    def test_transpile_should_raise_when_anti_join_where_residual_references_right_side(
+        self,
+    ):
+        """Test that an ANTI-join WHERE residual on the right side raises.
+
+        Given:
+            An ``ANTI JOIN`` whose ``WHERE`` references ``b.score`` — a right-
+            side column the left-only outer wrapper filter cannot resolve.
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            A ``ValueError`` is raised rather than the residual being silently
+            inlined or mis-bound.
+        """
+        # Arrange & act & assert
+        with pytest.raises(ValueError, match="only projects left-side columns"):
+            transpile(
+                "SELECT a.start FROM peaks a "
+                "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+                "WHERE b.score > 5",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+
+    def test_transpile_should_raise_when_semi_join_where_residual_references_right_side(
+        self,
+    ):
+        """Test that a SEMI-join WHERE residual on the right side raises.
+
+        Given:
+            A ``SEMI JOIN`` whose ``WHERE`` references ``b.score`` — a right-
+            side column the left-only outer wrapper filter cannot resolve.
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            A ``ValueError`` is raised, mirroring the ANTI case (both are
+            left-only outer projections).
+        """
+        # Arrange & act & assert
+        with pytest.raises(ValueError, match="only projects left-side columns"):
+            transpile(
+                "SELECT a.start FROM peaks a "
+                "SEMI JOIN genes b ON a.interval INTERSECTS b.interval "
+                "WHERE b.score > 5",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+
     def test_transpile_should_route_to_naive_predicate_plan_when_extra_predicate_uses_or(
         self,
     ):
@@ -5567,6 +5653,413 @@ class TestTranspileDuckDBIEJoinExecution:
 
         # Assert
         assert rows_default == rows_duckdb
+
+    def test_query_should_match_naive_plan_for_anti_join_with_where_residual(self, conn):
+        """Test that an ANTI-join WHERE residual filters without inverting the join.
+
+        Given:
+            Three left rows — two overlap a right row (excluded by the
+            anti-join), one does not — and a top-level ``WHERE a.start >= 550``
+            post-join filter.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            ``dialect=None`` and executed.
+        Then:
+            Both plans return only the non-overlapping row that also passes
+            the residual, proving the filter is applied after the anti-join
+            rather than folded into its per-chromosome ON (#200); the buggy
+            inlining would resurrect the two overlapping rows below 550.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),  # overlaps g1; anti-excluded
+                ("chr1", 500, 600, "p2", 2, "+"),  # overlaps g2; anti-excluded
+                ("chr1", 700, 800, "p3", 3, "+"),  # no overlap; passes residual
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 500, 600, "g2", 2, "+"),
+            ],
+        )
+        query = (
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.start >= 550"
+        )
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+        rows_naive = sorted(conn.execute(sql_naive).fetchall())
+
+        # Assert
+        assert rows_duckdb == [(700,)]
+        assert rows_duckdb == rows_naive
+
+    def test_query_should_filter_anti_join_by_where_residual_column_absent_from_select(
+        self, conn
+    ):
+        """Test that an ANTI-join WHERE residual can filter on an unselected column.
+
+        Given:
+            An ``ANTI JOIN`` selecting only ``a.start`` but filtering on
+            ``a.end`` — a column present only in the ``WHERE`` residual.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The wrapper relation still exposes ``a.end`` so the outer filter
+            resolves, and the result matches the naive-predicate plan.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),  # overlaps g1; anti-excluded
+                ("chr1", 700, 800, "p3", 3, "+"),  # no overlap; a.end 800 > 750
+            ],
+        )
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 1, "+")])
+        query = (
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.end > 750"
+        )
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+        rows_naive = sorted(conn.execute(sql_naive).fetchall())
+
+        # Assert
+        assert rows_duckdb == [(700,)]
+        assert rows_duckdb == rows_naive
+
+    def test_query_should_match_naive_plan_for_semi_join_with_where_residual(self, conn):
+        """Test that a SEMI-join WHERE residual filters consistently with the naive plan.
+
+        Given:
+            Two overlapping left rows (kept by the semi-join) and a top-level
+            ``WHERE a.start >= 300`` post-join filter that keeps one of them.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and
+            ``dialect=None`` and executed.
+        Then:
+            Both plans return only the surviving overlapping row. SEMI's
+            result is identical whether the residual is inlined or applied
+            outside, so this locks the new SEMI outer-filter code path
+            against regressions rather than proving a behavior change (#200).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),  # overlaps g1; start < 300
+                ("chr1", 500, 600, "p2", 2, "+"),  # overlaps g2; start >= 300
+                ("chr1", 700, 800, "p3", 3, "+"),  # no overlap; semi-excluded
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 500, 600, "g2", 2, "+"),
+            ],
+        )
+        query = (
+            "SELECT a.start FROM peaks a "
+            "SEMI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.start >= 300"
+        )
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+        rows_naive = sorted(conn.execute(sql_naive).fetchall())
+
+        # Assert
+        assert rows_duckdb == [(500,)]
+        assert rows_duckdb == rows_naive
+
+    @settings(
+        max_examples=25,
+        deadline=None,
+        suppress_health_check=[HealthCheck.function_scoped_fixture],
+    )
+    @given(
+        peaks=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+        genes=st.lists(
+            st.tuples(
+                st.sampled_from(["chr1", "chr2"]),
+                st.integers(min_value=0, max_value=100),
+                st.integers(min_value=1, max_value=30),
+            ),
+            min_size=0,
+            max_size=6,
+        ),
+    )
+    def test_query_should_match_naive_plan_for_anti_join_where_residual_random_inputs(
+        self, conn, peaks, genes
+    ):
+        """Test ANTI JOIN with a WHERE residual against the naive plan over random inputs.
+
+        Given:
+            A Hypothesis-generated pair of small interval lists.
+        When:
+            An ``ANTI JOIN ... ON INTERSECTS ... WHERE a.start >= 50`` is
+            transpiled with ``dialect=None`` and ``dialect='duckdb'`` and
+            executed.
+        Then:
+            Both plans return the same rows for every input — the WHERE
+            filter never resurrects an anti-excluded row on either side of
+            the 50 threshold (#200).
+        """
+        # Arrange
+        peak_rows = [(c, s, s + length) for (c, s, length) in peaks]
+        gene_rows = [(c, s, s + length) for (c, s, length) in genes]
+        conn.execute("DROP TABLE IF EXISTS peaks")
+        conn.execute("DROP TABLE IF EXISTS genes")
+        conn.execute(
+            'CREATE TABLE peaks (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if peak_rows:
+            conn.executemany("INSERT INTO peaks VALUES (?, ?, ?)", peak_rows)
+        conn.execute(
+            'CREATE TABLE genes (chrom VARCHAR, "start" INTEGER, "end" INTEGER)'
+        )
+        if gene_rows:
+            conn.executemany("INSERT INTO genes VALUES (?, ?, ?)", gene_rows)
+        query = (
+            "SELECT a.chrom, a.start, a.end "
+            "FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.start >= 50"
+        )
+        sql_default = transpile(query, tables=["peaks", "genes"])
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Act
+        rows_default = sorted(set(conn.execute(sql_default).fetchall()))
+        rows_duckdb = sorted(set(conn.execute(sql_duckdb).fetchall()))
+
+        # Assert
+        assert rows_default == rows_duckdb
+
+    def test_query_should_inline_anti_join_on_residual_referencing_right_side(
+        self, conn
+    ):
+        """Test that an ANTI-join ON residual on the right side stays inlined.
+
+        Given:
+            An ``ANTI JOIN ... ON a.interval INTERSECTS b.interval AND
+            b.score > 100`` — a genuine join condition referencing the right
+            side, which no gene satisfies.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The residual stays inlined in the per-chromosome ON (it is a join
+            condition, not a post-join filter), so every left row survives the
+            anti-join and the result matches the naive plan. This guards the
+            provenance split from over-correcting the ON path — only WHERE
+            residuals move to the outer filter for the left-only shapes (#200).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),
+                ("chr1", 500, 600, "p2", 2, "+"),
+                ("chr1", 700, 800, "p3", 3, "+"),
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 10, "+"),
+                ("chr1", 500, 600, "g2", 50, "+"),
+            ],
+        )
+        query = (
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "AND b.score > 100"
+        )
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+        rows_naive = sorted(conn.execute(sql_naive).fetchall())
+
+        # Assert
+        assert rows_duckdb == [(100,), (500,), (700,)]
+        assert rows_duckdb == rows_naive
+
+    def test_query_should_match_naive_plan_for_anti_join_with_compound_where_residual(
+        self, conn
+    ):
+        """Test that a compound ANTI-join WHERE residual renders as one outer filter.
+
+        Given:
+            An ``ANTI JOIN`` with a two-clause post-join filter
+            ``WHERE a.start >= 550 AND a.end < 900`` over two columns.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            Both clauses are applied on the outer wrapper relation and the
+            result matches the naive plan (#200).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),  # overlaps g1; anti-excluded
+                ("chr1", 500, 600, "p2", 2, "+"),  # overlaps g2; anti-excluded
+                ("chr1", 700, 800, "p3", 3, "+"),  # no overlap; passes both clauses
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 500, 600, "g2", 2, "+"),
+            ],
+        )
+        query = (
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.start >= 550 AND a.end < 900"
+        )
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+        rows_naive = sorted(conn.execute(sql_naive).fetchall())
+
+        # Assert
+        assert rows_duckdb == [(700,)]
+        assert rows_duckdb == rows_naive
+
+    def test_query_should_group_anti_join_with_where_residual(self, conn):
+        """Test that an ANTI-join WHERE residual composes with GROUP BY on the wrapper.
+
+        Given:
+            An ``ANTI JOIN`` grouping by ``a.chrom`` with a post-join
+            ``WHERE a.start >= 550`` filter — the outer filter and the
+            aggregation both sit on the wrapper relation.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The filter is applied before the aggregation and the grouped
+            counts match the naive plan (#200).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),  # overlaps g1; anti-excluded
+                ("chr1", 500, 600, "p2", 2, "+"),  # overlaps g2; anti-excluded
+                ("chr1", 700, 800, "p3", 3, "+"),  # no overlap; passes filter
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 500, 600, "g2", 2, "+"),
+            ],
+        )
+        query = (
+            "SELECT a.chrom, COUNT(a.start) AS n FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.start >= 550 GROUP BY a.chrom"
+        )
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_duckdb = sorted(conn.execute(sql_duckdb).fetchall())
+        rows_naive = sorted(conn.execute(sql_naive).fetchall())
+
+        # Assert
+        assert rows_duckdb == [("chr1", 1)]
+        assert rows_duckdb == rows_naive
+
+    def test_query_should_order_anti_join_with_where_residual(self, conn):
+        """Test that an ANTI-join WHERE residual composes with ORDER BY on the wrapper.
+
+        Given:
+            An ``ANTI JOIN`` with a post-join ``WHERE a.start >= 550`` filter and
+            an order-sensitive ``ORDER BY a.start DESC`` — both the filter and the
+            sort sit on the wrapper relation.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            The filtered rows come back in the requested descending order,
+            matching the naive plan (rows compared without re-sorting so the
+            order itself is asserted) (#200).
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 100, 200, "p1", 1, "+"),  # overlaps g1; anti-excluded
+                ("chr1", 500, 600, "p2", 2, "+"),  # overlaps g2; anti-excluded
+                ("chr1", 700, 800, "p3", 3, "+"),  # no overlap; passes filter
+                ("chr1", 900, 1000, "p4", 4, "+"),  # no overlap; passes filter
+            ],
+        )
+        _make_table(
+            conn,
+            "genes",
+            [
+                ("chr1", 150, 250, "g1", 1, "+"),
+                ("chr1", 500, 600, "g2", 2, "+"),
+            ],
+        )
+        query = (
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.start >= 550 ORDER BY a.start DESC"
+        )
+        sql_duckdb = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_duckdb = conn.execute(sql_duckdb).fetchall()
+        rows_naive = conn.execute(sql_naive).fetchall()
+
+        # Assert
+        assert rows_duckdb == [(900,), (700,)]
+        assert rows_duckdb == rows_naive
 
 
 class TestTranspileDuckDBIEJoinKwargs:

--- a/tests/test_duckdb_iejoin.py
+++ b/tests/test_duckdb_iejoin.py
@@ -656,6 +656,78 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert rows_dd == rows_default
         assert rows_dd == [(100, 150, 175)]
 
+    def test_query_should_route_to_naive_predicate_plan_and_execute_correctly_when_sibling_contains_present(
+        self, conn
+    ):
+        """Test that a sibling CONTAINS defers an ANTI IEJoin to the naive plan.
+
+        Given:
+            An ANTI JOIN INTERSECTS query whose WHERE carries a sibling CONTAINS
+            predicate, and inputs where inlining that residual into the
+            per-chromosome ANTI ON would invert the anti-join semantics.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and with
+            ``dialect=None`` and both are executed.
+        Then:
+            The DuckDB path should defer to the naive-predicate plan (no IEJoin
+            SET VARIABLE) and return the same rows as the default plan.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [
+                ("chr1", 50, 250, "p1", 0, "+"),
+                ("chr1", 120, 140, "p2", 0, "+"),
+                ("chr1", 350, 500, "p3", 0, "+"),
+                ("chr1", 10, 500, "p4", 0, "+"),
+            ],
+        )
+        _make_table(conn, "genes", [("chr1", 300, 400, "g1", 0, "+")])
+        query = (
+            "SELECT a.start FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.interval CONTAINS 'chr1:100-200'"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_default = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_dd = sorted(conn.execute(sql_dd).fetchall())
+        rows_default = sorted(conn.execute(sql_default).fetchall())
+
+        # Assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert rows_dd == rows_default
+        assert rows_dd == [(50,)]
+
+    def test_transpile_should_route_to_naive_predicate_plan_when_residual_intersects_is_literal(
+        self,
+    ):
+        """Test that a sibling literal INTERSECTS defers the join to the naive plan.
+
+        Given:
+            A column-to-column INTERSECTS join whose WHERE carries a sibling
+            literal-range INTERSECTS predicate.
+        When:
+            The query is transpiled with ``dialect='duckdb'``.
+        Then:
+            It should defer to the naive-predicate plan rather than engaging the
+            IEJoin (which cannot see the residual once pass 3 expands it).
+        """
+        # Arrange
+        query = (
+            "SELECT a.start FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval "
+            "WHERE a.interval INTERSECTS 'chr1:100-200'"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+
     def test_transpile_should_route_self_join_to_fallback_plan_when_dialect_is_duckdb(
         self, conn
     ):

--- a/tests/test_expander.py
+++ b/tests/test_expander.py
@@ -31,6 +31,7 @@ from giql.expander import OperatorExpander
 from giql.expander import RegistrySnapshot
 from giql.expander import expand_operators
 from giql.expander import register
+from giql.expanders.intersects_duckdb import expand_intersects_duckdb
 from giql.expressions import GIQLDisjoin
 from giql.expressions import GIQLMerge
 from giql.expressions import Intersects
@@ -390,7 +391,6 @@ class _PluginTarget(Target):
         supports_lateral=True,
         supports_star_replace=False,
         supports_qualify=False,
-        range_join_strategy="naive",
     )
 
 
@@ -453,7 +453,6 @@ class TestTargetRegistration:
                 supports_lateral=False,
                 supports_star_replace=True,
                 supports_qualify=True,
-                range_join_strategy="iejoin",
             )
 
         first = _PluginTarget()
@@ -1179,7 +1178,6 @@ class _FakeTarget(Target):
         supports_lateral=True,
         supports_star_replace=False,
         supports_qualify=False,
-        range_join_strategy="naive",
     )
 
 
@@ -1781,29 +1779,33 @@ class TestMigratedOperatorsRegistered:
 
 
 class TestIEJoinRegistryDeferral:
-    """The duckdb IEJoin path defers to a target-specific Intersects expander (#141).
+    """A user (DuckDBTarget, Intersects) override replaces the built-in IEJoin (#169).
 
-    Resolves Finding 2: the IEJoin early return used to emit before the
-    ExpandOperators pass, so an operator on an IEJoin-eligible query was never
-    expanded. Now a *target-specific* ``(DuckDBTarget, Intersects)`` registry
-    entry overrides the built-in join strategy entirely (the public extension
-    hook), while the default duckdb path — with no such override — still emits the
-    built-in IEJoin SQL.
+    The DuckDB IEJoin join rewrite is itself a registered
+    ``(DuckDBTarget, Intersects)`` expander (:mod:`giql.expanders.intersects_duckdb`),
+    dispatched by the pass-3 ``ExpandOperators`` pass rather than a capability-gated
+    pre-pass. A user registration for the same key replaces the built-in override
+    (last-write-wins), so the user's expander fires; the default duckdb path, with
+    only the built-in override, emits the IEJoin SET VARIABLE SQL.
     """
 
-    def test_iejoin_query_expands_target_override_expander(self, clean_registry):
-        """Test that a target-specific Intersects override fires on an IEJoin query.
+    def test_iejoin_query_should_expand_user_override_when_it_supersedes_builtin(
+        self, clean_registry
+    ):
+        """Test that a user Intersects override supersedes the built-in on DuckDB.
 
         Given:
-            A column-to-column INTERSECTS join eligible for the duckdb IEJoin
-            path, with a (DuckDBTarget, Intersects) expander registered.
+            A column-to-column INTERSECTS join, with the built-in DuckDB IEJoin
+            override registered first and a user (DuckDBTarget, Intersects)
+            expander registered on top of it (last-write-wins).
         When:
             Transpiling with dialect='duckdb'.
         Then:
-            The override expander's sentinel should appear — the IEJoin path
-            defers to the registry rather than short-circuiting expansion.
+            It should emit the user override's sentinel and not the built-in
+            IEJoin SET VARIABLE SQL.
         """
         # Arrange
+        clean_registry.register(DuckDBTarget(), Intersects, expand_intersects_duckdb)
         clean_registry.register(
             DuckDBTarget(), Intersects, lambda n, c: exp.column("__giql_iejoin_sentinel")
         )
@@ -1819,17 +1821,16 @@ class TestIEJoinRegistryDeferral:
         assert "__giql_iejoin_sentinel" in sql
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_iejoin_query_emits_builtin_iejoin_without_override(self):
+    def test_iejoin_query_should_emit_builtin_iejoin_without_override(self):
         """Test that the default duckdb path emits the built-in IEJoin SQL.
 
         Given:
-            The same IEJoin-eligible duckdb query and no target-specific
-            Intersects override registered (only the built-in generic expander).
+            The same IEJoin-eligible duckdb query and only the built-in
+            (DuckDBTarget, Intersects) IEJoin override in the registry.
         When:
             Transpiling with dialect='duckdb'.
         Then:
-            The built-in IEJoin SET VARIABLE SQL is emitted (the generic
-            predicate expander does not disable the join strategy).
+            It should emit the built-in IEJoin SET VARIABLE SQL.
         """
         # Arrange
         query = (
@@ -1842,6 +1843,22 @@ class TestIEJoinRegistryDeferral:
 
         # Assert
         assert "SET VARIABLE __giql_iejoin_" in sql
+
+    def test_registry_should_resolve_duckdb_intersects_to_iejoin_override(self):
+        """Test that the built-in DuckDB IEJoin override is registered.
+
+        Given:
+            The process-wide registry with its import-time built-in expanders.
+        When:
+            Querying it for the (DuckDBTarget, Intersects) entry.
+        Then:
+            It should report the override present and resolve it to the DuckDB
+            IEJoin expander — the migrated pass-3 join strategy (#169), not the
+            generic naive-predicate fallback.
+        """
+        # Act & assert
+        assert REGISTRY.has_override(DuckDBTarget(), Intersects) is True
+        assert REGISTRY.resolve(DuckDBTarget(), Intersects) is expand_intersects_duckdb
 
 
 class TestTranspileExpanderDispatch:

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -33,12 +33,12 @@ def _generate_through_passes(sql: str, tables: Tables) -> str:
     ExpandOperators pass (epic #137). Emitter-level tests that pin canonicalized /
     expanded output must therefore run all three passes before generating, exactly
     as :func:`giql.transpile.transpile` does, rather than calling ``generate`` on a
-    bare parsed AST. Operators still on the legacy emitter (DISJOIN) pass through
-    the expansion pass untouched. This helper runs the passes in isolation to pin
-    the expanded emitter output on the generic target directly, without the DuckDB
-    IEJoin pre-pass (the only remaining pre-pass join rewrite — a column-to-column
-    ``INTERSECTS`` join otherwise expands to the naive overlap predicate right here
-    in pass 3, since the binned pre-pass rewrite was dropped in #167).
+    bare parsed AST. This helper runs the passes in isolation to pin the expanded
+    emitter output on the generic target directly. There is no pre-pass join
+    rewrite anymore: a column-to-column ``INTERSECTS`` join expands to the naive
+    overlap predicate right here in pass 3 (the binned pre-pass was dropped in #167,
+    and the DuckDB IEJoin pre-pass was relocated into the ``(DuckDBTarget,
+    Intersects)`` registry override in #169, which only fires on the duckdb target).
     """
     ast = parse_one(sql, dialect=GIQLDialect)
     ast = resolve_operator_refs(ast, tables)

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -40,14 +40,12 @@ class TestCapabilities:
             supports_lateral=True,
             supports_star_replace=False,
             supports_qualify=True,
-            range_join_strategy="naive",
         )
 
         # Assert
         assert caps.supports_lateral is True
         assert caps.supports_star_replace is False
         assert caps.supports_qualify is True
-        assert caps.range_join_strategy == "naive"
 
     def test___eq___with_identical_values(self):
         """Test value equality of Capabilities.
@@ -64,13 +62,11 @@ class TestCapabilities:
             supports_lateral=True,
             supports_star_replace=True,
             supports_qualify=True,
-            range_join_strategy="iejoin",
         )
         second = Capabilities(
             supports_lateral=True,
             supports_star_replace=True,
             supports_qualify=True,
-            range_join_strategy="iejoin",
         )
 
         # Act & assert
@@ -91,13 +87,11 @@ class TestCapabilities:
             supports_lateral=True,
             supports_star_replace=True,
             supports_qualify=True,
-            range_join_strategy="iejoin",
         )
         differing = Capabilities(
             supports_lateral=True,
             supports_star_replace=True,
-            supports_qualify=True,
-            range_join_strategy="naive",
+            supports_qualify=False,
         )
 
         # Act & assert
@@ -118,7 +112,6 @@ class TestCapabilities:
             supports_lateral=True,
             supports_star_replace=False,
             supports_qualify=False,
-            range_join_strategy="naive",
         )
 
         # Act & assert
@@ -138,7 +131,7 @@ class TestGenericTarget:
             An instance is constructed.
         Then:
             It should carry the portable SQL-92 baseline: no engine dialect,
-            lateral supported, no star-REPLACE, no QUALIFY, naive-predicate joins.
+            lateral supported, no star-REPLACE, no QUALIFY.
         """
         # Act
         target = GenericTarget()
@@ -149,7 +142,6 @@ class TestGenericTarget:
         assert target.capabilities.supports_lateral is True
         assert target.capabilities.supports_star_replace is False
         assert target.capabilities.supports_qualify is False
-        assert target.capabilities.range_join_strategy == "naive"
 
 
 class TestDuckDBTarget:
@@ -164,7 +156,7 @@ class TestDuckDBTarget:
             An instance is constructed.
         Then:
             It should serialize through the duckdb dialect and enable
-            lateral, star-REPLACE, QUALIFY, and the IEJoin strategy.
+            lateral, star-REPLACE, and QUALIFY.
         """
         # Act
         target = DuckDBTarget()
@@ -175,7 +167,6 @@ class TestDuckDBTarget:
         assert target.capabilities.supports_lateral is True
         assert target.capabilities.supports_star_replace is True
         assert target.capabilities.supports_qualify is True
-        assert target.capabilities.range_join_strategy == "iejoin"
 
 
 class TestDataFusionTarget:
@@ -190,8 +181,7 @@ class TestDataFusionTarget:
             An instance is constructed.
         Then:
             It should fall back to generic serialization (no sqlglot
-            DataFusion dialect), disable star-REPLACE and QUALIFY, and use
-            the naive-predicate join strategy.
+            DataFusion dialect) and disable lateral, star-REPLACE, and QUALIFY.
         """
         # Act
         target = DataFusionTarget()
@@ -202,7 +192,6 @@ class TestDataFusionTarget:
         assert target.capabilities.supports_lateral is False
         assert target.capabilities.supports_star_replace is False
         assert target.capabilities.supports_qualify is False
-        assert target.capabilities.range_join_strategy == "naive"
 
 
 class TestTarget:
@@ -367,7 +356,6 @@ class _PostgresTarget(Target):
         supports_lateral=True,
         supports_star_replace=False,
         supports_qualify=True,
-        range_join_strategy="naive",
     )
 
 
@@ -528,7 +516,6 @@ class TestCustomTargetInjection:
                 supports_lateral=True,
                 supports_star_replace=False,
                 supports_qualify=False,
-                range_join_strategy="naive",
             )
 
         REGISTRY.register_target(_ShadowTarget())
@@ -605,7 +592,6 @@ class TestTargetDrivesSerialization:
                 supports_lateral=True,
                 supports_star_replace=False,
                 supports_qualify=False,
-                range_join_strategy="naive",
             )
 
         REGISTRY.register_target(_DuckLikeTarget())


### PR DESCRIPTION
## Summary

Relocate the DuckDB IEJoin column-to-column `INTERSECTS` join rewrite from a capability-gated **pre-pass transformer** (`giql.transformer.IntersectsDuckDBIEJoinTransformer`) into a registered **`(DuckDBTarget, Intersects)` override expander** (`giql.expanders.intersects_duckdb`). This is the DuckDB counterpart to #167 (naive-predicate `GenericTarget` default) and completes the operator-expander registry migration (epic #137): `INTERSECTS` join strategy is now fully registry-driven, mirroring the CLUSTER / MERGE relocation (#144). No pre-pass join rewrite remains. **This PR also folds in the fix for #200** (SEMI/ANTI `WHERE`-residual inlining), see below.

**Dispatch is now uniform.** A column-to-column `INTERSECTS` join flows untouched into pass 3, where `ExpandOperators` resolves its expander through the registry's fallback chain: `(GenericTarget, Intersects)` emits the naive overlap predicate on `None` / `"datafusion"`, and the `(DuckDBTarget, Intersects)` override supersedes it on `"duckdb"`. The override defers to that **same** naive predicate for every shape the IEJoin path declines (LEFT/RIGHT/FULL, self-joins, multiple `INTERSECTS`, extra predicates, non-base operands, 3+ tables) and for literal-range / residual predicates. The `uses_iejoin` / `range_join_strategy` capability branch is gone.

**Why the whole-query string still works as an expander (verified before removing the pre-pass):** the IEJoin rewrite emits a multi-statement string (`SET VARIABLE …; SELECT … FROM query(getvariable(…))`), which is not a node-local expression. The override produces it through the existing `ExpansionContext.add_statement_finalizer` seam, wrapping the built SQL in an `exp.Command` that **serializes verbatim**. Two facts make this a safe, output-preserving move:

- **A column-to-column `INTERSECTS` survives to pass 3 structurally intact.** Pass 1 attaches resolution metadata only; pass 2 synthesizes no CTE for its operands (they are column slots, not reference slots). So the override rebuilds the join from the *same raw AST* the former pre-pass read, ignoring the (harmless) resolution metadata.
- **Byte-identical output.** Transpiling INNER / SEMI / ANTI / star / extra-predicate / GROUP-BY / declined-LEFT / declined-self-join / literal shapes on this branch matches `origin/main` byte-for-byte (after normalizing the per-call `uuid4` token), and the DuckDB behavioral oracle (`tests/test_duckdb_iejoin.py`, executed against real DuckDB 1.5.4) passes unchanged.

**Scope / decisions:**

- The `range_join_strategy` capability is **removed** from `Capabilities` — it became vestigial once the registration itself is the single source of truth for "this target uses IEJoin". (Its only reader was the deleted `uses_iejoin` branch.)
- `has_override` is **retained** as registry introspection (still exercised by `test_expander.py`), but no longer gates a pre-pass — there is none. Its docstrings and the CLUSTER / MERGE cross-references to the removed `giql.transformer` module are updated.
- Reframes #95 (LEFT/RIGHT JOIN in the IEJoin dialect) as "defer to the naive default" and likely moots it, per the issue.

Closes #169. Closes #200.

## Folded-in fix — #200 (SEMI/ANTI `WHERE`-residual inlining)

The IEJoin override collected JOIN-`ON` and top-level `WHERE` residuals into one list and appended all of them to each per-chromosome join `ON`. That is sound for INNER (`ON overlap WHERE r` ≡ `ON overlap AND r`) and for the equivalent SEMI case, but for **ANTI it inverts the anti-join**: a row failing the residual `r` satisfies `NOT EXISTS b (overlap AND r)` unconditionally, so rows that should be filtered out are resurrected. Repro (`… ANTI JOIN … ON a.interval INTERSECTS b.interval WHERE a.start >= 550`) returned every peak instead of the single non-overlapping one that passes the filter. This was pre-existing on `main`; #169 only widened its exposure, so it is fixed here rather than left dangling.

**Fix (root-cause, provenance split).** `_extract_extra_predicates` now returns `(on_residuals, where_residuals)`. `ON` residuals are genuine join conditions and stay inlined into the per-chromosome `ON` for every kind. For the left-only shapes (SEMI / ANTI), `WHERE` residuals are instead layered as an **outer `WHERE` on the wrapper relation** — reusing the existing wrapper-relation rewriter and pre-allocating their columns into the wrapper projection list so a filter can reference a column absent from the `SELECT`. A right-side reference in such a residual raises the same left-only `ValueError` the `SELECT` list already enforces. INNER keeps inlining `WHERE` residuals (byte-identical output, provably equivalent), so the working INNER path is untouched. Isolates the optimization cleanly: the per-chromosome IEJoin handles only the overlap plus genuine join conditions, and every post-join clause (WHERE / GROUP BY / HAVING / ORDER BY / LIMIT) composes on top of the wrapper relation.

## Proposed changes

- **`src/giql/transformer.py` → `src/giql/expanders/intersects_duckdb.py`** (git rename, 93% similarity) — the module now also holds the registered `@register(DuckDBTarget, Intersects) def expand_intersects_duckdb`, which runs `IntersectsDuckDBIEJoinTransformer.transform_to_sql(node.root())`, registers a finalizer emitting `exp.Command(this=<iejoin sql>)` when it produces output, and otherwise delegates to the shared `_expand_spatial_op(node, ctx, "intersects")`. The residual handling splits ON vs WHERE provenance and routes SEMI/ANTI `WHERE` residuals to an outer wrapper filter (#200).
- **`src/giql/transpile.py`** — remove the `uses_iejoin` pre-pass block, the `IntersectsDuckDBIEJoinTransformer` import, and the `REGISTRY.has_override` / `Intersects` gating; dispatch flows entirely through pass 3.
- **`src/giql/targets.py`** — drop the `range_join_strategy` field and the `RangeJoinStrategy` type; update the `Capabilities` / target docstrings.
- **`src/giql/expander.py`, `src/giql/expanders/intersects.py`, `src/giql/resolver.py`, `src/giql/expanders/cluster.py`, `src/giql/expanders/merge.py`** — docstrings: the IEJoin is a registered override (pass 3), not a pre-pass; `has_override` reframed as introspection; de-link the now-removed `giql.transformer` module references.
- **docs** — `transpilation/extending.rst` (join strategy is registry-selected, not a capability flag; the finalizer seam handles whole-query join folds); the performance and spatial-operator guides describe output and are unchanged.

## Test cases

| # | Test Suite | Given | When | Then | Coverage Target |
|---|------------|-------|------|------|-----------------|
| 1 | `TestIEJoinRegistryDeferral` | The process-wide registry with its built-in expanders | Querying `(DuckDBTarget, Intersects)` | It reports the override present and resolves to `expand_intersects_duckdb` | `#169` registration |
| 2 | `TestIEJoinRegistryDeferral` | A user `(DuckDBTarget, Intersects)` expander registered | Transpiling an IEJoin-eligible join with `dialect="duckdb"` | It emits the user override sentinel, not the built-in `SET VARIABLE` SQL | Last-write-wins override |
| 3 | `TestIEJoinRegistryDeferral` | Only the built-in override in the registry | Transpiling the same join with `dialect="duckdb"` | It emits the built-in IEJoin `SET VARIABLE` SQL | Built-in registry dispatch |
| 4 | `TestCapabilities` | Two `Capabilities` differing only in `supports_qualify` | Comparing for equality | It treats them as unequal (per-field value semantics) | `range_join_strategy` removal |
| 5 | `TestDuckDBTarget` / `TestGenericTarget` / `TestDataFusionTarget` | Each built-in target class | An instance is constructed | It exposes the expected capability set (no `range_join_strategy`) | Capability surface |
| 6 | `tests/test_duckdb_iejoin.py` (unchanged) | INNER / SEMI / ANTI / star / extra-predicate / GROUP-BY / declined shapes | Transpile and execute on real DuckDB | Correct rows, IEJoin `SET VARIABLE` output for supported shapes, naive predicate for declined | Behavioral regression oracle |
| 7 | `tests/test_duckdb_iejoin.py` (#200) | ANTI / SEMI joins with a top-level `WHERE` residual (incl. a filter column absent from `SELECT`, a right-side reference, and Hypothesis-random inputs) | Transpile with `dialect="duckdb"` vs the naive plan and execute | Rows match the naive plan (no anti-join inversion), the residual lands in the outer wrapper `WHERE` not the per-chromosome `ON`, and a right-side residual raises | `#200` residual routing |

## Review

Round 1: 6 reviewers (principal-SWE + Python/SQL lens) across 6 focuses — migration completeness, expander correctness, behavior preservation, public-API/docs, test quality, adversarial. **3 blocking, all remediated and independently verified (0 unresolved).**

- **B1 (correctness):** the adversarial reviewer found that, because the IEJoin now runs in pass 3 (deepest-first), a sibling spatial predicate (`CONTAINS`/`WITHIN`/literal `INTERSECTS`/`ANY`) could be expanded to plain SQL *before* the join `INTERSECTS`, escaping the transformer's residual detection — engaging the IEJoin and inlining the residual, which for ANTI joins produced **silent wrong rows** (5 spurious rows where the correct answer was `[]`) and for the un-parenthesized form flipped to a hard error on parse depth. Fixed at the root: generic spatial expansions now carry a `meta` tag, and the DuckDB override declines to the naive predicate whenever any sibling spatial predicate is present (un-expanded GIQL node *or* tagged expansion) — robust to pass-3 ordering, keeping the deepest-first order (#154) intact. Regression tests added (ANTI + `CONTAINS` execution vs the naive plan; residual literal `INTERSECTS` routing).
- **B2 / B3 (test hygiene):** restored an accidentally-deleted `TestTranspileExpanderDispatch` class header (10 tests had been silently reparented), and reworked the deferral test to genuinely exercise last-write-wins supersession (register the built-in, then a user override on top).

The five non-adversarial reviewers independently confirmed the refactor is byte-identical to `main` across 17–27 shapes (resolution/canonicalization provably cannot raise on and do not restructure a column-to-column `INTERSECTS`), the `exp.Command` fold serializes verbatim, error messages are unchanged, and the `range_join_strategy` removal is complete and justified. Advisories were folded in (docstring precision) or dispositioned (internal class name kept; no changelog convention; `has_override` retained as introspection).

**#200 fold-in** adds the residual provenance split plus 11 regression tests (ANTI/SEMI `WHERE`-residual vs the naive plan, a filter column absent from `SELECT`, a right-side-reference raise, a structural outer-`WHERE`-not-inlined assertion, a Hypothesis property test, plus the ANTI `ON`-residual-right-side mirror, a compound-`AND` residual, and `WHERE` + `GROUP BY` composition). The delta was re-reviewed by 2 independent read-only reviewers (adversarial correctness + test quality), **0 blocking** — the adversarial reviewer verified all six probe areas on real DuckDB (outer-`WHERE` clause ordering, the B1 sibling-spatial guard interaction, shared-column allocation, INNER byte-identity, right-side rejection), and the test-quality reviewer confirmed against a pre-fix worktree that the ANTI regression tests fail on the buggy code and pass on the fix. Full suite after the fold-in: **2019 passed / 90 xfailed / 95.55% coverage**.

**Round 2 review (holistic, 5 reviewers).** With both features integrated at final HEAD, a 5-reviewer principal-SWE + SQL-expert pass (migration completeness / SQL semantics / cross-feature interaction / test quality / adversarial) found **0 blocking**. Two SQL-focused reviewers plus the composition reviewer ran differential harnesses against real DuckDB (~40 + broad adversarial shapes) and confirmed the #200 residual split is correct across every INNER/SEMI/ANTI shape, with INNER byte-identical to pre-#200; the test-quality reviewer confirmed against a pre-fix worktree that the new tests discriminate the fix. Seven advisories, all resolved: the actionable ones were folded in — a flaky structural assertion re-anchored on a token-proof form, a four-site “transformer chain / generator” docstring sweep (including the dead `range_join_strategy` symbol name this PR removed), and two coverage adds (SEMI right-side-raise, residual + `ORDER BY`) — the rest dispositioned no-change (documented `a.*` star-narrowing; a strictly-better transpile-time error surface; a pre-existing invalid-query edge). Verified independently, **0 unresolved (7/7 Resolved)**. Full suite: **2019 passed / 90 xfailed / 95.55% coverage**.

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM