### PR TITLE
Decline unsupported DuckDB IEJoin shapes to the naive-predicate plan — Closes #201, #202, #204, #205

### DIFF
--- a/docs/transpilation/performance.rst
+++ b/docs/transpilation/performance.rst
@@ -381,8 +381,9 @@ results.
    rows = conn.execute(sql).fetchall()
 
 The dialect rewrites the whole query, so the supported shape is
-``SELECT <qualified projections> FROM <base table> {INNER|SEMI|ANTI}
-JOIN <base table> {ON|WHERE} <one column-to-column INTERSECTS>`` — the
+``SELECT <qualified non-star projections> FROM <base table>
+{INNER|SEMI|ANTI} JOIN <base table> {ON|WHERE} <one column-to-column
+INTERSECTS>`` — the
 JOIN and the column-to-column ``INTERSECTS`` are both required
 (literal-range ``INTERSECTS`` against a single table falls through to
 the default predicate generator).
@@ -390,11 +391,13 @@ the default predicate generator).
 **Join variants.** ``INNER JOIN`` is the default. ``SEMI JOIN`` returns
 distinct left rows that have at least one overlapping match; ``ANTI
 JOIN`` returns left rows with no overlapping match. Both restrict the
-outer SELECT to left-side projections — any reference to the right
-side (``b.col`` / ``b.*`` / aggregate over ``b.*``) raises
-``ValueError``. ANTI uses a left-distinct chromosome partition rather
-than the chromosome INTERSECT used by INNER / SEMI, so left rows on
-chromosomes absent from the right table are preserved.
+outer SELECT to left-side projections — any ``b.col`` reference (or an
+aggregate over ``b.col``) raises ``ValueError``; a right-side ``b.*``
+declines to the naive-predicate plan with every other star (which then
+rejects the out-of-scope right table at bind time). ANTI uses a
+left-distinct chromosome partition rather than the chromosome INTERSECT
+used by INNER / SEMI, so left rows on chromosomes absent from the right
+table are preserved.
 
 DuckDB plans INNER through the IE_JOIN / PIECEWISE_MERGE_JOIN
 sort-merge family. SEMI and ANTI with inequality predicates plan
@@ -433,12 +436,6 @@ decorations:
   ``dialect=None`` path, ``dialect="duckdb"`` is one workaround — the
   dialect inlines extras directly into each per-chromosome subquery
   and is unaffected by that bug.
-- **Star projections (``a.*`` / ``b.*``).** Expanded to the genomic
-  columns declared by the corresponding :class:`Table` config (chrom
-  / start / end, plus strand when set). This narrows the result schema
-  relative to the naive-predicate plan, which delegates star expansion to
-  DuckDB and projects every base-table column. Users with additional
-  non-genomic columns should list them explicitly.
 
 The dialect splits unsupported shapes into two buckets. Soft-fallback
 shapes route to the naive-predicate plan automatically and return correct
@@ -455,6 +452,40 @@ The soft-fallback shapes are:
   when the join keeps its side modifier and the ``INTERSECTS`` lives in
   the top-level ``WHERE`` (e.g. ``LEFT JOIN ... ON TRUE WHERE
   a.interval INTERSECTS b.interval``).
+- **SEMI / ANTI join with the INTERSECTS in the WHERE.** A ``SEMI`` /
+  ``ANTI`` join whose column-to-column ``INTERSECTS`` sits in the
+  top-level ``WHERE`` rather than its own ``ON`` (e.g. ``ANTI JOIN ... ON
+  TRUE WHERE a.interval INTERSECTS b.interval``) falls back. The right
+  table is out of scope in the ``WHERE`` after a left-only join, so the
+  reference plans reject it with a binder error; the dialect declines so
+  it surfaces that same error instead of relocating the predicate into
+  the join and inventing anti/semi-overlap results. The idiomatic form
+  with the ``INTERSECTS`` in the join ``ON`` is unaffected.
+- **Star projections.** Any star in the top-level SELECT list — bare
+  ``*``, ``a.*``, ``b.*``, or ``a.* AS x`` — falls back. Building the
+  dialect's per-chromosome dynamic SQL requires enumerating the star's
+  columns at transpile time, but only the registered genomic columns
+  (``chrom`` / ``start`` / ``end`` / ``strand``) are known — arbitrary
+  user columns are invisible. The naive-predicate plan expands the real
+  star against DuckDB's live schema, so declining keeps the projection
+  identical across backends rather than silently narrowing it.
+- **Projections the IEJoin cannot rebuild.** The dialect's projection
+  rebuild handles a qualified column (``a.col``) or a plain aggregate
+  over qualified columns (``SUM(a.score)`` / ``COUNT(*)``). Any other
+  SELECT-list shape the naive plan compiles for free — an expression
+  (``a.start + 1``), a window aggregate (``SUM(a.score) OVER (...)``), a
+  ``FILTER`` clause, a scalar subquery, an aggregate nested in an
+  expression (``COUNT(*) * 2``), a bare literal, or a star nested in an
+  aggregate argument (``COUNT(a.*)`` / ``MIN(COLUMNS(*))``) — falls back,
+  so ``dialect="duckdb"`` stays consistent with every other backend
+  instead of hard-erroring or, for the aggregate-nested star,
+  miscompiling. A projection whose column the rebuild cannot attribute to
+  a join side (unqualified, an unknown table, or the right side under a
+  SEMI / ANTI join) raises at transpile time instead (see the hard-error
+  list below) — the unknown-table and right-side cases are rejected by the
+  naive plan too, and a bare unqualified column, though it may be
+  naive-valid when unambiguous, has no side the dialect can infer without a
+  live schema.
 - **NATURAL joins.** ``NATURAL JOIN`` falls back because the dialect
   cannot enumerate shared columns at transpile time (only the
   registered ``chrom`` / ``start`` / ``end`` / ``strand`` columns are
@@ -498,37 +529,35 @@ The soft-fallback shapes are:
 Query-shape ``ValueError`` raises (the dialect deliberately refuses
 these rather than silently miscompile):
 
-- **Bare** ``SELECT *`` **and unqualified columns.** The dialect path
-  needs to know which side each output column comes from. Use ``a.*``,
-  ``b.*``, ``a.col``, or ``a.col AS x``.
-- **Expression-form projections.** ``a.start + 1`` and other non-column
-  expressions (other than aggregates) raise. Project the underlying
-  column and compute in a wrapping query around the dialect's output,
-  or omit ``dialect="duckdb"`` to use the naive-predicate plan.
+- **Unqualified columns.** A bare column reference (``SELECT score``)
+  raises — the dialect path needs to know which side each output column
+  comes from, and has no live schema to infer it (so an unambiguous
+  unqualified column that the naive plan would accept still raises here).
+  Use ``a.col`` or ``a.col AS x``. (Bare ``SELECT *`` does not raise; like
+  every star it falls back to the naive-predicate plan — see the
+  soft-fallback list above. An expression / window aggregate / ``FILTER``
+  clause over an *unqualified* column raises the same "requires qualified
+  projections" error — once qualified, the wrapper itself falls back to the
+  naive plan rather than erroring. A scalar subquery always falls back, even
+  over an unqualified inner column, since that column resolves against the
+  subquery's own scope.)
 - **Unknown table qualifier.** ``c.col`` when the only sides are ``a``
   and ``b``.
 - **Unknown alias in GROUP BY / HAVING / ORDER BY.** A modifier-clause
   column qualified with a table alias outside the join's two sides
   (``c.col``) raises with a ``cannot resolve … in <CLAUSE>`` message
   naming the expected aliases.
-- **Right-side reference in SEMI / ANTI joins.** ``b.col`` / ``b.*`` /
-  aggregate over ``b.*`` in the outer SELECT, GROUP BY, HAVING, ORDER
+- **Right-side reference in SEMI / ANTI joins.** ``b.col`` or an
+  aggregate over ``b.col`` in the outer SELECT, GROUP BY, HAVING, ORDER
   BY, or aggregate argument under ``SEMI JOIN`` / ``ANTI JOIN`` raises;
-  SEMI / ANTI return left-side columns only.
+  SEMI / ANTI return left-side columns only. (A right-side ``b.*`` falls
+  back to the naive-predicate plan with every other star — see the
+  soft-fallback list above.)
 - **Aggregate of unqualified column.** ``SUM(score)`` raises; use
-  ``SUM(a.score)`` or ``SUM(b.score)``.
-- **Star projection with a user alias.** ``a.* AS x`` raises (most
-  engines reject star-with-alias outright); either drop the alias and
-  use ``a.*``, or list the columns explicitly with per-column aliases.
-- **Window aggregates and FILTER clauses.** ``SUM(a.score) OVER
-  (...)`` and ``SUM(a.score) FILTER (WHERE ...)`` raise with a
-  dedicated error; rewrite the projection or omit ``dialect="duckdb"``.
-- **Aggregates inside expressions.** ``COUNT(*) * 2`` and similar
-  arithmetic-over-aggregate projections raise; project the aggregate
-  on its own and do arithmetic in a wrapping query.
-- **Scalar subqueries in the SELECT list.** ``(SELECT SUM(x) FROM
-  other_table) AS s`` raises; rewrite without the subquery or omit
-  ``dialect="duckdb"``.
+  ``SUM(a.score)`` or ``SUM(b.score)``. (A qualified aggregate the IEJoin
+  cannot rebuild — ``SUM(a.score) OVER (...)``, ``SUM(a.score) FILTER
+  (WHERE ...)``, ``COUNT(*) * 2``, ``COUNT(a.*)`` — falls back to the
+  naive plan instead; see the soft-fallback list above.)
 - **Catalog/schema-qualified extra predicates.** ``mycat.myschema.a.col``
   in an extra predicate raises; the alias rewriter would leave the
   catalog/schema qualifier intact in the inner subquery, where it

--- a/src/giql/expanders/intersects_duckdb.py
+++ b/src/giql/expanders/intersects_duckdb.py
@@ -44,7 +44,6 @@ from giql.expressions import Contains
 from giql.expressions import Intersects
 from giql.expressions import SpatialSetPredicate
 from giql.expressions import Within
-from giql.table import Table
 from giql.table import Tables
 from giql.targets import DuckDBTarget
 
@@ -53,13 +52,36 @@ class _UnqualifiedProjectionError(Exception):
     """Signal an unrecoverable projection-resolution failure in the DuckDB IEJoin path.
 
     Raised by :class:`IntersectsDuckDBIEJoinTransformer` when a query engages
-    the dialect path but contains a SELECT-list shape the dialect cannot
-    translate (bare ``*``, unqualified column, expression-form projection,
-    unknown table qualifier, ``a.* AS x``, window aggregate, ``FILTER`` clause,
-    arithmetic over an aggregate, or a scalar subquery in the projection list),
-    or an extras predicate that references an unqualified or unknown-aliased
-    column. Caught and re-raised as :class:`ValueError` at the dialect's public
+    the dialect path but contains a SELECT-list shape the rebuild cannot
+    attribute to a join side: an unqualified column, an unknown table
+    qualifier, an aggregate over an unqualified column, or a right-side
+    reference under a SEMI / ANTI join, plus an extras predicate that
+    references an unqualified or unknown-aliased column. The unknown-table,
+    aggregate-of-unqualified, and right-side cases are also rejected by the
+    naive plan; a *bare* unqualified column may in fact be naive-valid when it
+    is unambiguous, but the dialect has no live schema to attribute it to a
+    side, so it surfaces a clean transpile-time error rather than guessing.
+    Caught and re-raised as :class:`ValueError` at the dialect's public
     boundary.
+
+    Shapes the naive plan *accepts* but the IEJoin cannot rebuild do NOT raise
+    — star projections (#202), and expressions / window aggregates / ``FILTER``
+    clauses / scalar subqueries / aggregate-nested stars (#204, #205) — they
+    signal :class:`_DeclineIEJoin` and fall back to the naive plan instead.
+    """
+
+
+class _DeclineIEJoin(Exception):
+    """Signal that the IEJoin should decline a valid query to the naive plan.
+
+    Distinct from :class:`_UnqualifiedProjectionError`: this is not a user
+    error but a shape the naive-predicate plan compiles for free while the
+    IEJoin projection rebuild cannot express it (an expression, a window
+    aggregate, a ``FILTER`` clause, a scalar subquery, an aggregate nested in
+    an expression, or a star nested in an aggregate argument — #204, #205).
+    Caught in :meth:`IntersectsDuckDBIEJoinTransformer.transform_to_sql`, which
+    returns ``None`` so the generic naive-predicate plan handles the query,
+    keeping ``dialect="duckdb"`` consistent with every other backend.
     """
 
 
@@ -130,6 +152,141 @@ def _has_outer_join_intersects(query: exp.Select) -> bool:
     if where and _find_column_intersects_in(where.this):
         return True
     return False
+
+
+def _has_left_only_join_where_intersects(query: exp.Select) -> bool:
+    """Return True if a SEMI/ANTI join carries its INTERSECTS in the WHERE.
+
+    A left-only (``SEMI`` / ``ANTI``) join's right table is out of scope in
+    the top-level ``WHERE`` — the reference plans (``dialect=None`` /
+    ``"datafusion"``) reject a right-referencing ``WHERE`` predicate with a
+    binder error. The dialect's ``WHERE``-branch (which exists to support the
+    legitimate implicit comma/cross-join idiom, an ``INNER`` join whose right
+    table *is* in scope in the ``WHERE``) would instead relocate that
+    ``INTERSECTS`` into the join ``ON`` and invent anti/semi-overlap results,
+    diverging from every other backend (#201). Decline whenever an explicit
+    ``SEMI`` / ``ANTI`` join is present and a column-to-column ``INTERSECTS``
+    sits in the top-level ``WHERE`` (necessarily out of scope), so the naive
+    plan surfaces the same binder error the reference plans raise. The
+    ``INTERSECTS`` search recurses (via ``find_all``), so a column-to-column
+    ``INTERSECTS`` nested inside a ``WHERE`` subquery also declines here;
+    that is a harmless over-decline (it only ever routes to the correct
+    naive plan) and such shapes already decline via other gates.
+    """
+    if not isinstance(query, exp.Select):
+        return False
+    has_left_only_join = any(
+        (join.args.get("kind") or "").upper() in ("SEMI", "ANTI")
+        for join in query.args.get("joins") or []
+    )
+    if not has_left_only_join:
+        return False
+    where = query.args.get("where")
+    return bool(where and _find_column_intersects_in(where.this))
+
+
+def _has_star_projection(query: exp.Select) -> bool:
+    """Return True if the SELECT list contains any star projection.
+
+    The IEJoin rewrite restructures the query into per-chromosome subqueries
+    that project **explicitly-named** ``__giql_p<n>`` columns up through a
+    wrapper relation, so building that dynamic SQL requires enumerating the
+    star's columns at transpile time. But GIQL only knows the genomic columns
+    declared in the :class:`~giql.table.Table` config (chrom / start / end /
+    strand) — it has no view of the live table schema, so it cannot see
+    arbitrary base-table columns (``name`` / ``score`` / ...). Expanding
+    ``a.*`` here would silently drop them, narrowing the result relative to
+    every other backend (#202). Decline any star projection (bare ``*`` or
+    qualified ``t.*``, with or without a user alias) so the naive-predicate
+    plan expands it against DuckDB's live schema at bind time, keeping the
+    projection identical across backends.
+    """
+    if not isinstance(query, exp.Select):
+        return False
+    for sel in query.expressions:
+        target = sel.this if isinstance(sel, exp.Alias) else sel
+        while isinstance(target, exp.Paren):
+            target = target.this
+        if isinstance(target, exp.Star):
+            return True
+        if isinstance(target, exp.Column) and isinstance(target.this, exp.Star):
+            return True
+    return False
+
+
+def _projection_declines_to_naive(
+    target: exp.Expression,
+    l_alias: str,
+    r_alias: str,
+    is_left_only: bool,
+) -> bool:
+    """Return True if *target* is a projection the IEJoin should decline to naive.
+
+    The IEJoin projection rebuild only handles a qualified column (``a.col``)
+    or a plain aggregate over qualified columns (``SUM(a.score)`` / ``COUNT(*)``);
+    it emits explicitly-named ``__giql_p<n>`` inner columns and reconstructs the
+    outer SELECT from them. Any other shape the naive-predicate plan compiles
+    for free — an expression (``a.start + 1``), a window aggregate, a ``FILTER``
+    clause, a scalar subquery, an aggregate nested in an expression
+    (``COUNT(*) * 2``), or a star nested in an aggregate argument
+    (``COUNT(a.*)`` / ``MIN(COLUMNS(*))``) — should decline so ``dialect="duckdb"``
+    stays consistent with every other backend instead of hard-erroring or, for
+    the aggregate-nested star, miscompiling (#204, #205).
+
+    A projection that references a column **in its own scope** the rebuild
+    cannot attribute to a join side (unqualified, an unknown table, or the
+    right side under a SEMI / ANTI join) does NOT decline — the dispatch raises
+    a clean :class:`_UnqualifiedProjectionError` instead. The unknown-table and
+    right-side cases are rejected by the naive plan too; a bare unqualified
+    column may be naive-valid when unambiguous, but the dialect has no live
+    schema to pick a side, so a transpile-time error is more actionable than
+    guessing. Columns inside a nested subquery resolve against that subquery,
+    not the join, so they are ignored by this test.
+    """
+    # A qualified, non-star column is rebuilt directly — never declines here.
+    if (
+        isinstance(target, exp.Column)
+        and target.table
+        and not isinstance(target.this, exp.Star)
+    ):
+        return False
+    # An aggregate is decided here in full (it never falls through to the
+    # column scan below — an unqualified aggregate argument like ``SUM(score)``
+    # is diagnosed in ``render_aggregate``, not treated as a decline). A star
+    # nested in an aggregate argument (``COUNT(a.*)`` / ``MIN(COLUMNS(*))`` /
+    # ``COUNT(a.* EXCLUDE (name))``) cannot be enumerated, so it declines
+    # regardless of any EXCLUDE / REPLACE modifier columns (#204); a plain
+    # aggregate over qualified columns (``COUNT(*)`` / ``SUM(a.score)`` /
+    # ``COUNT(DISTINCT a.col)``) is rebuilt directly.
+    if isinstance(target, exp.AggFunc):
+        has_star_arg = any(
+            isinstance(col.this, exp.Star) for col in target.find_all(exp.Column)
+        )
+        return has_star_arg or target.find(exp.Columns) is not None
+    # Unsupported by the rebuild. Decline to naive unless an own-scope column
+    # is out of scope (a user error the naive plan rejects too — let the
+    # dispatch raise instead).
+    for col in target.find_all(exp.Column):
+        if isinstance(col.this, exp.Star):
+            continue  # qualified star — declinable, not a plain column ref
+        # Skip a column inside a nested subquery within *target* (it resolves
+        # against that subquery, not the join). *target* is an ancestor of
+        # *col*, so walking up from ``col.parent`` reaches it; a Select /
+        # Subquery strictly between them is a nested scope. When ``col`` IS
+        # ``target`` (a bare column projection), there is no interior to walk.
+        in_subquery = False
+        node = col.parent if col is not target else target
+        while node is not None and node is not target:
+            if isinstance(node, (exp.Select, exp.Subquery)):
+                in_subquery = True
+                break
+            node = node.parent
+        if in_subquery:
+            continue
+        tbl = _normalize_alias(col.table) if col.table else ""
+        if tbl not in (l_alias, r_alias) or (is_left_only and tbl == r_alias):
+            return False
+    return True
 
 
 def _strip_intersects(
@@ -273,17 +430,29 @@ class IntersectsDuckDBIEJoinTransformer:
 
     Notes:
 
-    - ``a.*`` / ``b.*`` star projections expand to the genomic columns
-      declared by the corresponding :class:`~giql.table.Table` config
-      (chrom / start / end, plus strand when set). This narrows the result
-      schema relative to the generic naive-predicate plan, which delegates star expansion
-      to DuckDB and projects every base-table column. Users with additional
-      non-genomic columns should list them explicitly.
+    - Star projections (bare ``*`` and ``a.*`` / ``b.*``) decline to the
+      generic naive-predicate plan, which delegates star expansion to DuckDB
+      and projects every base-table column against the live schema. The
+      dialect cannot enumerate a star at transpile time — it only knows the
+      :class:`~giql.table.Table` config's genomic columns (chrom / start /
+      end / strand), not arbitrary user columns — so declining keeps the
+      projection identical across backends rather than silently narrowing
+      it (#202).
+    - A projection the rebuild cannot express but the naive plan handles —
+      an expression (``a.start + 1``), a window aggregate, a ``FILTER``
+      clause, a scalar subquery, an aggregate nested in an expression
+      (``COUNT(*) * 2``), or a star nested in an aggregate argument
+      (``COUNT(a.*)`` / ``MIN(COLUMNS(*))``) — also declines to the naive
+      plan, keeping ``dialect="duckdb"`` consistent with every backend
+      rather than hard-erroring or miscompiling (#204, #205). Only a
+      genuine out-of-scope column reference (unqualified / unknown-table /
+      right-side) still raises.
     - ``SEMI JOIN`` and ``ANTI JOIN`` outputs are left-side only. Any
-      ``b.col`` / ``b.*`` reference in the outer SELECT, aggregate
-      arguments, GROUP BY, HAVING, or ORDER BY raises
-      :class:`_UnqualifiedProjectionError` (wrapped to :class:`ValueError`
-      at the public boundary).
+      ``b.col`` reference in the outer SELECT, aggregate arguments, GROUP BY,
+      HAVING, or ORDER BY raises :class:`_UnqualifiedProjectionError`
+      (wrapped to :class:`ValueError` at the public boundary). A right-side
+      ``b.*`` under SEMI / ANTI declines to the naive plan with every other
+      star (which then rejects the out-of-scope right table at bind time).
     - ``ANTI JOIN`` partitions on the left table's distinct chromosomes
       only (not the chromosome INTERSECT used by INNER / SEMI) so that
       left rows on chromosomes absent from the right table are preserved.
@@ -305,10 +474,16 @@ class IntersectsDuckDBIEJoinTransformer:
         query(getvariable(...))``, so any top-level clause :meth:`_build_sql`
         does not read would be silently dropped. The check below is a
         whitelist: engage the dialect path only for a query that is
-        exactly ``SELECT <qualified projections> FROM <registered base
-        table> [JOIN <registered base table>] {ON|WHERE} <one
-        column-to-column INTERSECTS>`` with no other top-level clause.
-        Everything else returns ``None`` so the generic naive-predicate plan handles it.
+        exactly ``SELECT <qualified columns / plain aggregates> FROM
+        <registered base table> [JOIN <registered base table>] {ON|WHERE}
+        <one column-to-column INTERSECTS>`` with no other top-level clause.
+        Star projections (schema-less enumeration would narrow them, #202),
+        projections the rebuild cannot express but the naive plan handles —
+        expressions / window aggregates / FILTER clauses / scalar subqueries /
+        aggregate-nested stars (#204, #205) — and a ``SEMI`` / ``ANTI`` join
+        whose ``INTERSECTS`` sits out of scope in the ``WHERE`` (#201) also
+        decline. Everything else returns ``None`` so the generic
+        naive-predicate plan handles it.
         """
         if not isinstance(query, exp.Select):
             return None
@@ -328,6 +503,20 @@ class IntersectsDuckDBIEJoinTransformer:
         if _has_outer_join_intersects(query):
             return None
 
+        # A SEMI / ANTI join whose INTERSECTS lives in the top-level WHERE
+        # (out of scope for the right table) diverges from the reference
+        # plans, which reject it with a binder error. Decline so the naive
+        # plan surfaces that error instead of inventing results (#201).
+        if _has_left_only_join_where_intersects(query):
+            return None
+
+        # Star projections (bare ``*`` or ``a.*`` / ``b.*``) need column
+        # enumeration the schema-less transpile cannot do without silently
+        # narrowing to the configured genomic columns. Decline so the naive
+        # plan expands the real star against DuckDB's live schema (#202).
+        if _has_star_projection(query):
+            return None
+
         if _count_column_intersects(query) != 1:
             return None
 
@@ -337,11 +526,11 @@ class IntersectsDuckDBIEJoinTransformer:
         # wrapper-relation aliases that don't exist in the subquery's own
         # scope. Reject those shapes here. ``EXISTS (SELECT ...)`` parses
         # as ``Exists(Select(...))`` without an ``exp.Subquery`` wrapper,
-        # so we also check ``exp.Select`` directly. Bare scalar subqueries
-        # in the SELECT list (``SELECT (SELECT SUM(x) FROM ...)``) get a
-        # targeted error from :meth:`_resolve_projections` rather than a
-        # silent fallback — only subqueries hidden inside aggregate args
-        # fall back here.
+        # so we also check ``exp.Select`` directly. A bare scalar subquery
+        # in the SELECT list (``SELECT (SELECT SUM(x) FROM ...)``) is not
+        # gated here — it declines to the naive plan later via the
+        # :meth:`_resolve_projections` projection pre-scan (#205), since its
+        # columns resolve against its own scope.
         for clause_key in ("group", "having", "order"):
             modifier = query.args.get(clause_key)
             if modifier is None:
@@ -448,6 +637,11 @@ class IntersectsDuckDBIEJoinTransformer:
         # uniform.
         try:
             return self._build_sql(query, intersects, sides, the_join)
+        except _DeclineIEJoin:
+            # A projection the naive plan handles but the IEJoin cannot rebuild
+            # (expression / window / FILTER / scalar subquery / aggregate-nested
+            # star) — fall back to the naive-predicate plan (#204, #205).
+            return None
         except _UnqualifiedProjectionError as exc:
             raise ValueError(str(exc)) from exc
 
@@ -744,10 +938,13 @@ class IntersectsDuckDBIEJoinTransformer:
         Returns ``None`` when a soft-fallback condition fires (the residual
         of the join carries a shape the naive-predicate plan can handle but the
         dialect cannot inline, or a single-column USING references a column
-        that is not both tables' ``chrom_col``). Raises
-        :class:`_UnqualifiedProjectionError` when a user-mistake condition
-        fires; callers translating to the public surface wrap the raise to
-        :class:`ValueError`.
+        that is not both tables' ``chrom_col``). May propagate
+        :class:`_DeclineIEJoin` from the :meth:`_resolve_projections` projection
+        pre-scan (a naive-valid projection the rebuild cannot express — #204,
+        #205); :meth:`transform_to_sql` catches it and declines to the naive
+        plan. Raises :class:`_UnqualifiedProjectionError` when a user-mistake
+        condition fires; callers translating to the public surface wrap the
+        raise to :class:`ValueError`.
         """
         on_residuals, where_residuals = self._extract_extra_predicates(query, intersects)
         all_residuals = on_residuals + where_residuals
@@ -804,10 +1001,6 @@ class IntersectsDuckDBIEJoinTransformer:
         ) = self._resolve_projections(
             query,
             sides,
-            l_table,
-            r_table,
-            (l_chrom, l_start, l_end),
-            (r_chrom, r_start, r_end),
             outer_where_residuals,
         )
 
@@ -986,10 +1179,6 @@ class IntersectsDuckDBIEJoinTransformer:
         self,
         query: exp.Select,
         sides: "_IEJoinSides",
-        l_table: Table | None,
-        r_table: Table | None,
-        l_cols: tuple[str, str, str],
-        r_cols: tuple[str, str, str],
         outer_where_residuals: list[exp.Expression] | None = None,
     ) -> tuple[list[str], list[str], dict[tuple[str, str], str]]:
         """Resolve the SELECT list (and any modifier-referenced columns).
@@ -1007,40 +1196,46 @@ class IntersectsDuckDBIEJoinTransformer:
           list — every column the query touches in any clause, projected
           once each under a unique ``__giql_p<n>`` alias.
         * ``outer_projections`` is the outer SELECT's projection list,
-          rendered using the inner aliases (qualified columns, aggregate
-          calls, ``a.*``/``b.*`` expansions including ``strand_col`` when
-          the corresponding :class:`~giql.table.Table` config declares one).
+          rendered using the inner aliases (qualified columns and plain
+          aggregate calls). Star projections never reach here — they decline
+          upstream (#202) — nor do the naive-valid shapes the projection
+          pre-scan declines (expressions, window aggregates, FILTER clauses,
+          scalar subqueries, aggregate-nested stars — #204, #205).
         * ``projection_map`` binds each ``(normalized_alias, column_name)``
           referenced anywhere in the query to its inner alias name so the
           wrapper-relation rewriter and aggregate-argument rewriting can
           translate user-written references to the wrapper relation.
 
-        Raises :class:`_UnqualifiedProjectionError` for SELECT-list shapes
-        the dialect cannot translate (bare ``*``, unqualified column,
-        unknown table qualifier, ``a.* AS x``, window aggregate, ``FILTER``
-        clause, scalar subquery, arithmetic over an aggregate, aggregate
-        over an unqualified column), and (when ``sides.is_left_only_join``)
-        any reference to the right side of the join.
+        Raises :class:`_DeclineIEJoin` (caught upstream, declining to the naive
+        plan) for a SELECT-list shape the naive plan handles but the rebuild
+        cannot express. Raises :class:`_UnqualifiedProjectionError` only for a
+        genuine user error the naive plan also rejects — an unqualified column,
+        an unknown table qualifier, an aggregate over an unqualified column, or
+        (when ``sides.is_left_only_join``) a reference to the right side.
         """
-        l_chrom, l_start, l_end = l_cols
-        r_chrom, r_start, r_end = r_cols
         q = self._sql_quote_ident
         l_alias = sides.left_user_alias
         r_alias = sides.right_user_alias
 
-        def star_columns(
-            table: Table | None, defaults: tuple[str, str, str]
-        ) -> tuple[str, ...]:
-            """Expand ``a.*`` / ``b.*`` to the genomic columns declared by
-            the :class:`~giql.table.Table` config (chrom / start / end, plus
-            ``strand_col`` when set). Without this, ``strand_col`` would
-            silently disappear under ``dialect='duckdb'`` even when the
-            user has registered it.
-            """
-            chrom, start, end = defaults
-            if table is not None and table.strand_col:
-                return (chrom, start, end, table.strand_col)
-            return (chrom, start, end)
+        # Decline (fall back to the naive-predicate plan) for any projection the
+        # IEJoin cannot rebuild but the naive plan handles — an expression, a
+        # window aggregate, a FILTER clause, a scalar subquery, an aggregate
+        # nested in an expression, or a star nested in an aggregate argument
+        # (#204, #205). Run before any allocation so an aggregate-nested star
+        # (COUNT(a.*)) declines rather than allocating a bogus ``a."*"`` column.
+        # A projection with an out-of-scope column reference is a user error the
+        # naive plan also rejects, so it is left to the dispatch below to raise.
+        for sel in query.expressions:
+            target = sel.this if isinstance(sel, exp.Alias) else sel
+            while isinstance(target, exp.Paren):
+                target = target.this
+            if _projection_declines_to_naive(
+                target, l_alias, r_alias, sides.is_left_only_join
+            ):
+                raise _DeclineIEJoin(
+                    f"dialect='duckdb' cannot rebuild projection {target.sql()!r}; "
+                    "deferring to the naive-predicate plan."
+                )
 
         inner_projections: list[str] = []
         projection_map: dict[tuple[str, str], str] = {}
@@ -1156,51 +1351,17 @@ class IntersectsDuckDBIEJoinTransformer:
         for sel in query.expressions:
             target = sel.this if isinstance(sel, exp.Alias) else sel
             user_alias = sel.alias if isinstance(sel, exp.Alias) else None
-            # Peel paren wrappers at the top of dispatch so paren-wrapped
-            # aggregates like ``(SUM(a.score)) AS s`` route through the
-            # AggFunc branch below, and paren-wrapped diagnostic shapes
-            # (``(SUM(a.score) OVER (...))``) hit the targeted error
-            # branches below rather than the generic catch-all.
+            # Peel paren wrappers at the top of dispatch so a paren-wrapped
+            # aggregate like ``(SUM(a.score)) AS s`` routes through the AggFunc
+            # branch below rather than the generic catch-all.
             while isinstance(target, exp.Paren):
                 target = target.this
 
-            if isinstance(target, exp.Star) and not isinstance(sel, exp.Column):
-                raise _UnqualifiedProjectionError(
-                    "dialect='duckdb' requires qualified projections; bare '*' "
-                    "is not supported. Use 'a.*', 'b.*', or qualified columns."
-                )
-
-            if isinstance(target, exp.Column) and isinstance(target.this, exp.Star):
-                # Reject ``a.* AS x`` — most SQL engines reject
-                # star-with-alias outright, and the dialect has no
-                # reasonable interpretation (apply ``x`` as a prefix?
-                # as a single composite column name?).
-                if user_alias is not None:
-                    raise _UnqualifiedProjectionError(
-                        "dialect='duckdb' does not support star projections "
-                        f"with a user alias; got {sel.sql()!r}. Either drop "
-                        "the alias (use ``a.*``) or list the columns "
-                        "explicitly with per-column aliases."
-                    )
-                tbl = _normalize_alias(target.table) if target.table else ""
-                if tbl == l_alias:
-                    cols = star_columns(l_table, (l_chrom, l_start, l_end))
-                elif tbl == r_alias:
-                    cols = star_columns(r_table, (r_chrom, r_start, r_end))
-                else:
-                    raise _UnqualifiedProjectionError(
-                        f"Unknown table qualifier {target.table!r} in projection; "
-                        f"expected {l_alias!r} or {r_alias!r}."
-                    )
-                reject_right_side_if_left_only(tbl, sel.sql())
-                # Expand to the genomic columns the Table config knows
-                # about; arbitrary additional columns require explicit
-                # listing since schema introspection isn't available at
-                # transpile time.
-                for col in cols:
-                    alias = allocate(tbl, col)
-                    outer_projections.append(f"{alias} AS {q(col)}")
-                continue
+            # Star projections (bare ``*`` and ``a.*`` / ``b.*``) never reach
+            # here — :func:`_has_star_projection` declines them upstream (#202) —
+            # and neither do the naive-valid shapes the projection pre-scan
+            # above declined (expressions / window aggregates / FILTER clauses /
+            # scalar subqueries / aggregate-nested stars — #204, #205).
 
             if isinstance(target, exp.AggFunc):
                 render_aggregate(target, user_alias)
@@ -1215,61 +1376,26 @@ class IntersectsDuckDBIEJoinTransformer:
                 outer_projections.append(f"{alias} AS {q(outer_name)}")
                 continue
 
-            # Diagnostic branches for shapes the dialect deliberately
-            # rejects. Specialize the error message when we can recognize
-            # the unsupported shape so the user isn't told "use a
-            # qualified column" when they actually wrote an aggregate
-            # variant the dispatcher couldn't classify. Direct-isinstance
-            # branches catch bare shapes; the ``target.find(...)`` branches
-            # below catch nested forms (``CAST(SUM(a.x) OVER (...) AS
-            # DOUBLE)`` etc.) before they fall through to the generic
-            # AggFunc-found catch-all.
-            if isinstance(target, exp.Window):
-                raise _UnqualifiedProjectionError(
-                    "dialect='duckdb' does not support window aggregates "
-                    f"in the SELECT list; got {target.sql()!r}. Either "
-                    "drop the OVER (...) clause, or omit dialect='duckdb' "
-                    "to use the generic naive-predicate plan."
-                )
-            if isinstance(target, exp.Filter):
-                raise _UnqualifiedProjectionError(
-                    "dialect='duckdb' does not support FILTER (WHERE ...) "
-                    f"clauses on aggregates; got {target.sql()!r}. Either "
-                    "rewrite the FILTER as a WHERE predicate alongside "
-                    "the INTERSECTS, or omit dialect='duckdb'."
-                )
-            if isinstance(target, exp.Subquery):
-                # A scalar subquery in the SELECT list (e.g.
-                # ``(SELECT SUM(x) FROM other_table)``) is shaped like an
-                # aggregate but doesn't fit the dialect's projection rules.
-                raise _UnqualifiedProjectionError(
-                    "dialect='duckdb' does not support scalar subqueries in "
-                    f"the SELECT list; got {target.sql()!r}. Either rewrite "
-                    "without the subquery, or omit dialect='duckdb' to use "
-                    "the generic naive-predicate plan."
-                )
-            if target.find(exp.Window) is not None:
-                raise _UnqualifiedProjectionError(
-                    "dialect='duckdb' does not support window aggregates "
-                    f"in the SELECT list; got {target.sql()!r}. Either "
-                    "drop the OVER (...) clause, or omit dialect='duckdb' "
-                    "to use the generic naive-predicate plan."
-                )
-            if target.find(exp.Filter) is not None:
-                raise _UnqualifiedProjectionError(
-                    "dialect='duckdb' does not support FILTER (WHERE ...) "
-                    f"clauses on aggregates; got {target.sql()!r}. Either "
-                    "rewrite the FILTER as a WHERE predicate alongside "
-                    "the INTERSECTS, or omit dialect='duckdb'."
-                )
-            if target.find(exp.AggFunc) is not None:
-                raise _UnqualifiedProjectionError(
-                    "dialect='duckdb' does not support aggregates inside "
-                    f"arithmetic or function expressions; got {target.sql()!r}. "
-                    "Project the underlying aggregate as its own column and "
-                    "do the arithmetic in a wrapping query, or omit "
-                    "dialect='duckdb'."
-                )
+            # Everything reaching here is an unsupported wrapper (an
+            # expression, a window aggregate, a FILTER clause, or an aggregate
+            # nested in an expression) that the pre-scan did NOT decline because
+            # it references an out-of-scope column — an unqualified column, an
+            # unknown table, or the right side under a SEMI / ANTI join (e.g.
+            # ``SUM(score) OVER (...)``, ``score + 1``). A plain aggregate with
+            # an unqualified argument (``SUM(score)``) is diagnosed earlier in
+            # ``render_aggregate``.
+            #
+            # A right-side column wrapped in an unsupported shape under a
+            # left-only join gets the dedicated left-side-only message rather
+            # than the generic "qualify the column" one, which would steer the
+            # user toward another invalid form (``b.col`` is never valid here).
+            for col in target.find_all(exp.Column):
+                col_table = _normalize_alias(col.table) if col.table else ""
+                reject_right_side_if_left_only(col_table, target.sql())
+            # Otherwise the fault is an unqualified / unknown-table column; the
+            # accurate guidance is to qualify it (once qualified, the wrapper
+            # itself declines to the naive plan — #204, #205 — rather than
+            # erroring).
             raise _UnqualifiedProjectionError(
                 "dialect='duckdb' requires qualified projections; got "
                 f"{target.sql()!r}. Use a qualified column reference like "

--- a/tests/test_duckdb_iejoin.py
+++ b/tests/test_duckdb_iejoin.py
@@ -637,8 +637,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         with pytest.raises(ValueError, match=r"[Uu]nknown dialect.*'postgres'"):
             transpile(query, tables=["peaks"], dialect="postgres")
 
-    def test_transpile_should_raise_when_select_has_unqualified_wildcard(self):
-        """Test that bare ``SELECT *`` is rejected under the DuckDB dialect.
+    def test_transpile_should_decline_bare_star_to_naive_plan_when_dialect_is_duckdb(
+        self,
+    ):
+        """Test that bare ``SELECT *`` declines to the naive-predicate plan.
 
         Given:
             A column-to-column INTERSECTS JOIN whose projection is a bare
@@ -646,8 +648,9 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            It should raise ``ValueError`` whose message mentions
-            "qualified" projections.
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding)
+            so DuckDB expands the star against the live schema (#202),
+            rather than raising or silently narrowing the projection.
         """
         # Arrange
         query = """
@@ -656,9 +659,12 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             JOIN genes b ON a.interval INTERSECTS b.interval
             """
 
-        # Act & assert
-        with pytest.raises(ValueError, match="qualified"):
-            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
 
     # --- DI-001..DI-009: new SQL-structure / contract tests --------------
 
@@ -1601,94 +1607,88 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_raise_with_window_specific_message_when_window_aggregate_in_select(
-        self,
-    ):
-        """Test that a window-aggregate projection raises with a targeted message.
+    def test_transpile_should_decline_window_aggregate_to_naive_plan(self):
+        """Test that a window-aggregate projection declines to the naive plan.
 
         Given:
             A SELECT list containing ``SUM(a.score) OVER (PARTITION BY
-            a.chrom)`` — a window aggregate, which the dispatcher does
-            not classify as ``exp.AggFunc``.
+            a.chrom)`` — a window aggregate over qualified columns the IEJoin
+            projection rebuild cannot express.
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            A ``ValueError`` is raised whose message names "window
-            aggregates" (rather than the generic "qualified
-            projections" message).
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan evaluates the window aggregate (#205).
         """
-        # Act & assert
-        with pytest.raises(ValueError) as excinfo:
-            transpile(
-                "SELECT a.chrom AS c, "
-                "SUM(a.score) OVER (PARTITION BY a.chrom) AS s "
-                "FROM peaks a JOIN genes b "
-                "ON a.interval INTERSECTS b.interval",
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-            )
-        assert "window" in str(excinfo.value).lower()
-
-    def test_transpile_should_raise_with_window_message_when_paren_wrapped_window_aggregate(
-        self,
-    ):
-        """Test that ``(SUM(a.score) OVER (...))`` gets the targeted window message.
-
-        Given:
-            A paren-wrapped window aggregate in the SELECT list. The
-            Paren wrapper hides the inner ``exp.Window`` from the
-            non-peeled type check that the diagnostic branches used to
-            rely on.
-        When:
-            ``transpile`` is called with ``dialect='duckdb'``.
-        Then:
-            The dispatcher peels the Paren and routes to the window
-            diagnostic branch, raising the dedicated window-aggregate
-            message rather than the generic
-            arithmetic-over-aggregate one.
-        """
-        # Act & assert
-        with pytest.raises(ValueError) as excinfo:
-            transpile(
-                "SELECT a.chrom AS c, "
-                "(SUM(a.score) OVER (PARTITION BY a.chrom)) AS s "
-                "FROM peaks a JOIN genes b "
-                "ON a.interval INTERSECTS b.interval",
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-            )
-        assert "window" in str(excinfo.value).lower()
-
-    def test_transpile_should_raise_with_aggregate_in_expression_message_when_count_in_arithmetic(
-        self,
-    ):
-        """Test that arithmetic over an aggregate raises with a targeted message.
-
-        Given:
-            A SELECT list containing ``COUNT(*) * 2`` — arithmetic over
-            an aggregate, which the dispatcher does not classify as
-            ``exp.AggFunc``.
-        When:
-            ``transpile`` is called with ``dialect='duckdb'``.
-        Then:
-            A ``ValueError`` is raised whose message names aggregates
-            inside expressions (rather than the generic "qualified
-            projections" message).
-        """
-        # Act & assert
-        with pytest.raises(ValueError) as excinfo:
-            transpile(
-                "SELECT a.chrom AS c, COUNT(*) * 2 AS doubled "
-                "FROM peaks a JOIN genes b "
-                "ON a.interval INTERSECTS b.interval "
-                "GROUP BY a.chrom",
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-            )
-        message = str(excinfo.value).lower()
-        assert "aggregate" in message and (
-            "expression" in message or "arithmetic" in message
+        # Act
+        sql = transpile(
+            "SELECT a.chrom AS c, "
+            "SUM(a.score) OVER (PARTITION BY a.chrom) AS s "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
         )
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    def test_transpile_should_decline_paren_wrapped_window_aggregate_to_naive_plan(
+        self,
+    ):
+        """Test that ``(SUM(a.score) OVER (...))`` declines to the naive plan.
+
+        Given:
+            A paren-wrapped window aggregate over qualified columns in the
+            SELECT list.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            The dispatcher peels the Paren and declines the IEJoin (no ``SET
+            VARIABLE`` scaffolding) so the naive-predicate plan handles the
+            window aggregate (#205).
+        """
+        # Act
+        sql = transpile(
+            "SELECT a.chrom AS c, "
+            "(SUM(a.score) OVER (PARTITION BY a.chrom)) AS s "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    def test_transpile_should_decline_aggregate_in_expression_to_naive_plan(self):
+        """Test that arithmetic over an aggregate declines to the naive plan.
+
+        Given:
+            A SELECT list containing ``COUNT(*) * 2`` — an aggregate nested in
+            an arithmetic expression the IEJoin projection rebuild cannot
+            express.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan evaluates the expression (#205).
+        """
+        # Act
+        sql = transpile(
+            "SELECT a.chrom AS c, COUNT(*) * 2 AS doubled "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval "
+            "GROUP BY a.chrom",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
 
     def test_transpile_should_route_to_naive_predicate_plan_when_modifier_has_subquery(
         self,
@@ -1810,34 +1810,33 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         assert "a.score" not in outer_select
         assert re.search(r"SUM\(__giql_p\d+\)", outer_select) is not None
 
-    def test_transpile_should_raise_with_subquery_specific_message_when_scalar_subquery_in_select(
-        self,
-    ):
-        """Test that a scalar subquery in SELECT gets a targeted error.
+    def test_transpile_should_decline_scalar_subquery_to_naive_plan(self):
+        """Test that a scalar subquery in the SELECT list declines to the naive plan.
 
         Given:
-            A SELECT list containing a scalar subquery that itself
-            contains an aggregate (``(SELECT SUM(score) FROM
-            other_table)``). Previously this hit the
-            arithmetic-over-aggregate message with misleading guidance.
+            A SELECT list containing a scalar subquery
+            (``(SELECT SUM(score) FROM peaks)``) — the subquery's columns
+            resolve against its own scope, and the IEJoin projection rebuild
+            cannot express it.
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            A ``ValueError`` whose message names the scalar-subquery
-            shape (rather than steering the user toward "do the
-            arithmetic in a wrapping query").
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan evaluates the subquery (#205).
         """
-        # Act & assert
-        with pytest.raises(ValueError) as excinfo:
-            transpile(
-                "SELECT a.chrom AS c, "
-                "(SELECT SUM(score) FROM peaks) AS s "
-                "FROM peaks a JOIN genes b "
-                "ON a.interval INTERSECTS b.interval",
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-            )
-        assert "subquer" in str(excinfo.value).lower()
+        # Act
+        sql = transpile(
+            "SELECT a.chrom AS c, "
+            "(SELECT SUM(score) FROM peaks) AS s "
+            "FROM peaks a JOIN genes b "
+            "ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
 
     def test_transpile_should_route_to_naive_predicate_plan_when_query_has_distinct_on(
         self,
@@ -2138,17 +2137,17 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         with pytest.raises(ValueError, match="[Uu]nknown.*qualifier|'c'"):
             transpile(query, tables=["peaks", "genes"], dialect="duckdb")
 
-    def test_transpile_should_raise_when_projection_uses_expression_form(self):
-        """Test that an arithmetic projection expression is rejected.
+    def test_transpile_should_decline_expression_form_projection_to_naive_plan(self):
+        """Test that an arithmetic projection expression declines to the naive plan.
 
         Given:
-            A SELECT list containing an expression
+            A SELECT list containing an expression over a qualified column
             (``a.start + 1``) rather than a bare qualified column.
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            It should raise ``ValueError`` whose message mentions
-            "qualified".
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan evaluates the expression (#205).
         """
         # Arrange
         query = """
@@ -2157,18 +2156,17 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             JOIN genes b ON a.interval INTERSECTS b.interval
             """
 
-        # Act & assert — message should echo the offending expression so
-        # the user can spot which projection to rewrite.
-        with pytest.raises(ValueError) as excinfo:
-            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
-        message = str(excinfo.value)
-        assert "qualified" in message
-        assert "a.start + 1" in message or "a.start" in message
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
 
-    def test_transpile_should_raise_when_star_qualifier_references_unknown_table(
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    def test_transpile_should_decline_star_with_unknown_qualifier_to_naive_plan(
         self,
     ):
-        """Test that ``c.*`` against an out-of-scope alias is rejected.
+        """Test that ``c.*`` against an out-of-scope alias declines to naive.
 
         Given:
             A SELECT list with a qualified-star projection ``c.*`` whose
@@ -2176,8 +2174,10 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            It should raise ``ValueError`` whose message names the
-            unknown qualifier.
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding)
+            like every star (#202) and defer the out-of-scope qualifier to
+            DuckDB's binder, which rejects it at execution — matching the
+            naive-predicate plan rather than raising at transpile time.
         """
         # Arrange
         query = """
@@ -2186,9 +2186,12 @@ class TestTranspileDuckDBIEJoinSQLStructure:
             JOIN genes b ON a.interval INTERSECTS b.interval
             """
 
-        # Act & assert
-        with pytest.raises(ValueError, match="[Uu]nknown.*qualifier|'c'"):
-            transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
 
     def test_transpile_should_use_unique_variable_names_across_interleaved_calls(
         self, conn
@@ -2689,34 +2692,34 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Assert
         assert "SET VARIABLE __giql_iejoin_" not in sql
 
-    def test_transpile_should_raise_when_select_projects_a_literal(self):
-        """Test that a literal-only SELECT-list entry raises ``ValueError``.
+    def test_transpile_should_decline_literal_projection_to_naive_plan(self):
+        """Test that a literal-only SELECT-list entry declines to the naive plan.
 
         Given:
             A query whose SELECT list contains a bare integer literal
-            (``SELECT 100 FROM peaks a JOIN ...``).
+            (``SELECT 100 FROM peaks a JOIN ...``) — a constant projection
+            with no column the IEJoin projection rebuild handles.
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            A ``ValueError`` matching ``qualified`` should be raised
-            and the offending literal text should appear in the message.
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan projects the literal (#205).
         """
-        # Act & assert
-        with pytest.raises(ValueError) as excinfo:
-            transpile(
-                "SELECT 100 FROM peaks a "
-                "JOIN genes b ON a.interval INTERSECTS b.interval",
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-            )
-        message = str(excinfo.value)
-        assert "qualified" in message
-        assert "100" in message
+        # Act
+        sql = transpile(
+            "SELECT 100 FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
 
-    def test_transpile_should_raise_when_star_projection_carries_a_user_alias(
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    def test_transpile_should_decline_aliased_star_to_naive_plan(
         self,
     ):
-        """Test that ``SELECT a.* AS x`` is rejected rather than silently stripped.
+        """Test that ``SELECT a.* AS x`` declines to the naive-predicate plan.
 
         Given:
             A query with a star projection that also has a user alias
@@ -2724,29 +2727,34 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
-            A ``ValueError`` should be raised mentioning the
-            unsupported alias and pointing at concrete alternatives
-            (drop the alias, or list columns explicitly).
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding)
+            like every star (#202) and defer the aliased-star shape to
+            DuckDB — matching the naive-predicate plan rather than raising
+            at transpile time.
         """
-        # Act & assert
-        with pytest.raises(ValueError) as excinfo:
-            transpile(
-                "SELECT a.* AS x FROM peaks a "
-                "JOIN genes b ON a.interval INTERSECTS b.interval",
-                tables=["peaks", "genes"],
-                dialect="duckdb",
-            )
-        message = str(excinfo.value).lower()
-        assert "star" in message or "alias" in message
+        # Act
+        sql = transpile(
+            "SELECT a.* AS x FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
 
     def test_transpile_should_surface_value_error_for_unqualified_projection_under_dialect(
         self,
     ):
-        """Test that the dialect surfaces a plain ``ValueError`` on bare ``*``.
+        """Test that the dialect surfaces a plain ``ValueError`` on an unqualified column.
 
         Given:
             A query that triggers the dialect's unqualified-projection
-            rejection (bare ``SELECT *``).
+            rejection (an unqualified column ``SELECT score``). Bare
+            ``SELECT *`` no longer raises — stars decline to the naive
+            plan (#202) — so an unqualified column is the shape that still
+            exercises this contract.
         When:
             ``transpile`` is called with ``dialect='duckdb'``.
         Then:
@@ -2759,7 +2767,8 @@ class TestTranspileDuckDBIEJoinSQLStructure:
         # Act & assert
         with pytest.raises(ValueError) as excinfo:
             transpile(
-                "SELECT * FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval",
+                "SELECT score FROM peaks a "
+                "JOIN genes b ON a.interval INTERSECTS b.interval",
                 tables=["peaks", "genes"],
                 dialect="duckdb",
             )
@@ -3417,37 +3426,51 @@ class TestTranspileDuckDBIEJoinExecution:
 
     # --- DX-001..DX-011: behavioral truth tables -------------------------
 
-    def test_query_should_expand_qualified_star_when_dialect_is_duckdb(self, conn):
-        """Test that ``a.*, b.*`` expands to the genomic columns plus strand of each side.
+    def test_query_should_preserve_all_columns_for_qualified_star_when_dialect_is_duckdb(
+        self, conn
+    ):
+        """Test that ``a.*, b.*`` preserves every base-table column, matching the naive plan.
 
         Given:
-            A ``SELECT a.*, b.*`` projection over an INTERSECTS join.
+            A ``SELECT a.*, b.*`` projection over an INTERSECTS join, where
+            each table carries non-genomic columns (``name`` / ``score``)
+            beyond the configured chrom / start / end / strand.
         When:
-            The query is transpiled with ``dialect='duckdb'`` and executed.
+            The query is transpiled with ``dialect='duckdb'`` and executed,
+            and separately with ``dialect=None``.
         Then:
-            Each row should carry chrom / start / end plus strand from
-            both sides (the default Table config declares strand_col),
-            and the result should contain the expected overlap pair.
+            The DuckDB path should decline the IEJoin (#202) so the star
+            expands against the live schema — the result carries every
+            base-table column from both sides (not just the genomic subset),
+            identical in columns and rows to the naive-predicate plan.
         """
         # Arrange
         _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
         _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
-        sql = transpile(
-            """
+        query = """
             SELECT a.*, b.*
             FROM peaks a
             JOIN genes b ON a.interval INTERSECTS b.interval
-            """,
-            tables=["peaks", "genes"],
-            dialect="duckdb",
-        )
+            """
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
 
         # Act
-        result = conn.execute(sql)
-        rows = result.fetchall()
+        result_dd = conn.execute(sql_dd)
+        cols_dd = [d[0] for d in result_dd.description]
+        rows_dd = result_dd.fetchall()
+        result_naive = conn.execute(sql_naive)
+        cols_naive = [d[0] for d in result_naive.description]
+        rows_naive = result_naive.fetchall()
 
         # Assert
-        assert rows == [("chr1", 100, 200, "+", "chr1", 150, 250, "-")]
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert cols_dd == ["chrom", "start", "end", "name", "score", "strand"] * 2
+        assert rows_dd == [
+            ("chr1", 100, 200, "p1", 7, "+", "chr1", 150, 250, "g1", 9, "-")
+        ]
+        assert cols_dd == cols_naive
+        assert rows_dd == rows_naive
 
     def test_query_should_propagate_user_alias_on_qualified_column(self, conn):
         """Test that a ``a.start AS s`` alias survives the IEJoin rewrite.
@@ -6114,3 +6137,707 @@ class TestTranspileDuckDBIEJoinKwargs:
         message = str(excinfo.value)
         assert "Unknown dialect" in message
         assert "'postgres'" in message
+
+
+class TestTranspileDuckDBIEJoinLeftOnlyWhereIntersects:
+    """Regression tests for #201.
+
+    A ``SEMI`` / ``ANTI`` join whose column-to-column ``INTERSECTS`` lives in
+    the top-level ``WHERE`` (out of scope for the right table after a left-only
+    join) must decline the IEJoin rewrite so the naive-predicate plan surfaces
+    the same binder error the reference plans raise — rather than relocating
+    the predicate into the join and inventing anti/semi-overlap results.
+    """
+
+    @pytest.mark.parametrize("kind", ["ANTI", "SEMI"])
+    @pytest.mark.parametrize(
+        "on_clause", ["ON TRUE", "ON FALSE", "ON a.score > b.score"]
+    )
+    def test_transpile_should_decline_left_only_where_intersects_to_naive_plan(
+        self, kind, on_clause
+    ):
+        """Test that a SEMI/ANTI join with a WHERE-INTERSECTS declines to naive.
+
+        Given:
+            A ``SEMI`` / ``ANTI`` join carrying an arbitrary ``ON`` clause and
+            the column-to-column ``INTERSECTS`` in the top-level ``WHERE``.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan handles the out-of-scope WHERE reference,
+            regardless of the ignored ``ON`` content.
+        """
+        # Arrange
+        query = (
+            f"SELECT a.name FROM peaks a {kind} JOIN genes b {on_clause} "
+            "WHERE a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    @pytest.mark.parametrize("kind", ["ANTI", "SEMI"])
+    def test_query_should_raise_binder_error_for_where_intersects_like_naive_plan(
+        self, conn, kind
+    ):
+        """Test that DuckDB rejects the WHERE-INTERSECTS shape as the naive plan does.
+
+        Given:
+            A ``SEMI`` / ``ANTI`` join with ``ON TRUE`` and the ``INTERSECTS``
+            in the ``WHERE`` (right table out of scope), plus fixture data.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and with
+            ``dialect=None`` and both are executed.
+        Then:
+            Both should raise a DuckDB binder error naming the out-of-scope
+            right table — the dialect no longer diverges by silently inventing
+            results.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            f"SELECT a.name FROM peaks a {kind} JOIN genes b ON TRUE "
+            "WHERE a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act & assert
+        with pytest.raises(duckdb.Error, match='(?i)referenced table "?b"? not found'):
+            conn.execute(sql_dd)
+        with pytest.raises(duckdb.Error, match='(?i)referenced table "?b"? not found'):
+            conn.execute(sql_naive)
+
+    @pytest.mark.parametrize("kind", ["ANTI", "SEMI"])
+    def test_transpile_should_still_engage_iejoin_for_idiomatic_on_intersects(
+        self, kind
+    ):
+        """Test that the idiomatic SEMI/ANTI ON-INTERSECTS form still uses the IEJoin.
+
+        Given:
+            The well-formed shape with the ``INTERSECTS`` in the join's own
+            ``ON`` clause (the right table is legitimately in scope there).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should still engage the IEJoin path (``SET VARIABLE
+            __giql_iejoin_`` emitted) — the #201 decline must not over-reach
+            and disable the supported idiomatic form.
+        """
+        # Arrange
+        query = (
+            f"SELECT a.name FROM peaks a {kind} JOIN genes b "
+            "ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+
+    def test_query_should_not_change_idiomatic_anti_result_after_decline_gate(
+        self, peaks_genes
+    ):
+        """Test that the idiomatic ANTI ON-INTERSECTS still returns correct rows.
+
+        Given:
+            The idiomatic ``ANTI JOIN ... ON a.interval INTERSECTS b.interval``
+            over the shared fixture (peaks with no overlapping gene survive).
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed.
+        Then:
+            It should return exactly the left rows with no overlap, matching
+            the naive-predicate plan — confirming the new gate left the
+            supported path untouched.
+        """
+        # Arrange
+        conn = peaks_genes
+        query = (
+            "SELECT a.name FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_dd = sorted(conn.execute(sql_dd).fetchall())
+        rows_naive = sorted(conn.execute(sql_naive).fetchall())
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql_dd
+        assert rows_dd == rows_naive
+        assert rows_dd == [("p2",), ("p5",)]
+
+
+class TestTranspileDuckDBIEJoinStarProjectionFallback:
+    """Regression tests for #202.
+
+    Star projections (bare ``*``, ``a.*``, ``b.*``, ``a.* AS x``) must decline
+    the IEJoin rewrite so DuckDB expands the real star against the live schema,
+    keeping every base-table column and staying identical to the naive plan —
+    rather than silently narrowing the projection to the configured genomic
+    columns.
+    """
+
+    @pytest.mark.parametrize(
+        "projection",
+        ["a.*", "b.*", "a.*, b.*", "*", "a.* AS x", "a.chrom, b.*"],
+    )
+    def test_transpile_should_decline_star_projection_to_naive_plan(self, projection):
+        """Test that every star projection shape declines the IEJoin.
+
+        Given:
+            A column-to-column INTERSECTS INNER join whose SELECT list carries
+            a star in some form (bare, qualified, aliased, or mixed).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan expands the star against the live schema.
+        """
+        # Arrange
+        query = (
+            f"SELECT {projection} FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    def test_query_should_match_naive_plan_for_a_star_under_anti(self, conn):
+        """Test the #202 repro: ``a.*`` under ANTI preserves every column.
+
+        Given:
+            The exact issue reproduction — ``SELECT a.*`` over an ANTI join
+            with one non-overlapping left row carrying ``name`` / ``score``
+            beyond the configured genomic columns.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed,
+            and separately with ``dialect=None``.
+        Then:
+            The DuckDB result should carry all six base-table columns
+            (``name`` / ``score`` no longer dropped) and equal the naive plan
+            in both columns and rows.
+        """
+        # Arrange
+        _make_table(
+            conn,
+            "peaks",
+            [("chr1", 100, 200, "p1", 7, "+"), ("chr1", 700, 800, "p3", 30, "+")],
+        )
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            "SELECT a.* FROM peaks a "
+            "ANTI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        res_dd = conn.execute(sql_dd)
+        cols_dd = [d[0] for d in res_dd.description]
+        rows_dd = res_dd.fetchall()
+        res_naive = conn.execute(sql_naive)
+        cols_naive = [d[0] for d in res_naive.description]
+        rows_naive = res_naive.fetchall()
+
+        # Assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert cols_dd == ["chrom", "start", "end", "name", "score", "strand"]
+        assert rows_dd == [("chr1", 700, 800, "p3", 30, "+")]
+        assert cols_dd == cols_naive
+        assert rows_dd == rows_naive
+
+    def test_query_should_match_naive_plan_for_bare_star(self, conn):
+        """Test that bare ``SELECT *`` returns both tables' full columns.
+
+        Given:
+            A ``SELECT *`` over an INNER INTERSECTS join, each table carrying
+            non-genomic columns.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed,
+            and separately with ``dialect=None``.
+        Then:
+            The DuckDB result should carry all twelve columns (both tables'
+            full schema) and equal the naive plan in columns and rows.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = "SELECT * FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval"
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        res_dd = conn.execute(sql_dd)
+        cols_dd = [d[0] for d in res_dd.description]
+        rows_dd = res_dd.fetchall()
+        res_naive = conn.execute(sql_naive)
+        cols_naive = [d[0] for d in res_naive.description]
+        rows_naive = res_naive.fetchall()
+
+        # Assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert cols_dd == ["chrom", "start", "end", "name", "score", "strand"] * 2
+        assert rows_dd == [
+            ("chr1", 100, 200, "p1", 7, "+", "chr1", 150, 250, "g1", 9, "-")
+        ]
+        assert cols_dd == cols_naive
+        assert rows_dd == rows_naive
+
+    def test_transpile_should_still_engage_iejoin_for_explicit_columns(self):
+        """Test that explicit (non-star) qualified projections still use the IEJoin.
+
+        Given:
+            A projection listing explicit qualified columns (no star).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should still engage the IEJoin path (``SET VARIABLE
+            __giql_iejoin_`` emitted) — the #202 star decline must not
+            over-reach and disable non-star projections.
+        """
+        # Arrange
+        query = (
+            "SELECT a.chrom, a.start, a.name, b.score FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql
+
+    def test_query_should_match_naive_plan_for_a_star_under_semi(self, conn):
+        """Test that ``a.*`` under SEMI preserves every column, matching the naive plan.
+
+        Given:
+            A ``SELECT a.*`` over a SEMI join, where the one matching left
+            row carries ``name`` / ``score`` beyond the genomic columns.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed,
+            and separately with ``dialect=None``.
+        Then:
+            The DuckDB result should carry all six base-table columns and
+            equal the naive plan in both columns and rows — the star decline
+            preserves the full projection under SEMI just as under ANTI/INNER.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            "SELECT a.* FROM peaks a "
+            "SEMI JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        res_dd = conn.execute(sql_dd)
+        cols_dd = [d[0] for d in res_dd.description]
+        rows_dd = res_dd.fetchall()
+        res_naive = conn.execute(sql_naive)
+        cols_naive = [d[0] for d in res_naive.description]
+        rows_naive = res_naive.fetchall()
+
+        # Assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert cols_dd == ["chrom", "start", "end", "name", "score", "strand"]
+        assert rows_dd == [("chr1", 100, 200, "p1", 7, "+")]
+        assert cols_dd == cols_naive
+        assert rows_dd == rows_naive
+
+    def test_query_should_match_naive_plan_for_aliased_star(self, conn):
+        """Test that ``a.* AS x`` executes to the same result as the naive plan.
+
+        Given:
+            A ``SELECT a.* AS x`` projection over an INNER INTERSECTS join.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed,
+            and separately with ``dialect=None``.
+        Then:
+            The declined DuckDB plan should be genuinely executable and
+            produce the same columns and rows as the naive plan (DuckDB
+            applies the alias uniformly across the expanded star), confirming
+            the fallback is not a broken shape.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            "SELECT a.* AS x FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        res_dd = conn.execute(sql_dd)
+        cols_dd = [d[0] for d in res_dd.description]
+        rows_dd = res_dd.fetchall()
+        res_naive = conn.execute(sql_naive)
+        cols_naive = [d[0] for d in res_naive.description]
+        rows_naive = res_naive.fetchall()
+
+        # Assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert cols_dd == cols_naive
+        assert rows_dd == rows_naive
+        assert rows_dd == [("chr1", 100, 200, "p1", 7, "+")]
+
+    @pytest.mark.parametrize("kind", ["ANTI", "SEMI"])
+    def test_query_should_raise_for_right_star_under_left_only_join_like_naive_plan(
+        self, conn, kind
+    ):
+        """Test that a right-side ``b.*`` under SEMI/ANTI errors as the naive plan does.
+
+        Given:
+            A ``SELECT b.*`` projection over a SEMI / ANTI join — the right
+            table is out of scope in a left-only join's output.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and with
+            ``dialect=None`` and both are executed.
+        Then:
+            Both should raise the same DuckDB binder error naming the
+            out-of-scope right table — the star decline defers the rejection
+            to DuckDB rather than raising a bespoke transpile-time error.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            f"SELECT b.* FROM peaks a {kind} JOIN genes b "
+            "ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act & assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        with pytest.raises(duckdb.Error, match='(?i)referenced table "?b"? not found'):
+            conn.execute(sql_dd)
+        with pytest.raises(duckdb.Error, match='(?i)referenced table "?b"? not found'):
+            conn.execute(sql_naive)
+
+    def test_query_should_raise_for_unknown_qualifier_star_like_naive_plan(self, conn):
+        """Test that ``c.*`` errors at execution as the naive plan does.
+
+        Given:
+            A ``SELECT c.*`` projection whose qualifier ``c`` is not one of
+            the join's two tables.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and with
+            ``dialect=None`` and both are executed.
+        Then:
+            Both should raise the same DuckDB binder error naming the unknown
+            table — the star decline defers the rejection to DuckDB rather
+            than raising at transpile time.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            "SELECT c.* FROM peaks a JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act & assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        with pytest.raises(duckdb.Error, match='(?i)referenced table "?c"? not found'):
+            conn.execute(sql_dd)
+        with pytest.raises(duckdb.Error, match='(?i)referenced table "?c"? not found'):
+            conn.execute(sql_naive)
+
+
+class TestTranspileDuckDBIEJoinUnsupportedProjectionFallback:
+    """Regression tests for #204 and #205.
+
+    Projections the naive-predicate plan compiles but the IEJoin projection
+    rebuild cannot express — expressions (``a.start + 1``), window aggregates,
+    ``FILTER`` clauses, scalar subqueries, aggregates nested in expressions
+    (``COUNT(*) * 2``), and stars nested in an aggregate argument
+    (``COUNT(a.*)`` / ``MIN(COLUMNS(*))``) — must decline the IEJoin and fall
+    back to the naive plan, keeping ``dialect="duckdb"`` consistent with every
+    other backend rather than hard-erroring (#205) or miscompiling (#204). A
+    projection with an out-of-scope column reference stays a clean transpile
+    error (the naive plan rejects it too).
+    """
+
+    @pytest.mark.parametrize(
+        "projection",
+        [
+            "COUNT(a.*)",
+            "COUNT(b.*)",
+            "COUNT(a.* EXCLUDE (name))",
+            "MIN(COLUMNS(*))",
+            "a.start + 1",
+            "SUM(a.score) OVER ()",
+            "SUM(a.score) FILTER (WHERE a.score > 0)",
+            "COUNT(*) * 2",
+            "(SELECT 1) AS s",
+            "100",
+            "a.name, COUNT(a.*)",
+        ],
+    )
+    def test_transpile_should_decline_unsupported_projection_to_naive_plan(
+        self, projection
+    ):
+        """Test that every unsupported-but-naive-valid projection declines.
+
+        Given:
+            A column-to-column INTERSECTS INNER join whose SELECT list carries
+            a projection the IEJoin cannot rebuild but the naive plan handles.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan compiles the projection.
+        """
+        # Arrange
+        query = (
+            f"SELECT {projection} FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    def test_query_should_match_naive_plan_for_count_qualified_star(self, conn):
+        """Test the #204 repro: ``COUNT(a.*)`` returns the naive count, not a crash.
+
+        Given:
+            A ``SELECT COUNT(a.*)`` over an INTERSECTS join with one
+            overlapping pair.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed,
+            and separately with ``dialect=None``.
+        Then:
+            The DuckDB result should equal the naive plan's count instead of
+            crashing with a binder error on a synthesized ``a."*"`` column.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            "SELECT COUNT(a.*) FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_dd = conn.execute(sql_dd).fetchall()
+        rows_naive = conn.execute(sql_naive).fetchall()
+
+        # Assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert rows_dd == rows_naive
+        assert rows_dd == [(1,)]
+
+    def test_query_should_match_naive_plan_for_min_columns_star(self, conn):
+        """Test the #204 repro: ``MIN(COLUMNS(*))`` matches the naive per-column min.
+
+        Given:
+            A ``SELECT MIN(COLUMNS(*))`` over an INTERSECTS join.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed,
+            and separately with ``dialect=None``.
+        Then:
+            The DuckDB result should equal the naive plan's per-column min
+            across both tables' columns, not the previous bogus single scalar.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            "SELECT MIN(COLUMNS(*)) FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        res_dd = conn.execute(sql_dd)
+        cols_dd = [d[0] for d in res_dd.description]
+        rows_dd = res_dd.fetchall()
+        res_naive = conn.execute(sql_naive)
+        cols_naive = [d[0] for d in res_naive.description]
+        rows_naive = res_naive.fetchall()
+
+        # Assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert len(cols_dd) == 12
+        assert cols_dd == cols_naive
+        assert rows_dd == rows_naive
+
+    @pytest.mark.parametrize(
+        "projection, expected",
+        [
+            ("a.start + 1", [(101,)]),
+            ("SUM(a.score) OVER ()", [(7,)]),
+            ("SUM(a.score) FILTER (WHERE a.score > 0)", [(7,)]),
+            ("COUNT(*) * 2", [(2,)]),
+            ("(SELECT 1) AS s", [(1,)]),
+            ("COUNT(a.*)", [(1,)]),
+        ],
+    )
+    def test_query_should_match_naive_plan_for_unsupported_projection(
+        self, conn, projection, expected
+    ):
+        """Test that a declined unsupported projection executes like the naive plan.
+
+        Given:
+            A projection the IEJoin cannot rebuild but the naive plan handles —
+            an expression, a window aggregate, a FILTER clause, an
+            arithmetic-over-aggregate, a scalar subquery, or an aggregate over a
+            qualified star — over an INTERSECTS join with one overlapping pair.
+        When:
+            The query is transpiled with ``dialect='duckdb'`` and executed, and
+            separately with ``dialect=None``.
+        Then:
+            The declined DuckDB plan should return the same rows as the naive
+            plan (#204, #205), confirming the fallback is genuinely executable.
+        """
+        # Arrange
+        _make_table(conn, "peaks", [("chr1", 100, 200, "p1", 7, "+")])
+        _make_table(conn, "genes", [("chr1", 150, 250, "g1", 9, "-")])
+        query = (
+            f"SELECT {projection} FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval"
+        )
+        sql_dd = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+        sql_naive = transpile(query, tables=["peaks", "genes"])
+
+        # Act
+        rows_dd = conn.execute(sql_dd).fetchall()
+        rows_naive = conn.execute(sql_naive).fetchall()
+
+        # Assert
+        assert "SET VARIABLE" not in sql_dd.upper()
+        assert rows_dd == rows_naive
+        assert rows_dd == expected
+
+    @pytest.mark.parametrize(
+        "projection",
+        [
+            "score + 1",
+            "SUM(score) OVER ()",
+            "SUM(score) FILTER (WHERE score > 0)",
+        ],
+    )
+    def test_transpile_should_raise_when_unsupported_wrapper_has_unqualified_column(
+        self, projection
+    ):
+        """Test that an unqualified column inside an unsupported wrapper raises.
+
+        Given:
+            An expression / window aggregate / FILTER clause whose argument
+            references an unqualified column the dialect cannot attribute to a
+            join side.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise ``ValueError`` guiding the user to qualify the
+            column (rather than declining) — every wrapper kind reaches the same
+            diagnostic.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="qualified"):
+            transpile(
+                f"SELECT {projection} FROM peaks a "
+                "JOIN genes b ON a.interval INTERSECTS b.interval",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+
+    @pytest.mark.parametrize("kind", ["SEMI", "ANTI"])
+    def test_transpile_should_raise_left_side_only_for_right_ref_in_wrapper(self, kind):
+        """Test that a right-side column in a wrapper names the left-only rule.
+
+        Given:
+            A ``SUM(b.score) OVER ()`` projection under a SEMI / ANTI join — a
+            right-side reference the left-only output cannot resolve.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should raise the dedicated left-side-only ``ValueError`` (naming
+            the right side) rather than the generic "qualify the column"
+            message, which would steer the user toward another invalid form.
+        """
+        # Act & assert
+        with pytest.raises(ValueError, match="left-side"):
+            transpile(
+                f"SELECT SUM(b.score) OVER () FROM peaks a {kind} JOIN genes b "
+                "ON a.interval INTERSECTS b.interval",
+                tables=["peaks", "genes"],
+                dialect="duckdb",
+            )
+
+    @pytest.mark.parametrize("kind", ["SEMI", "ANTI"])
+    def test_transpile_should_decline_unsupported_projection_under_left_only_join(
+        self, kind
+    ):
+        """Test that an unsupported projection under SEMI/ANTI declines to naive.
+
+        Given:
+            An ``a.start + 1`` expression projection under a SEMI / ANTI join.
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should decline the IEJoin (no ``SET VARIABLE`` scaffolding) so
+            the naive-predicate plan handles it — the decline applies under
+            left-only joins as under INNER.
+        """
+        # Arrange
+        query = (
+            f"SELECT a.start + 1 FROM peaks a {kind} JOIN genes b "
+            "ON a.interval INTERSECTS b.interval"
+        )
+
+        # Act
+        sql = transpile(query, tables=["peaks", "genes"], dialect="duckdb")
+
+        # Assert
+        assert "SET VARIABLE" not in sql.upper()
+        assert "getvariable" not in sql
+
+    def test_transpile_should_still_engage_iejoin_for_plain_aggregate(self):
+        """Test that a plain qualified aggregate still engages the IEJoin.
+
+        Given:
+            A supported ``SUM(a.score)`` aggregate projection (no window,
+            FILTER, expression wrapper, or star argument).
+        When:
+            ``transpile`` is called with ``dialect='duckdb'``.
+        Then:
+            It should still engage the IEJoin path (``SET VARIABLE
+            __giql_iejoin_`` emitted) — the #204 / #205 declines must not
+            over-reach and disable plain aggregates.
+        """
+        # Act
+        sql = transpile(
+            "SELECT SUM(a.score) FROM peaks a "
+            "JOIN genes b ON a.interval INTERSECTS b.interval",
+            tables=["peaks", "genes"],
+            dialect="duckdb",
+        )
+
+        # Assert
+        assert "SET VARIABLE __giql_iejoin_" in sql


### PR DESCRIPTION
## Summary

Four cross-backend consistency defects in the DuckDB IEJoin `INTERSECTS` override (all surfaced by the PR #199 Round-2 adversarial review) share one root cause — the dialect rewrote a query shape it could not faithfully compile, diverging from the naive-predicate plan every other backend uses. All four are fixed the same way: **decline the IEJoin rewrite and fall back to the naive plan** for the shape in question, so `dialect="duckdb"` stays behaviorally consistent with `dialect=None` / `"datafusion"`. Declining is cheap — the naive overlap predicate still plans as a chromosome-keyed hash/range join (#167), so the only thing given up is the explicit per-chromosome IEJoin sort-merge fast path, for shapes almost nobody writes.

### #201 — SEMI/ANTI join with an out-of-scope `WHERE`-`INTERSECTS`

A `SEMI` / `ANTI` join whose column-to-column `INTERSECTS` sits in the top-level `WHERE` (rather than its own `ON`) references the right table, which is **out of scope** after a left-only join. The reference plans reject it with a binder error; the dialect's `WHERE`-branch instead relocated the predicate into the join `ON` and **invented** anti/semi-overlap results — the invented answer even varied with the (reference-ignored) `ON` content (`ON TRUE` → `[p3]`, `ON FALSE` → all rows, ...). New guard `_has_left_only_join_where_intersects` declines whenever an explicit `SEMI`/`ANTI` join is present and a column-to-column `INTERSECTS` sits in the top-level `WHERE`. (The existing `_has_outer_join_intersects` guard missed it — `SEMI`/`ANTI` carry `kind`, not `side`.) The idiomatic form (`INTERSECTS` in the join `ON`) and the implicit comma/cross-join (`INNER`) `WHERE`-branch are unaffected.

### #202 — star projections silently narrowed to the configured genomic columns

`SELECT a.*` (also `b.*` / bare `*`) under `dialect="duckdb"` expanded to **only** the `Table`-config genomic columns (chrom/start/end/strand), silently dropping user columns like `name`/`score` — the naive plan preserves every base-table column, so the same query returned a narrower row shape on DuckDB than everywhere else. New guard `_has_star_projection` declines **any** star projection (bare `*`, `a.*`, `b.*`, `a.* AS x`), which expands the real star against DuckDB's live schema at bind time — identical across backends. Applying candidate fix #1 uniformly also removes the artificial transpile-time errors for bare `*` / `a.* AS x` / unknown `c.*` (those now behave exactly as on every other backend). The dead star-expansion branch, the `star_columns` helper, and four now-unused `_resolve_projections` parameters are removed.

### #204 / #205 — projections the naive plan compiles but the IEJoin cannot rebuild

The IEJoin projection rebuild threads each output column through the per-chromosome subqueries as an explicitly-named `__giql_p<n>` alias, so it only handles a qualified column (`a.col`) or a plain aggregate over qualified columns (`SUM(a.score)` / `COUNT(*)`). Any other SELECT-list shape the naive plan compiles for free — an expression (`a.start + 1`), a window aggregate (`SUM(a.score) OVER (...)`), a `FILTER` clause, a scalar subquery, an aggregate nested in an expression (`COUNT(*) * 2`), a bare literal, or a star nested in an aggregate argument (`COUNT(a.*)` / `MIN(COLUMNS(*))`) — previously **hard-errored** (#205) or, for the aggregate-nested star, **miscompiled** (`COUNT(a.*)` crashed on a synthesized `a."*"` column; `MIN(COLUMNS(*))` returned a bogus scalar — #204).

A projection pre-scan (`_projection_declines_to_naive`) now declines all of these to the naive plan. The one thing it does **not** decline is a projection that references an *out-of-scope* column in its own scope (unqualified, an unknown table, or the right side under a SEMI/ANTI join): those are genuine user errors the naive plan also rejects, so they keep a clean transpile-time `ValueError`. Because the naive-valid wrappers now decline upstream, the specialized diagnostic branches (the window / `FILTER` / scalar-subquery / arithmetic-over-aggregate messages) only ever fired for the out-of-scope-column case — where the generic "requires qualified projections" message is *more* accurate (qualify the column and the wrapper itself declines) — so they collapse into that single message.

## Verified behavior (DuckDB 1.5.4)

- **#202** `a.*` / `a.*, b.*` / bare `*` under `duckdb` now return the full column set (`chrom, start, end, name, score, strand`), column- and row-identical to the naive plan.
- **#201** `ANTI`/`SEMI JOIN ... ON TRUE WHERE a.interval INTERSECTS b.interval` now raises the same `BinderException` the naive plan raises, instead of silently returning `[('p3',)]`.
- **#204** `COUNT(a.*)` returns the naive count instead of crashing; `MIN(COLUMNS(*))` returns the naive per-column min instead of a bogus scalar.
- **#205** `a.start + 1`, `SUM(a.score) OVER ()`, `SUM(a.score) FILTER (...)`, `COUNT(*) * 2`, scalar subqueries and literals now execute identically to the naive plan.
- Idiomatic `SEMI`/`ANTI ... ON <INTERSECTS>`, explicit columns, and plain aggregates (`SUM(a.score)`, `COUNT(*)`, `COUNT(DISTINCT a.col)`) still engage the IEJoin (`SET VARIABLE __giql_iejoin_` emitted) — the declines do not over-reach. Declines compose correctly with GROUP BY / ORDER BY / SEMI / ANTI.

## Tests

- Repointed the tests that pinned the old buggy / hard-error behavior (stars, SEMI/ANTI WHERE-INTERSECTS, and the six window / `FILTER` / arithmetic-over-aggregate / scalar-subquery / expression / literal hard-error tests) to assert the corrected decline-to-naive behavior.
- Regression classes: `TestTranspileDuckDBIEJoinLeftOnlyWhereIntersects` (#201), `TestTranspileDuckDBIEJoinStarProjectionFallback` (#202), and `TestTranspileDuckDBIEJoinUnsupportedProjectionFallback` (#204/#205 — parametrized decline over every unsupported-but-naive-valid projection, execution parity for `COUNT(a.*)` / `MIN(COLUMNS(*))` / `a.start + 1` / `SUM(a.score) OVER ()`, a keep-raise test for an out-of-scope column inside an unsupported wrapper, and a plain-aggregate-still-engages guard).
- Docs (`performance.rst`): the unsupported-but-naive-valid projection shapes move into the soft-fallback list; the corresponding hard-error entries are removed.

Full suite: 2071 passed / 90 xfailed, 95.62% coverage.

## Review

Round 1 (#201/#202) — 5 independent reviewers, principal-SWE + SQL-expert lens (`.sdlc/reviews/issue-#201/review-1.md`): **0 blocking**, unanimous ship; adversarial reviewer could not break either gate; actionable advisories remediated inline. #204 and #205 were filed as follow-ups from that round and are now folded in here.

Round 2 (#204/#205 fold-in) — 5 independent reviewers, same lens (`.sdlc/reviews/issue-#201/review-2.md`): **0 blocking**, verdict SHIP. The adversarial reviewer ran an execution sweep over ~30 shapes and could not find a miscompile / over-decline / under-decline; the holistic reviewer confirmed the four decline mechanisms compose without ordering hazards and the #200 outer-WHERE-residual path survives. Actionable advisories remediated inline: `COUNT(a.* EXCLUDE (...))` now declines instead of a misleading error; a right-side reference in an unsupported wrapper under SEMI/ANTI now gets the accurate left-side-only message; the "parity" rationale for unqualified columns was corrected to the honest capability reason; stale scalar-subquery comments/docs fixed; and execution-parity / keep-raise / SEMI-ANTI test coverage was broadened. One pre-existing defect surfaced by the review — a catalog/schema-qualified projection column (`memory.main.a.name`) silently drops the qualifier and miscompiles a query the naive plan rejects — was confirmed on the merge-base (spans four surfaces) and filed as follow-up **#206**, out of scope here.

Closes #201. Closes #202. Closes #204. Closes #205.

https://claude.ai/code/session_01KAYsMtN7vYuECZHeeFFzCM
